### PR TITLE
bug fix: checking partition id in Cluster.java

### DIFF
--- a/src/java/voldemort/cluster/Cluster.java
+++ b/src/java/voldemort/cluster/Cluster.java
@@ -83,7 +83,7 @@ public class Cluster implements Serializable {
         for(Node node: nodes)
             tags.addAll(node.getPartitionIds());
         Collections.sort(tags);
-        for(int i = 0; i < numberOfTags; i++) {
+        for(int i = 0; i < tags.size(); i++) {
             if(tags.get(i).intValue() != i)
                 throw new IllegalArgumentException("Invalid tag assignment.");
         }


### PR DESCRIPTION
"numberOfTags" is always zero in getNumberOfTags(). So, this for loop statement was uselessness code. This patch is fix it.
