### PR TITLE
Debug messages for initial Voldemort profiling (now see #83)

### DIFF
--- a/src/java/voldemort/server/niosocket/AsyncRequestHandler.java
+++ b/src/java/voldemort/server/niosocket/AsyncRequestHandler.java
@@ -282,7 +282,22 @@ public class AsyncRequestHandler extends SelectorManagerWorker {
             if(logger.isTraceEnabled())
                 traceInputBufferState("Before streaming request handler");
 
+            // this is the lowest level in the NioSocketServer stack at which we
+            // still have a reference to the client IP address and port
+            long startNs = -1;
+
+            if(logger.isDebugEnabled())
+                startNs = System.nanoTime();
+
             state = streamRequestHandler.handleRequest(dataInputStream, dataOutputStream);
+
+            if(logger.isDebugEnabled()) {
+                logger.debug("Handled request from "
+                             + socketChannel.socket().getRemoteSocketAddress() + " handlerRef: "
+                             + System.identityHashCode(streamRequestHandler) + " at time: "
+                             + System.currentTimeMillis() + " elapsed time: "
+                             + (System.nanoTime() - startNs) + " ns");
+            }
 
             if(logger.isTraceEnabled())
                 traceInputBufferState("After streaming request handler");

--- a/src/java/voldemort/store/routed/action/AbstractReadRepair.java
+++ b/src/java/voldemort/store/routed/action/AbstractReadRepair.java
@@ -75,6 +75,11 @@ public abstract class AbstractReadRepair<K, V, PD extends PipelineData<K, V>> ex
     public void execute(Pipeline pipeline) {
         insertNodeValues();
 
+        long startTimeNs = -1;
+
+        if(logger.isTraceEnabled())
+            startTimeNs = System.nanoTime();
+
         if(nodeValues.size() > 1 && preferred > 1) {
             List<NodeValue<ByteArray, byte[]>> toReadRepair = Lists.newArrayList();
 
@@ -110,6 +115,15 @@ public abstract class AbstractReadRepair<K, V, PD extends PipelineData<K, V>> ex
                 } catch(Exception e) {
                     logger.debug("Read repair failed: ", e);
                 }
+            }
+
+            if(logger.isDebugEnabled()) {
+                String logStr = "Repaired (node, key, version): (";
+                for(NodeValue<ByteArray, byte[]> v: toReadRepair) {
+                    logStr += "(" + v.getNodeId() + ", " + v.getKey() + "," + v.getVersion() + ") ";
+                }
+                logStr += "in " + (System.nanoTime() - startTimeNs) + " ns";
+                logger.debug(logStr);
             }
         }
 

--- a/src/java/voldemort/store/routed/action/PerformParallelPutRequests.java
+++ b/src/java/voldemort/store/routed/action/PerformParallelPutRequests.java
@@ -129,6 +129,11 @@ public class PerformParallelPutRequests extends
                                                                                            requestTime);
                     responses.put(node.getId(), response);
 
+                    if(logger.isDebugEnabled())
+                        logger.debug("Finished secondary PUT for key " + key + " (keyRef: "
+                                     + System.identityHashCode(key) + "); took " + requestTime
+                                     + " ms on node " + node.getId() + "(" + node.getHost() + ")");
+
                     if(isHintedHandoffEnabled() && pipeline.isFinished()) {
                         if(response.getValue() instanceof UnreachableStoreException) {
                             Slop slop = new Slop(pipelineData.getStoreName(),

--- a/src/java/voldemort/store/routed/action/PerformSerialGetAllRequests.java
+++ b/src/java/voldemort/store/routed/action/PerformSerialGetAllRequests.java
@@ -79,6 +79,10 @@ public class PerformSerialGetAllRequests
             boolean zoneRequirement = false;
             MutableInt successCount = pipelineData.getSuccessCount(key);
 
+            logger.debug("GETALL for key " + key + " (keyRef: " + System.identityHashCode(key)
+                         + ") successes: " + successCount.intValue() + " preferred: " + preferred
+                         + " required: " + required);
+
             if(successCount.intValue() >= preferred) {
                 if(pipelineData.getZonesRequired() != null) {
 
@@ -131,6 +135,13 @@ public class PerformSerialGetAllRequests
                     successCount.increment();
                     pipelineData.getResponses().add(response);
                     failureDetector.recordSuccess(response.getNode(), response.getRequestTime());
+
+                    if(logger.isDebugEnabled())
+                        logger.debug("GET for key " + key + " (keyRef: "
+                                     + System.identityHashCode(key) + ") successes: "
+                                     + successCount.intValue() + " preferred: " + preferred
+                                     + " required: " + required + " new GET success on node "
+                                     + node.getId());
 
                     HashSet<Integer> zoneResponses = null;
                     if(pipelineData.getKeyToZoneResponse().containsKey(key)) {

--- a/src/java/voldemort/store/routed/action/PerformSerialRequests.java
+++ b/src/java/voldemort/store/routed/action/PerformSerialRequests.java
@@ -98,6 +98,12 @@ public class PerformSerialRequests<V, PD extends BasicPipelineData<V>> extends
                                                                              result,
                                                                              ((System.nanoTime() - start) / Time.NS_PER_MS));
 
+                if(logger.isDebugEnabled())
+                    logger.debug("GET for key " + key + " successes: "
+                                 + pipelineData.getSuccesses() + " preferred: " + preferred
+                                 + " required: " + required + " new GET success on node "
+                                 + node.getId());
+
                 pipelineData.incrementSuccesses();
                 pipelineData.getResponses().add(response);
                 failureDetector.recordSuccess(response.getNode(), response.getRequestTime());

--- a/src/java/voldemort/store/slop/HintedHandoff.java
+++ b/src/java/voldemort/store/slop/HintedHandoff.java
@@ -101,15 +101,17 @@ public class HintedHandoff {
 
         for(final Node node: handoffStrategy.routeHint(failedNode)) {
             int nodeId = node.getId();
-            if(logger.isTraceEnabled())
-                logger.trace("Sending an async hint to " + nodeId);
+
+            if(logger.isDebugEnabled())
+                logger.debug("Sending an async hint to " + nodeId);
 
             if(!failedNodes.contains(node) && failureDetector.isAvailable(node)) {
                 NonblockingStore nonblockingStore = nonblockingSlopStores.get(nodeId);
                 Utils.notNull(nonblockingStore);
                 final long startNs = System.nanoTime();
-                if(logger.isTraceEnabled())
-                    logger.trace("Attempt to write " + slop.getKey() + " for " + failedNode
+
+                if(logger.isDebugEnabled())
+                    logger.debug("Slop attempt to write " + slop.getKey() + " for " + failedNode
                                  + " to node " + node);
 
                 NonblockingStoreCallback callback = new NonblockingStoreCallback() {
@@ -127,6 +129,12 @@ public class HintedHandoff {
                                     failedNodes.add(node);
                                 if(response.getValue() instanceof UnreachableStoreException) {
                                     UnreachableStoreException use = (UnreachableStoreException) response.getValue();
+
+                                    logger.debug("Write of key " + slop.getKey() + " for "
+                                                 + failedNode + " to node " + node
+                                                 + " failed due to unreachable: "
+                                                 + use.getMessage());
+
                                     failureDetector.recordException(node,
                                                                     (System.nanoTime() - startNs)
                                                                     / Time.NS_PER_MS,
@@ -136,6 +144,12 @@ public class HintedHandoff {
                             }
                             return;
                         }
+
+                        if(logger.isDebugEnabled())
+                            logger.debug("Slop write of key " + slop.getKey() + " for "
+                                         + failedNode + " to node " + node + " succeeded in "
+                                         + (System.nanoTime() - startNs) + " ns");
+
                         failureDetector.recordSuccess(node, (System.nanoTime() - startNs)
                                                             / Time.NS_PER_MS);
 
@@ -151,7 +165,7 @@ public class HintedHandoff {
             }
         }
     }
-    
+  
     /**
      * Send a hint of a request originally meant for the failed node to another
      * node in the ring, as selected by the {@link HintedHandoffStrategy}
@@ -166,8 +180,8 @@ public class HintedHandoff {
         boolean persisted = false;
         for(Node node: handoffStrategy.routeHint(failedNode)) {
             int nodeId = node.getId();
-            if(logger.isTraceEnabled())
-                logger.trace("Trying to send hint to " + nodeId);
+            if(logger.isDebugEnabled())
+                logger.debug("Trying to send hint to " + nodeId);
 
             if(!failedNodes.contains(node) && failureDetector.isAvailable(node)) {
                 Store<ByteArray, Slop, byte[]> slopStore = slopStores.get(nodeId);
@@ -175,10 +189,10 @@ public class HintedHandoff {
                 long startNs = System.nanoTime();
 
                 try {
-                    if(logger.isTraceEnabled())
-                        logger.trace("Attempt to handoff " + slop.getOperation() + " on "
-                                     + slop.getKey() + " for " + failedNode
-                                     + " to node " + node);
+                    if(logger.isDebugEnabled())
+                        logger.debug("Slop attempt to write " + slop.getKey() + " (keyRef: "
+                                     + System.identityHashCode(slop.getKey()) + ") for "
+                                     + failedNode + " to node " + node);
 
                     // No transform needs to applied to the slop
                     slopStore.put(slop.makeKey(), new Versioned<Slop>(slop, version), null);
@@ -197,6 +211,12 @@ public class HintedHandoff {
                 } catch(ObsoleteVersionException e) {
                     logger.debug(e, e);
                 }
+
+                if(logger.isDebugEnabled())
+                    logger.debug("Slop write of key " + slop.getKey() + " (keyRef: "
+                                 + System.identityHashCode(slop.getKey()) + " for " + failedNode
+                                 + " to node " + node + " succeeded in "
+                                 + (System.nanoTime() - startNs) + " ns");
             }
         }
 


### PR DESCRIPTION
See #83
# Modification Summary

This is a simple patch that prints log4j `DEBUG` messages for use in profiling Voldemort in production. The overhead when `DEBUG` is off should be negligible, and the main overhead when it is on will be due to logging. I don't propose this patch be merged into trunk--Jay and I have talked about how to do this "right", but it will be a first step towards better understanding Voldemort behavior.

To turn it on, set log4j to run at the `DEBUG` level, ideally with timestamp logging at the millisecond level.
## Client-side modifications
- `PipelineRoutedStore`:
  - end-to-end latencies for `GET`, `GETALL`, `GETVERSIONS`, `PUT`, `DELETE`
  - for `PUT`: `ParallelPutRequests`, `SerialPutRequests`
  - for `GET`, `GETVERSIONS`: `PerformParallelRequests`, `PerformSerialRequests`
  - for `GETALL`: `PerformParallelGetAllRequests`,`PerformSerialGetAllRequests` 
- `SocketStore`:
  - client-server `WARS` analysis
  - opaque re: _what kind_ of request
  - logs remote and local ports, start/end time
## Server-side modifications:
- `AsyncRequestHandler`:
  - lowest level at which we have a socket handle
  - logs completion time of server request with local+client IP, port
- `VoldemortNativeRequestHandler`:
  - detailed logging for `GET`, `GETALL`, `GETVERSIONS`, `PUT`, `DELETE`
    - keys, value hashes, time, versions
- `BdbStorageEngine`:
  - storage-specific `GET`, `GETALL`, `GETVERSIONS`, `PUT`, `DELETE` logging  
## Other
- `AbstractReadRepair`:
  - basic logging for measuring how often RR fires and how long it takes
- `HintedHandoff`:
  - basic logging for measuring how often and how long hintedhandoff happens/takes
## How do we correlate debug messages across method invocations?

There is no notion of a request context in Voldemort, so we can't easily correlate log messages produced by different methods. This is problematic: on the client, given a log message in a `SocketStore`, how do we know which request it belongs to? (The key is probably sufficient, but in the event of concurrent requests to the same key,we cannot disambiguate.) Across clients and servers we have a similar problem.

We cannot change the method signatures, so instead we correlate at method boundaries. In general, the same (`ByteArray key`) instance is used up and down the client stack (from the serializing class to the socket) and another (`ByteArray key`) instance is used similarly in the server stack. Using  System.identityHashCode()` to get a (non-unique but close enough to unique) handle to track exactly which request we're operating on up and down the stack. Across system boundaries, we have some other messiness, which I outline here:

<pre>
CLIENT:CLIENT    PipelineRoutedStore -> SocketStore : identityHashCode(key)
CLIENT:SERVER    SocketStore -> AsyncRequestHandler : clientId:clientPort
SERVER:SERVER    AsyncRequestHandler -> VoldemortNativeRequestHandler : identityHashCode(handler)
SERVER:SERVER    VoldemortNativeRequestHandler -> BdbStorageEngine : identityHashCode(key)
</pre>

This means, for example, to find the corresponding debug messages in `BdbStorageEngine`:
1. Find the hashcode of the request key `ByteArray` in the `PipelineRoutedStore` log
2. Find the corresponding client socket in the `SocketStore` logs
3. Find the request that came in on the client socket in the `AsyncRequestHandler` logs
4. Find the server-side request key `ByteArray` in the `AsyncRequestHandler` logs
5. Find the debug message in `BdbStorageEngine` for the corresponding request key

It's pretty nasty, but I can't think of a better way to do it without modifying the API. This is effectively a five-way join between the logs.

_Caveat:_ While it would be nice, this ad-hoc method-by-method parameter-based correlation means that we can't rely on sampling to limit tracing overheads (as in [Dapper](http://research.google.com/pubs/pub36356.html)). This is potentially going to be a problem: the logging overhead may be onerous. If each method output, say, 1 in 1000 `DEBUG` messages, it would decrease overheads. However, we cannot ensure that that all classes choose the _same_ requests to output. For example, `PipelineRoutedStore` may output a debug message for a given request while `SocketStore` does not. Statistically, there will be intersection, but this is likely rare (roughly p^4). There is possibly a one-to-one correlation of debug messages between some classes, but more likely we can't synchronize the counts between classes (if we had a means of doing so, we wouldn't have this problem, and because the join key changes between classes, it's not likely that there's an easy common scheme to do so).
