### PR TITLE
fixed valueof method to handle null value

### DIFF
--- a/src/java/voldemort/utils/CmdUtils.java
+++ b/src/java/voldemort/utils/CmdUtils.java
@@ -36,14 +36,14 @@ public class CmdUtils {
 
     @SuppressWarnings("unchecked")
     public static <T> T valueOf(OptionSet options, String opt, T defaultValue) {
-        if(options.has(opt))
+        if(options.has(opt) && options.valueOf(opt) != null)
             return (T) options.valueOf(opt);
         else
             return defaultValue;
     }
 
     public static <T> T valueOf(OptionSet options, OptionSpec<T> opt, T defaultValue) {
-        if(options.has(opt))
+        if(options.has(opt) && options.valueOf(opt) != null)
             return options.valueOf(opt);
         else
             return defaultValue;


### PR DESCRIPTION
When I executed the following command, I got NullPointerException.

```
./bin/voldemort-admin-tool.sh --restore --url tcp://localhost:6666 --node 0
```

```
Exception in thread "main" java.lang.NullPointerException
 at voldemort.VoldemortAdminTool.main(VoldemortAdminTool.java:252)
```

So I fixed CmdUtils#valueof methods. I just added null check logic.
