### PR TITLE
Fixes duplicate .xsd files in JAR file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -147,10 +147,6 @@
       <fileset dir="${classes.dir}">
         <include name="**/*.*" />
       </fileset>
-      <!-- include xsds -->
-      <fileset dir="${java.dir}">
-        <include name="**/*.xsd" />
-      </fileset>
     	
     	<fileset dir=".">
     	 		<include name="META-INF/MANIFEST.MF" />


### PR DESCRIPTION
This pull request fixes an issue that was preventing me from including `voldemort-1.3.0.jar` in a Leiningen project. The problem is that the build script includes duplicate copies of the `.xsd` files (`cluster.xsd` and `stores.xsd`) in the `.jar` file. This causes the following exception when trying to include `voldemort-1.3.0.jar` in another `.jar` file:

```
java.util.zip.ZipException: duplicate entry: voldemort/xml/cluster.xsd
```

Before building, the `.xsd` files are in `src`:

```
$ ant clean
$ find . -name '*.xsd'
./src/java/voldemort/xml/cluster.xsd
./src/java/voldemort/xml/stores.xsd
```

After building, the `.xsd` files are copied to `dist`:

```
$ ant
$ find . -name '*.xsd'
./dist/classes/voldemort/xml/cluster.xsd
./dist/classes/voldemort/xml/stores.xsd
./src/java/voldemort/xml/cluster.xsd
./src/java/voldemort/xml/stores.xsd
```

The files are the same:

```
$ diff src/java/voldemort/xml/cluster.xsd dist/classes/voldemort/xml/cluster.xsd
$ diff src/java/voldemort/xml/stores.xsd dist/classes/voldemort/xml/stores.xsd
```

The rule which I removed from `build.xml` was including both copies in the `.jar` file:

```
$ jar tf dist/voldemort-1.3.0.jar | grep '\.xsd$'
voldemort/xml/cluster.xsd
voldemort/xml/stores.xsd
voldemort/xml/cluster.xsd
voldemort/xml/stores.xsd
```

After building with my modified `build.xml`, only the `.xsd` files from `dist/classes` are included in the `.jar` file:

```
$ tar tf dist/voldemort-1.3.0.jar | grep '\.xsd$'
voldemort/xml/cluster.xsd
voldemort/xml/stores.xsd
```
