### PR TITLE
Using standard logger in the StreamingClient constructor

### DIFF
--- a/src/java/voldemort/client/protocol/admin/StreamingClient.java
+++ b/src/java/voldemort/client/protocol/admin/StreamingClient.java
@@ -75,7 +75,7 @@ public class StreamingClient extends BaseStreamingClient {
     public StreamingClient(StreamingClientConfig config) {
         super(config);
         MAX_FAULTY_NODES = config.getFailedNodesTolerated();
-        System.out.println("MAX_FAULTY_NODES is set to : " + MAX_FAULTY_NODES);
+        logger.info("StreamingClient constructed with MAX_FAULTY_NODES set to : " + MAX_FAULTY_NODES);
         streamingSlopResults = Executors.newFixedThreadPool(1);
 
     }


### PR DESCRIPTION
A simple change so that StreamingClient construction doesn't pollute the standard output with unconfigurable logs.
