### PR TITLE
Ignore Manifest file in GIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ server.state
 .temp
 .idea
 data/
+/META-INF

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,8 +1,0 @@
-Manifest-Version: 1.0
-Ant-Version: Apache Ant 1.7.1
-Created-By: 20.2-b06 (Sun Microsystems Inc.)
-Voldemort-Implementation-Version: 1.3.1
-Implementation-Title: Voldemort
-Implementation-Version: 1.3.1
-Implementation-Vendor: LinkedIn
-


### PR DESCRIPTION
The manifest.mf is an autogenerated file, so doesn't make sense to have it GIT
