### PR TITLE
NullPointerException while swapping to new version of read-only store

### DIFF
--- a/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
+++ b/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
@@ -350,7 +350,7 @@ public class ReadOnlyStorageEngine implements StorageEngine<ByteArray, byte[], b
      */
     private void deleteBackups() {
         File[] storeDirList = ReadOnlyUtils.getVersionDirs(storeDir, 0L, currentVersionId);
-        if(storeDirList.length > (numBackups + 1)) {
+        if(storeDirList != null && storeDirList.length > (numBackups + 1)) {
             // delete ALL old directories asynchronously
             File[] extraBackups = ReadOnlyUtils.findKthVersionedDir(storeDirList,
                                                                     0,
@@ -424,7 +424,7 @@ public class ReadOnlyStorageEngine implements StorageEngine<ByteArray, byte[], b
                 throw new VoldemortException("Cannot parse version id");
 
             File[] backUpDirs = ReadOnlyUtils.getVersionDirs(storeDir, versionId, Long.MAX_VALUE);
-            if(backUpDirs.length <= 1) {
+            if(backUpDirs == null || backUpDirs.length <= 1) {
                 logger.warn("No rollback performed since there are no back-up directories");
                 return;
             }


### PR DESCRIPTION
ReadOnlyUtils.getVersionDirs returns null if storeDir does not exist. I don't yet know how it could get into a state where it thinks the directory doesn't exist, but the NPE is obscuring the actual cause, so I'm fixing that first.
