### PR TITLE
Fix bug #167: Python Client: Store not found

### DIFF
--- a/clients/python/tests/voldemort_config/config/server.properties
+++ b/clients/python/tests/voldemort_config/config/server.properties
@@ -2,7 +2,7 @@
 node.id=0
 
 max.threads=100
-
+enable.server.routing=True
 ############### DB options ######################
 
 http.enable=true


### PR DESCRIPTION
Python client requires server side routing
