### PR TITLE
Debug messages for initial Voldemort profiling

### DIFF
--- a/src/java/voldemort/server/protocol/vold/VoldemortNativeRequestHandler.java
+++ b/src/java/voldemort/server/protocol/vold/VoldemortNativeRequestHandler.java
@@ -101,6 +101,14 @@ public class VoldemortNativeRequestHandler extends AbstractRequestHandler implem
     private void handleGetVersion(DataInputStream inputStream,
                                   DataOutputStream outputStream,
                                   Store<ByteArray, byte[], byte[]> store) throws IOException {
+        long startTimeMs = -1;
+        long startTimeNs = -1;
+
+        if(logger.isDebugEnabled()) {
+            startTimeMs = System.currentTimeMillis();
+            startTimeNs = System.nanoTime();
+        }
+
         ByteArray key = readKey(inputStream);
         List<Version> results = null;
         try {
@@ -112,10 +120,24 @@ public class VoldemortNativeRequestHandler extends AbstractRequestHandler implem
             return;
         }
         outputStream.writeInt(results.size());
+
+        String clockStr = "";
+
         for(Version v: results) {
             byte[] clock = ((VectorClock) v).toBytes();
+
+            if(logger.isDebugEnabled())
+                clockStr += clock + " ";
+
             outputStream.writeInt(clock.length);
             outputStream.write(clock);
+        }
+
+        if(logger.isDebugEnabled()) {
+            logger.debug("GETVERSIONS started at: " + startTimeMs + " handlerRef: "
+                         + System.identityHashCode(this) + " key: " + key + " "
+                         + (System.nanoTime() - startTimeNs) + " ns, keySize: " + key.length()
+                         + "clocks: " + clockStr);
         }
     }
 
@@ -269,6 +291,14 @@ public class VoldemortNativeRequestHandler extends AbstractRequestHandler implem
     private void handleGet(DataInputStream inputStream,
                            DataOutputStream outputStream,
                            Store<ByteArray, byte[], byte[]> store) throws IOException {
+        long startTimeMs = -1;
+        long startTimeNs = -1;
+
+        if(logger.isDebugEnabled()) {
+            startTimeMs = System.currentTimeMillis();
+            startTimeNs = System.nanoTime();
+        }
+
         ByteArray key = readKey(inputStream);
 
         byte[] transforms = null;
@@ -286,11 +316,22 @@ public class VoldemortNativeRequestHandler extends AbstractRequestHandler implem
             return;
         }
         writeResults(outputStream, results);
+        if(logger.isDebugEnabled()) {
+            debugLogReturnValue(key, results, startTimeMs, startTimeNs, "GET");
+        }
     }
 
     private void handleGetAll(DataInputStream inputStream,
                               DataOutputStream outputStream,
                               Store<ByteArray, byte[], byte[]> store) throws IOException {
+        long startTimeMs = -1;
+        long startTimeNs = -1;
+
+        if(logger.isDebugEnabled()) {
+            startTimeMs = System.currentTimeMillis();
+            startTimeNs = System.nanoTime();
+        }
+
         // read keys
         int numKeys = inputStream.readInt();
         List<ByteArray> keys = new ArrayList<ByteArray>(numKeys);
@@ -321,18 +362,69 @@ public class VoldemortNativeRequestHandler extends AbstractRequestHandler implem
 
         // write back the results
         outputStream.writeInt(results.size());
+
+        if(logger.isDebugEnabled())
+            logger.debug("GETALL start");
+
         for(Map.Entry<ByteArray, List<Versioned<byte[]>>> entry: results.entrySet()) {
             // write the key
             outputStream.writeInt(entry.getKey().length());
             outputStream.write(entry.getKey().get());
             // write the values
             writeResults(outputStream, entry.getValue());
+
+            if(logger.isDebugEnabled()) {
+                debugLogReturnValue(entry.getKey(),
+                                    entry.getValue(),
+                                    startTimeMs,
+                                    startTimeNs,
+                                    "GETALL");
+            }
         }
+
+        if(logger.isDebugEnabled())
+            logger.debug("GETALL end");
+    }
+
+    private void debugLogReturnValue(ByteArray key,
+                                     List<Versioned<byte[]>> values,
+                                     long startTimeMs,
+                                     long startTimeNs,
+                                     String getType) {
+        long totalValueSize = 0;
+        String valueSizeStr = "[";
+        String valueHashStr = "[";
+        String versionsStr = "[";
+        for(Versioned<byte[]> b: values) {
+            int len = b.getValue().length;
+            totalValueSize += len;
+            valueSizeStr += len + ",";
+            valueHashStr += b.hashCode() + ",";
+            versionsStr += b.getVersion();
+        }
+        valueSizeStr += "]";
+        valueHashStr += "]";
+        versionsStr += "]";
+
+        logger.debug(getType + " handlerRef: " + System.identityHashCode(this) + " start time: "
+                     + startTimeMs + " key: " + key + " elapsed time: "
+                     + (System.nanoTime() - startTimeNs) + " ns, keySize: " + key.length()
+                     + " numResults: " + values.size() + " totalResultSize: " + totalValueSize
+                     + " resultSizes: " + valueSizeStr + " resultHashes: " + valueHashStr
+                     + " versions: " + versionsStr + " current time: " + System.currentTimeMillis());
     }
 
     private void handlePut(DataInputStream inputStream,
                            DataOutputStream outputStream,
                            Store<ByteArray, byte[], byte[]> store) throws IOException {
+        long startTimeMs = -1;
+        long startTimeNs = -1;
+
+        if(logger.isDebugEnabled()) {
+            startTimeMs = System.currentTimeMillis();
+            startTimeNs = System.nanoTime();
+        }
+
         ByteArray key = readKey(inputStream);
         int valueSize = inputStream.readInt();
         byte[] bytes = new byte[valueSize];
@@ -352,11 +444,28 @@ public class VoldemortNativeRequestHandler extends AbstractRequestHandler implem
         } catch(VoldemortException e) {
             writeException(outputStream, e);
         }
+
+        if(logger.isDebugEnabled()) {
+            logger.debug("PUT started at: " + startTimeMs + " handlerRef: "
+                         + System.identityHashCode(this) + " key: " + key + " "
+                         + (System.nanoTime() - startTimeNs) + " ns, keySize: " + key.length()
+                         + " valueHash: " + value.hashCode() + " valueSize: " + valueSize
+                         + " clockSize: " + clock.sizeInBytes() + " time: "
+                         + System.currentTimeMillis());
+        }
     }
 
     private void handleDelete(DataInputStream inputStream,
                               DataOutputStream outputStream,
                               Store<ByteArray, byte[], byte[]> store) throws IOException {
+        long startTimeMs = -1;
+        long startTimeNs = -1;
+
+        if(logger.isDebugEnabled()) {
+            startTimeMs = System.currentTimeMillis();
+            startTimeNs = System.nanoTime();
+        }
+
         ByteArray key = readKey(inputStream);
         int versionSize = inputStream.readShort();
         byte[] versionBytes = new byte[versionSize];
@@ -368,6 +477,13 @@ public class VoldemortNativeRequestHandler extends AbstractRequestHandler implem
             outputStream.writeBoolean(succeeded);
         } catch(VoldemortException e) {
             writeException(outputStream, e);
+        }
+
+        if(logger.isDebugEnabled()) {
+            logger.debug("DELETE started at: " + startTimeMs + " key: " + key + " handlerRef: "
+                         + System.identityHashCode(this) + " time: "
+                         + (System.nanoTime() - startTimeNs) + " ns, keySize: " + key.length()
+                         + " clockSize: " + version.sizeInBytes());
         }
     }
 

--- a/src/java/voldemort/store/routed/PipelineRoutedStore.java
+++ b/src/java/voldemort/store/routed/PipelineRoutedStore.java
@@ -144,6 +144,14 @@ public class PipelineRoutedStore extends RoutedStore {
     public List<Versioned<byte[]>> get(final ByteArray key, final byte[] transforms) {
         StoreUtils.assertValidKey(key);
 
+        long startTimeMs = -1;
+        long startTimeNs = -1;
+
+        if(logger.isDebugEnabled()) {
+            startTimeMs = System.currentTimeMillis();
+            startTimeNs = System.nanoTime();
+        }
+
         BasicPipelineData<List<Versioned<byte[]>>> pipelineData = new BasicPipelineData<List<Versioned<byte[]>>>();
         if(zoneRoutingEnabled)
             pipelineData.setZonesRequired(storeDef.getZoneCountReads());
@@ -242,13 +250,41 @@ public class PipelineRoutedStore extends RoutedStore {
                 results.addAll(value);
         }
 
+        if(logger.isDebugEnabled()) {
+            logger.debug("Finished " + pipeline.getOperation().getSimpleName() + " for key " + key
+                         + " keyRef: " + System.identityHashCode(key) + "; started at "
+                         + startTimeMs + " took " + (System.nanoTime() - startTimeNs) + " values: "
+                         + formatNodeValuesFromGet(pipelineData.getResponses()));
+        }
+
         return results;
+    }
+
+    private String formatNodeValuesFromGet(List<Response<ByteArray, List<Versioned<byte[]>>>> results) {
+        // log all retrieved values
+        StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        for(Response<ByteArray, List<Versioned<byte[]>>> r: results) {
+            builder.append("(nodeId=" + r.getNode().getId() + ", key=" + r.getKey()
+                           + ", retrieved= " + r.getValue() + "), ");
+        }
+        builder.append("}");
+
+        return builder.toString();
     }
 
     public Map<ByteArray, List<Versioned<byte[]>>> getAll(Iterable<ByteArray> keys,
                                                           Map<ByteArray, byte[]> transforms)
             throws VoldemortException {
         StoreUtils.assertValidKeys(keys);
+
+        long startTimeMs = -1;
+        long startTimeNs = -1;
+
+        if(logger.isDebugEnabled()) {
+            startTimeMs = System.currentTimeMillis();
+            startTimeNs = System.nanoTime();
+        }
 
         boolean allowReadRepair = repairReads && (transforms == null || transforms.size() == 0);
 
@@ -318,11 +354,40 @@ public class PipelineRoutedStore extends RoutedStore {
         if(pipelineData.getFatalError() != null)
             throw pipelineData.getFatalError();
 
+        if(logger.isDebugEnabled()) {
+            logger.debug("Finished " + pipeline.getOperation().getSimpleName() + "for keys " + keys
+                         + " keyRef: " + System.identityHashCode(keys) + "; started at "
+                         + startTimeMs + " took " + (System.nanoTime() - startTimeNs) + " values: "
+                         + formatNodeValuesFromGetAll(pipelineData.getResponses()));
+        }
+
         return pipelineData.getResult();
+    }
+
+    private String formatNodeValuesFromGetAll(List<Response<Iterable<ByteArray>, Map<ByteArray, List<Versioned<byte[]>>>>> list) {
+        // log all retrieved values
+        StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        for(Response<Iterable<ByteArray>, Map<ByteArray, List<Versioned<byte[]>>>> r: list) {
+            builder.append("(nodeId=" + r.getNode().getId() + ", key=" + r.getKey()
+                           + ", retrieved= " + r.getValue() + ")");
+            builder.append(", ");
+        }
+        builder.append("}");
+
+        return builder.toString();
     }
 
     public List<Version> getVersions(final ByteArray key) {
         StoreUtils.assertValidKey(key);
+
+        long startTimeMs = -1;
+        long startTimeNs = -1;
+
+        if(logger.isDebugEnabled()) {
+            startTimeMs = System.currentTimeMillis();
+            startTimeNs = System.nanoTime();
+        }
 
         BasicPipelineData<List<Version>> pipelineData = new BasicPipelineData<List<Version>>();
         if(zoneRoutingEnabled)
@@ -385,7 +450,7 @@ public class PipelineRoutedStore extends RoutedStore {
 
         pipeline.addEvent(Event.STARTED);
         if(logger.isDebugEnabled()) {
-            logger.debug("Operation  " + pipeline.getOperation().getSimpleName() + "Key "
+            logger.debug("Operation  " + pipeline.getOperation().getSimpleName() + " Key "
                          + ByteUtils.toHexString(key.get()));
         }
         try {
@@ -403,11 +468,39 @@ public class PipelineRoutedStore extends RoutedStore {
         for(Response<ByteArray, List<Version>> response: pipelineData.getResponses())
             results.addAll(response.getValue());
 
+        if(logger.isDebugEnabled()) {
+            logger.debug("Finished " + pipeline.getOperation().getSimpleName() + " for key " + key
+                         + " keyRef: " + System.identityHashCode(key) + "; started at "
+                         + startTimeMs + " took " + (System.nanoTime() - startTimeNs) + " values: "
+                         + formatNodeValuesFromGetVersions(pipelineData.getResponses()));
+        }
+
         return results;
+    }
+
+    private <R> String formatNodeValuesFromGetVersions(List<Response<ByteArray, List<Version>>> results) {
+        // log all retrieved values
+        StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        for(Response<ByteArray, List<Version>> r: results) {
+            builder.append("(nodeId=" + r.getNode().getId() + ", key=" + r.getKey()
+                           + ", retrieved= " + r.getValue() + "), ");
+        }
+        builder.append("}");
+
+        return builder.toString();
     }
 
     public boolean delete(final ByteArray key, final Version version) throws VoldemortException {
         StoreUtils.assertValidKey(key);
+
+        long startTimeMs = -1;
+        long startTimeNs = -1;
+
+        if(logger.isDebugEnabled()) {
+            startTimeMs = System.currentTimeMillis();
+            startTimeNs = System.nanoTime();
+        }
 
         BasicPipelineData<Boolean> pipelineData = new BasicPipelineData<Boolean>();
         if(zoneRoutingEnabled)
@@ -480,6 +573,12 @@ public class PipelineRoutedStore extends RoutedStore {
             throw e;
         }
 
+        if(logger.isDebugEnabled()) {
+            logger.debug("Finished " + pipeline.getOperation().getSimpleName() + " for key "
+                         + key.get() + " keyRef: " + System.identityHashCode(key) + "; started at "
+                         + startTimeMs + " took " + (System.nanoTime() - startTimeNs));
+        }
+
         if(pipelineData.getFatalError() != null)
             throw pipelineData.getFatalError();
 
@@ -497,6 +596,15 @@ public class PipelineRoutedStore extends RoutedStore {
 
     public void put(ByteArray key, Versioned<byte[]> versioned, byte[] transforms)
             throws VoldemortException {
+
+        long startTimeMs = -1;
+        long startTimeNs = -1;
+
+        if(logger.isDebugEnabled()) {
+            startTimeMs = System.currentTimeMillis();
+            startTimeNs = System.nanoTime();
+        }
+
         StoreUtils.assertValidKey(key);
         PutPipelineData pipelineData = new PutPipelineData();
         if(zoneRoutingEnabled)
@@ -589,6 +697,13 @@ public class PipelineRoutedStore extends RoutedStore {
         } catch(VoldemortException e) {
             stats.reportException(e);
             throw e;
+        }
+
+        if(logger.isDebugEnabled()) {
+            logger.debug("Finished " + pipeline.getOperation().getSimpleName() + " for key " + key
+                         + " keyRef: " + System.identityHashCode(key) + "; started at "
+                         + startTimeMs + " took " + (System.nanoTime() - startTimeNs) + " value: "
+                         + versioned.getValue() + " (size: " + versioned.getValue().length + ")");
         }
 
         if(pipelineData.getFatalError() != null)

--- a/src/java/voldemort/store/routed/action/AbstractReadRepair.java
+++ b/src/java/voldemort/store/routed/action/AbstractReadRepair.java
@@ -75,6 +75,11 @@ public abstract class AbstractReadRepair<K, V, PD extends PipelineData<K, V>> ex
     public void execute(Pipeline pipeline) {
         insertNodeValues();
 
+        long startTimeNs = -1;
+
+        if(logger.isTraceEnabled())
+            startTimeNs = System.nanoTime();
+
         if(nodeValues.size() > 1 && preferred > 1) {
             List<NodeValue<ByteArray, byte[]>> toReadRepair = Lists.newArrayList();
 
@@ -110,6 +115,15 @@ public abstract class AbstractReadRepair<K, V, PD extends PipelineData<K, V>> ex
                 } catch(Exception e) {
                     logger.debug("Read repair failed: ", e);
                 }
+            }
+
+            if(logger.isDebugEnabled()) {
+                String logStr = "Repaired (node, key, version): (";
+                for(NodeValue<ByteArray, byte[]> v: toReadRepair) {
+                    logStr += "(" + v.getNodeId() + ", " + v.getKey() + "," + v.getVersion() + ") ";
+                }
+                logStr += "in " + (System.nanoTime() - startTimeNs) + " ns";
+                logger.debug(logStr);
             }
         }
 

--- a/src/java/voldemort/store/routed/action/PerformParallelPutRequests.java
+++ b/src/java/voldemort/store/routed/action/PerformParallelPutRequests.java
@@ -129,6 +129,11 @@ public class PerformParallelPutRequests extends
                                                                                            requestTime);
                     responses.put(node.getId(), response);
 
+                    if(logger.isDebugEnabled())
+                        logger.debug("Finished secondary PUT for key " + key + " (keyRef: "
+                                     + System.identityHashCode(key) + "); took " + requestTime
+                                     + " ms on node " + node.getId() + "(" + node.getHost() + ")");
+
                     if(isHintedHandoffEnabled() && pipeline.isFinished()) {
                         if(response.getValue() instanceof UnreachableStoreException) {
                             Slop slop = new Slop(pipelineData.getStoreName(),

--- a/src/java/voldemort/store/routed/action/PerformParallelRequests.java
+++ b/src/java/voldemort/store/routed/action/PerformParallelRequests.java
@@ -95,6 +95,8 @@ public class PerformParallelRequests<V, PD extends BasicPipelineData<V>> extends
             final Node node = nodes.get(i);
             pipelineData.incrementNodeIndex();
 
+            final long startMs = logger.isDebugEnabled() ? System.currentTimeMillis() : -1;
+
             NonblockingStoreCallback callback = new NonblockingStoreCallback() {
 
                 public void requestComplete(Object result, long requestTime) {
@@ -107,6 +109,13 @@ public class PerformParallelRequests<V, PD extends BasicPipelineData<V>> extends
                                                                                            key,
                                                                                            result,
                                                                                            requestTime);
+                    if(logger.isDebugEnabled())
+                        logger.debug("Finished " + pipeline.getOperation().getSimpleName()
+                                     + " for key " + key + " (keyRef: "
+                                     + System.identityHashCode(key) + "); started at " + startMs
+                                     + " took " + requestTime + " ms on node " + node.getId() + "("
+                                     + node.getHost() + ")");
+
                     responses.put(node.getId(), response);
                     latch.countDown();
 
@@ -163,6 +172,11 @@ public class PerformParallelRequests<V, PD extends BasicPipelineData<V>> extends
                 pipelineData.getZoneResponses().add(response.getNode().getZoneId());
             }
         }
+
+        if(logger.isDebugEnabled())
+            logger.debug("GET for key " + key + " (keyRef: " + System.identityHashCode(key)
+                         + "); successes: " + pipelineData.getSuccesses() + " preferred: "
+                         + preferred + " required: " + required);
 
         if(pipelineData.getSuccesses() < required) {
             if(insufficientSuccessesEvent != null) {

--- a/src/java/voldemort/store/routed/action/PerformSerialGetAllRequests.java
+++ b/src/java/voldemort/store/routed/action/PerformSerialGetAllRequests.java
@@ -79,6 +79,11 @@ public class PerformSerialGetAllRequests
             boolean zoneRequirement = false;
             MutableInt successCount = pipelineData.getSuccessCount(key);
 
+	    if(logger.isDebugEnabled())
+		logger.debug("GETALL for key " + key + " (keyRef: " + System.identityHashCode(key)
+			     + ") successes: " + successCount.intValue() + " preferred: " + preferred
+			     + " required: " + required);
+
             if(successCount.intValue() >= preferred) {
                 if(pipelineData.getZonesRequired() != null) {
 
@@ -131,6 +136,13 @@ public class PerformSerialGetAllRequests
                     successCount.increment();
                     pipelineData.getResponses().add(response);
                     failureDetector.recordSuccess(response.getNode(), response.getRequestTime());
+
+                    if(logger.isDebugEnabled())
+                        logger.debug("GET for key " + key + " (keyRef: "
+                                     + System.identityHashCode(key) + ") successes: "
+                                     + successCount.intValue() + " preferred: " + preferred
+                                     + " required: " + required + " new GET success on node "
+                                     + node.getId());
 
                     HashSet<Integer> zoneResponses = null;
                     if(pipelineData.getKeyToZoneResponse().containsKey(key)) {

--- a/src/java/voldemort/store/routed/action/PerformSerialRequests.java
+++ b/src/java/voldemort/store/routed/action/PerformSerialRequests.java
@@ -98,6 +98,13 @@ public class PerformSerialRequests<V, PD extends BasicPipelineData<V>> extends
                                                                              result,
                                                                              ((System.nanoTime() - start) / Time.NS_PER_MS));
 
+                if(logger.isDebugEnabled())
+                    logger.debug(pipeline.getOperation().getSimpleName() + " for key " + key
+                                 + " successes: " + pipelineData.getSuccesses() + " preferred: "
+                                 + preferred + " required: " + required + " new "
+                                 + pipeline.getOperation().getSimpleName() + " success on node "
+                                 + node.getId());
+
                 pipelineData.incrementSuccesses();
                 pipelineData.getResponses().add(response);
                 failureDetector.recordSuccess(response.getNode(), response.getRequestTime());

--- a/src/java/voldemort/store/socket/SocketStore.java
+++ b/src/java/voldemort/store/socket/SocketStore.java
@@ -100,6 +100,9 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
                                                                     requestRoutingType,
                                                                     key,
                                                                     version);
+        if(logger.isDebugEnabled())
+            logger.debug("DELETE keyRef: " + System.identityHashCode(key) + " requestRef: "
+                         + System.identityHashCode(clientRequest));
         requestAsync(clientRequest, callback, timeoutMs, "delete");
     }
 
@@ -113,6 +116,9 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
                                                               requestRoutingType,
                                                               key,
                                                               transforms);
+        if(logger.isDebugEnabled())
+            logger.debug("GET keyRef: " + System.identityHashCode(key) + " requestRef: "
+                         + System.identityHashCode(clientRequest));
         requestAsync(clientRequest, callback, timeoutMs, "get");
     }
 
@@ -126,6 +132,9 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
                                                                     requestRoutingType,
                                                                     keys,
                                                                     transforms);
+        if(logger.isDebugEnabled())
+            logger.debug("GETALL keyRef: " + System.identityHashCode(keys) + " requestRef: "
+                         + System.identityHashCode(clientRequest));
         requestAsync(clientRequest, callback, timeoutMs, "get all");
     }
 
@@ -137,6 +146,9 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
                                                                               requestFormat,
                                                                               requestRoutingType,
                                                                               key);
+        if(logger.isDebugEnabled())
+            logger.debug("GETVERSIONS keyRef: " + System.identityHashCode(key) + " requestRef: "
+                         + System.identityHashCode(clientRequest));
         requestAsync(clientRequest, callback, timeoutMs, "get versions");
     }
 
@@ -152,6 +164,9 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
                                                               key,
                                                               value,
                                                               transforms);
+        if(logger.isDebugEnabled())
+            logger.debug("PUT keyRef: " + System.identityHashCode(key) + " requestRef: "
+                         + System.identityHashCode(clientRequest));
         requestAsync(clientRequest, callback, timeoutMs, "put");
     }
 
@@ -162,6 +177,9 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
                                                                     requestRoutingType,
                                                                     key,
                                                                     version);
+        if(logger.isDebugEnabled())
+            logger.debug("DELETE keyRef: " + System.identityHashCode(key) + " requestRef: "
+                         + System.identityHashCode(clientRequest));
         return request(clientRequest, "delete");
     }
 
@@ -172,6 +190,9 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
                                                               requestRoutingType,
                                                               key,
                                                               transforms);
+        if(logger.isDebugEnabled())
+            logger.debug("GET keyRef: " + System.identityHashCode(key) + " requestRef: "
+                         + System.identityHashCode(clientRequest));
         return request(clientRequest, "get");
     }
 
@@ -184,6 +205,9 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
                                                                     requestRoutingType,
                                                                     keys,
                                                                     transforms);
+        if(logger.isDebugEnabled())
+            logger.debug("GETALL keyRef: " + System.identityHashCode(keys) + " requestRef: "
+                         + System.identityHashCode(clientRequest));
         return request(clientRequest, "getAll");
     }
 
@@ -193,6 +217,9 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
                                                                               requestFormat,
                                                                               requestRoutingType,
                                                                               key);
+        if(logger.isDebugEnabled())
+            logger.debug("GETVERSIONS keyRef: " + System.identityHashCode(key) + " requestRef: "
+                         + System.identityHashCode(clientRequest));
         return request(clientRequest, "getVersions");
     }
 
@@ -205,6 +232,9 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
                                                               key,
                                                               versioned,
                                                               transforms);
+        if(logger.isDebugEnabled())
+            logger.debug("PUT keyRef: " + System.identityHashCode(key) + " requestRef: "
+                         + System.identityHashCode(clientRequest));
         request(clientRequest, "put");
     }
 
@@ -240,17 +270,40 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
 
     private <T> T request(ClientRequest<T> delegate, String operationName) {
         ClientRequestExecutor clientRequestExecutor = pool.checkout(destination);
+
+        long startTimeMs = -1;
+        long startTimeNs = -1;
+
+        if(logger.isDebugEnabled()) {
+            startTimeMs = System.currentTimeMillis();
+            startTimeNs = System.nanoTime();
+        }
+
+        String debugMsgStr = "";
+
         BlockingClientRequest<T> blockingClientRequest = null;
         try {
             blockingClientRequest = new BlockingClientRequest<T>(delegate, timeoutMs);
             clientRequestExecutor.addClientRequest(blockingClientRequest, timeoutMs);
             blockingClientRequest.await();
+
+            if(logger.isDebugEnabled())
+                debugMsgStr += "success";
+
             return blockingClientRequest.getResult();
         } catch(InterruptedException e) {
+
+            if(logger.isDebugEnabled())
+                debugMsgStr += "unreachable: " + e.getMessage();
+
             throw new UnreachableStoreException("Failure in " + operationName + " on "
                                                 + destination + ": " + e.getMessage(), e);
         } catch(IOException e) {
             clientRequestExecutor.close();
+
+            if(logger.isDebugEnabled())
+                debugMsgStr += "failure: " + e.getMessage();
+
             throw new UnreachableStoreException("Failure in " + operationName + " on "
                                                 + destination + ": " + e.getMessage(), e);
         } finally {
@@ -258,6 +311,29 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
                 // close the executor if we timed out
                 clientRequestExecutor.close();
             }
+
+            if(logger.isDebugEnabled()) {
+                logger.debug("Sync request end, type: "
+                             + operationName
+                             + " requestRef: "
+                             + System.identityHashCode(delegate)
+                             + " totalTimeNs: "
+                             + (System.nanoTime() - startTimeNs)
+                             + " start time: "
+                             + startTimeMs
+                             + " end time: "
+                             + System.currentTimeMillis()
+                             + " client:"
+                             + clientRequestExecutor.getSocketChannel().socket().getLocalAddress()
+                             + ":"
+                             + clientRequestExecutor.getSocketChannel().socket().getLocalPort()
+                             + " server: "
+                             + clientRequestExecutor.getSocketChannel()
+                                                    .socket()
+                                                    .getRemoteSocketAddress() + " outcome: "
+                             + debugMsgStr);
+            }
+
             pool.checkin(destination, clientRequestExecutor);
         }
     }
@@ -285,6 +361,23 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
 
         try {
             clientRequestExecutor = pool.checkout(destination);
+
+            if(logger.isDebugEnabled()) {
+                logger.debug("Async request start; type: "
+                             + operationName
+                             + " requestRef: "
+                             + System.identityHashCode(delegate)
+                             + " time: "
+                             + System.currentTimeMillis()
+                             + " server: "
+                             + clientRequestExecutor.getSocketChannel()
+                                                    .socket()
+                                                    .getRemoteSocketAddress() + " local socket: "
+                             + clientRequestExecutor.getSocketChannel().socket().getLocalAddress()
+                             + ":"
+                             + clientRequestExecutor.getSocketChannel().socket().getLocalPort());
+            }
+
         } catch(Exception e) {
             // If we can't check out a socket from the pool, we'll usually get
             // either an IOException (subclass) or an UnreachableStoreException
@@ -335,6 +428,26 @@ public class SocketStore implements Store<ByteArray, byte[], byte[]>, Nonblockin
         private void invokeCallback(Object o, long requestTime) {
             if(callback != null) {
                 try {
+                    if(logger.isDebugEnabled()) {
+                        logger.debug("Async request end; requestRef: "
+                                     + System.identityHashCode(clientRequest)
+                                     + " time: "
+                                     + System.currentTimeMillis()
+                                     + " server: "
+                                     + clientRequestExecutor.getSocketChannel()
+                                                            .socket()
+                                                            .getRemoteSocketAddress()
+                                     + " local socket: "
+                                     + clientRequestExecutor.getSocketChannel()
+                                                            .socket()
+                                                            .getLocalAddress()
+                                     + ":"
+                                     + clientRequestExecutor.getSocketChannel()
+                                                            .socket()
+                                                            .getLocalPort() + " result: "
+                                     + o.toString());
+                    }
+
                     callback.requestComplete(o, requestTime);
                 } catch(Exception e) {
                     if(logger.isEnabledFor(Level.WARN))


### PR DESCRIPTION
# Modification Summary

This is a simple patch that prints log4j `DEBUG` messages for use in profiling Voldemort in production. The overhead when `DEBUG` is off should be negligible, and the main overhead when it is on will be due to logging. I don't propose this patch be merged into trunk--Jay and I have talked about how to do this "right", but it will be a first step towards better understanding Voldemort behavior.

To turn it on, set log4j to run at the `DEBUG` level, ideally with timestamp logging at the millisecond level.
## Client-side modifications
- `PipelineRoutedStore`:
  - end-to-end latencies for `GET`, `GETALL`, `GETVERSIONS`, `PUT`, `DELETE`
  - for `PUT`: `ParallelPutRequests`, `SerialPutRequests`
  - for `GET`, `GETVERSIONS`: `PerformParallelRequests`, `PerformSerialRequests`
  - for `GETALL`: `PerformParallelGetAllRequests`,`PerformSerialGetAllRequests` 
- `SocketStore`:
  - client-server `WARS` analysis
  - opaque re: _what kind_ of request
  - logs remote and local ports, start/end time
## Server-side modifications:
- `AsyncRequestHandler`:
  - lowest level at which we have a socket handle
  - logs completion time of server request with local+client IP, port
- `VoldemortNativeRequestHandler`:
  - detailed logging for `GET`, `GETALL`, `GETVERSIONS`, `PUT`, `DELETE`
    - keys, value hashes, time, versions
- `BdbStorageEngine`:
  - storage-specific `GET`, `GETALL`, `GETVERSIONS`, `PUT`, `DELETE` logging  
## Other
- `AbstractReadRepair`:
  - basic logging for measuring how often RR fires and how long it takes
- `HintedHandoff`:
  - basic logging for measuring how often and how long hintedhandoff happens/takes
## How do we correlate debug messages across method invocations?

There is no notion of a request context in Voldemort, so we can't easily correlate log messages produced by different methods. This is problematic: on the client, given a log message in a `SocketStore`, how do we know which request it belongs to? (The key is probably sufficient, but in the event of concurrent requests to the same key,we cannot disambiguate.) Across clients and servers we have a similar problem.

We cannot change the method signatures, so instead we correlate at method boundaries. In general, the same (`ByteArray key`) instance is used up and down the client stack (from the serializing class to the socket) and another (`ByteArray key`) instance is used similarly in the server stack. Using  System.identityHashCode()` to get a (non-unique but close enough to unique) handle to track exactly which request we're operating on up and down the stack. Across system boundaries, we have some other messiness, which I outline here:

<pre>
CLIENT:CLIENT    PipelineRoutedStore -> SocketStore : identityHashCode(key)
CLIENT:SERVER    SocketStore -> AsyncRequestHandler : clientId:clientPort
SERVER:SERVER    AsyncRequestHandler -> VoldemortNativeRequestHandler : identityHashCode(handler)
SERVER:SERVER    VoldemortNativeRequestHandler -> BdbStorageEngine : identityHashCode(key)
</pre>

This means, for example, to find the corresponding debug messages in `BdbStorageEngine`:
1. Find the hashcode of the request key `ByteArray` in the `PipelineRoutedStore` log
2. Find the corresponding client socket in the `SocketStore` logs
3. Find the request that came in on the client socket in the `AsyncRequestHandler` logs
4. Find the server-side request key `ByteArray` in the `AsyncRequestHandler` logs
5. Find the debug message in `BdbStorageEngine` for the corresponding request key

It's pretty nasty, but I can't think of a better way to do it without modifying the API. This is effectively a five-way join between the logs.

_Caveat:_ While it would be nice, this ad-hoc method-by-method parameter-based correlation means that we can't rely on sampling to limit tracing overheads (as in [Dapper](http://research.google.com/pubs/pub36356.html)). This is potentially going to be a problem: the logging overhead may be onerous. If each method output, say, 1 in 1000 `DEBUG` messages, it would decrease overheads. However, we cannot ensure that that all classes choose the _same_ requests to output. For example, `PipelineRoutedStore` may output a debug message for a given request while `SocketStore` does not. Statistically, there will be intersection, but this is likely rare (roughly p^4). There is possibly a one-to-one correlation of debug messages between some classes, but more likely we can't synchronize the counts between classes (if we had a means of doing so, we wouldn't have this problem, and because the join key changes between classes, it's not likely that there's an easy common scheme to do so).
