### PR TITLE
bind failures while running tests

### DIFF
--- a/src/java/voldemort/server/http/HttpService.java
+++ b/src/java/voldemort/server/http/HttpService.java
@@ -17,7 +17,6 @@
 package voldemort.server.http;
 
 import org.apache.log4j.Logger;
-import org.mortbay.jetty.AbstractConnector;
 import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.nio.SelectChannelConnector;
@@ -111,7 +110,8 @@ public class HttpService extends AbstractService {
             this.httpServer.start();
             logger.info("HTTP service started on port " + this.port);
         } catch(Exception e) {
-            throw new VoldemortException(e);
+            String errorMessage = " Error starting service on port " + this.port;
+            throw new VoldemortException(errorMessage, e);
         }
     }
 
@@ -133,7 +133,8 @@ public class HttpService extends AbstractService {
         this.context = null;
     }
 
-    @JmxGetter(name = "numberOfThreads", description = "The number of threads used for the thread pool for HTTP.")
+    @JmxGetter(name = "numberOfThreads",
+            description = "The number of threads used for the thread pool for HTTP.")
     public int getNumberOfThreads() {
         return numberOfThreads;
     }

--- a/test/common/voldemort/VoldemortTestConstants.java
+++ b/test/common/voldemort/VoldemortTestConstants.java
@@ -17,6 +17,7 @@
 package voldemort;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
 
 import org.apache.commons.io.IOUtils;
@@ -144,7 +145,11 @@ public class VoldemortTestConstants {
 
     private static String readString(String filename) {
         try {
-            return IOUtils.toString(VoldemortTestConstants.class.getResourceAsStream(filename));
+            InputStream inputStream = VoldemortTestConstants.class.getResourceAsStream(filename);
+            if(inputStream == null) {
+                throw new VoldemortException("Could not locate resource " + filename);
+            }
+            return IOUtils.toString(inputStream);
         } catch(IOException e) {
             throw new RuntimeException(e);
         }

--- a/test/unit/voldemort/client/SocketStoreClientFactoryMbeanTest.java
+++ b/test/unit/voldemort/client/SocketStoreClientFactoryMbeanTest.java
@@ -75,8 +75,11 @@ public class SocketStoreClientFactoryMbeanTest extends SocketStoreClientFactoryT
     private void checkMbeanIdCount(String domain, String type, int maxMbeans, boolean unregister) {
         ObjectName oName = JmxUtils.createObjectName(domain, type);
         Set<ObjectName> objects = mbServer.queryNames(oName, null);
-        assertFalse("Extra mbeans found", objects.size() > maxMbeans);
-        assertFalse("Fewer than expected mbeans found", objects.size() < maxMbeans);
+        String messagePrefix = "Domain " + domain + " expected Size " + maxMbeans + " actual size "
+                               + objects.size();
+        assertFalse(messagePrefix + ". Extra mbeans found", objects.size() > maxMbeans);
+        assertFalse(messagePrefix + ". Fewer than expected mbeans found",
+                    objects.size() < maxMbeans);
 
         if(unregister) {
             try {

--- a/test/unit/voldemort/client/protocol/admin/StreamingClientTest.java
+++ b/test/unit/voldemort/client/protocol/admin/StreamingClientTest.java
@@ -1,5 +1,7 @@
 package voldemort.client.protocol.admin;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,15 +43,12 @@ import voldemort.store.compress.CompressionStrategyFactory;
 import voldemort.store.slop.strategy.HintedHandoffStrategyType;
 import voldemort.store.socket.SocketStoreFactory;
 import voldemort.store.socket.TestSocketStoreFactory;
-import voldemort.store.socket.clientrequest.ClientRequestExecutorPool;
 import voldemort.utils.ByteArray;
 import voldemort.utils.Props;
 import voldemort.versioning.Versioned;
 import voldemort.xml.StoreDefinitionsMapper;
 
 import com.google.common.collect.Lists;
-
-import static org.junit.Assert.assertEquals;
 
 /*
  * Starts a streaming session and inserts some keys Using fetchKeys we check if
@@ -58,7 +57,7 @@ import static org.junit.Assert.assertEquals;
  * (i) Non zoned cluster with contiguous node ids
  * (ii) Non zoned cluster with non contiguous node ids
  * (iii) Zoned cluster with contiguous zone/node ids
- * 
+ *
  */
 @RunWith(Parameterized.class)
 public class StreamingClientTest {
@@ -148,7 +147,7 @@ public class StreamingClientTest {
     }
 
     @Before
-    public void testSetup() {
+    public void testSetup() throws IOException {
 
         if(null == servers) {
             servers = new VoldemortServer[numServers];
@@ -161,6 +160,7 @@ public class StreamingClientTest {
             } catch(IOException e1) {
                 // TODO Auto-generated catch block
                 e1.printStackTrace();
+                throw e1;
             }
 
             int count = 0;
@@ -176,8 +176,8 @@ public class StreamingClientTest {
                                                                                                              new Properties()),
                                                                           cluster);
                 } catch(IOException e) {
-                    // TODO Auto-generated catch block
                     e.printStackTrace();
+                    throw e;
                 }
                 serverPorts[count] = servers[count].getIdentityNode().getSocketPort();
                 count++;

--- a/test/unit/voldemort/client/rebalance/AbstractRebalanceTest.java
+++ b/test/unit/voldemort/client/rebalance/AbstractRebalanceTest.java
@@ -27,6 +27,8 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 
+import org.junit.After;
+
 import voldemort.ROTestUtils;
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
@@ -102,6 +104,13 @@ public abstract class AbstractRebalanceTest {
         }
 
         return cluster;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        for(VoldemortServer vs: serverMap.values()) {
+            vs.stop();
+        }
     }
 
     protected Store<ByteArray, byte[], byte[]> getSocketStore(String storeName,

--- a/test/unit/voldemort/client/rebalance/AbstractZonedRebalanceTest.java
+++ b/test/unit/voldemort/client/rebalance/AbstractZonedRebalanceTest.java
@@ -271,7 +271,7 @@ public abstract class AbstractZonedRebalanceTest extends AbstractRebalanceTest {
         // Hacky work around of TOCTOU bind Exception issues. Each test that
         // invokes this method brings servers up & down on the same ports. The
         // OS seems to need a rest between subsequent tests...
-        Thread.sleep(TimeUnit.SECONDS.toMillis(2));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(5));
         try {
             Cluster interimCluster = RebalanceUtils.getInterimCluster(cCluster, fCluster);
 

--- a/test/unit/voldemort/server/storage/RepairJobTest.java
+++ b/test/unit/voldemort/server/storage/RepairJobTest.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Test;
 
 import voldemort.MockTime;
@@ -133,6 +134,13 @@ public class RepairJobTest {
             serverMap.put(node, server);
         }
         return cluster;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        for(VoldemortServer vs: serverMap.values()) {
+            vs.stop();
+        }
     }
 
     private Store<ByteArray, byte[], byte[]> getSocketStore(String storeName, String host, int port) {

--- a/test/unit/voldemort/utils/ConsistencyCheckTest.java
+++ b/test/unit/voldemort/utils/ConsistencyCheckTest.java
@@ -88,7 +88,7 @@ public class ConsistencyCheckTest {
     ConsistencyCheck.Value hv1_dup = new ConsistencyCheck.HashedValue(versioned1);
     ConsistencyCheck.Value hv2 = new ConsistencyCheck.HashedValue(versioned2);
 
-    ConsistencyCheck.Value hv3 = new ConsistencyCheck.HashedValue(new Versioned<byte[]>(value1,vc3));
+    ConsistencyCheck.Value hv3 = new ConsistencyCheck.HashedValue(new Versioned<byte[]>(value1, vc3));
 
     // make set
     Set<ConsistencyCheck.ClusterNode> setFourNodes = new HashSet<ConsistencyCheck.ClusterNode>();
@@ -153,9 +153,9 @@ public class ConsistencyCheckTest {
         assertFalse(rc1.isExpired(new ConsistencyCheck.VersionValue(versioned1)));
         assertFalse(rc1.isExpired(new ConsistencyCheck.VersionValue(versioned2)));
         assertFalse(rc1.isExpired(new ConsistencyCheck.VersionValue(versioned3)));
-        assertTrue (rc2.isExpired(new ConsistencyCheck.VersionValue(versioned1)));
+        assertTrue(rc2.isExpired(new ConsistencyCheck.VersionValue(versioned1)));
         assertFalse(rc2.isExpired(new ConsistencyCheck.VersionValue(versioned2)));
-        assertTrue (rc2.isExpired(new ConsistencyCheck.VersionValue(versioned3)));
+        assertTrue(rc2.isExpired(new ConsistencyCheck.VersionValue(versioned3)));
     }
 
     @Test
@@ -168,16 +168,19 @@ public class ConsistencyCheckTest {
         vc1.incrementVersion(1, 100000001);
         vc1.incrementVersion(2, 100000003);
 
-        VectorClock vc2= new VectorClock();
+        VectorClock vc2 = new VectorClock();
         vc2.incrementVersion(1, 100000001);
         vc2.incrementVersion(3, 100000002);
         VectorClock vc3 = new VectorClock();
         vc3.incrementVersion(1, 100000001);
         vc3.incrementVersion(4, 100000001);
 
-        ConsistencyCheck.Value v1 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value1, vc1));
-        ConsistencyCheck.Value v2 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value2, vc2));
-        ConsistencyCheck.Value v3 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value3, vc3));
+        ConsistencyCheck.Value v1 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value1,
+                                                                                            vc1));
+        ConsistencyCheck.Value v2 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value2,
+                                                                                            vc2));
+        ConsistencyCheck.Value v3 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value3,
+                                                                                            vc3));
 
         // FULL: simple
         versionNodeSetMap.put(v1, setFourNodes);
@@ -284,9 +287,10 @@ public class ConsistencyCheckTest {
         VectorClock vc2 = new VectorClock();
         vc2.incrementVersion(1, 100000002);
 
-        ConsistencyCheck.Value v1 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value1, vc1));
-        ConsistencyCheck.Value v2 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value2, vc2));
-
+        ConsistencyCheck.Value v1 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value1,
+                                                                                            vc1));
+        ConsistencyCheck.Value v2 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value2,
+                                                                                            vc2));
 
         // setup
         Map<ByteArray, Map<ConsistencyCheck.Value, Set<ClusterNode>>> map = new HashMap<ByteArray, Map<ConsistencyCheck.Value, Set<ClusterNode>>>();
@@ -332,9 +336,10 @@ public class ConsistencyCheckTest {
         VectorClock vc2 = new VectorClock(now + 1);
         Versioned<byte[]> versioned = new Versioned<byte[]>(value1, vc1);
 
-        ConsistencyCheck.Value v1 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value1, vc1));
-        ConsistencyCheck.Value v2 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value2, vc2));
-
+        ConsistencyCheck.Value v1 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value1,
+                                                                                            vc1));
+        ConsistencyCheck.Value v2 = new ConsistencyCheck.VersionValue(new Versioned<byte[]>(value2,
+                                                                                            vc2));
 
         // make Prefix Nodes
         Set<ClusterNode> set = new HashSet<ClusterNode>();
@@ -552,8 +557,7 @@ public class ConsistencyCheckTest {
         urls.add(bootstrapUrl);
         ConsistencyCheck.ComparisonType[] comparisonTypes = ConsistencyCheck.ComparisonType.values();
 
-        for(ConsistencyCheck.ComparisonType type : comparisonTypes)
-        {
+        for(ConsistencyCheck.ComparisonType type: comparisonTypes) {
             StringWriter sw = new StringWriter();
             ConsistencyCheck checker = new ConsistencyCheck(urls, STORE_NAME, 0, sw, type);
             Reporter reporter = null;
@@ -562,6 +566,10 @@ public class ConsistencyCheckTest {
 
             assertEquals(7 - 2, reporter.numTotalKeys);
             assertEquals(3, reporter.numGoodKeys);
+        }
+
+        for(VoldemortServer vs: servers) {
+            vs.stop();
         }
     }
 }

--- a/test/unit/voldemort/utils/ServerTestUtilsTest.java
+++ b/test/unit/voldemort/utils/ServerTestUtilsTest.java
@@ -93,6 +93,10 @@ public class ServerTestUtilsTest {
                                                               cluster);
         }
         assertTrue(true);
+
+        for(VoldemortServer server: servers) {
+            ServerTestUtils.stopVoldemortServer(server);
+        }
     }
 
     // @Test


### PR DESCRIPTION
1) Fixed bunch of bind failures where the server is not stopped after
the test causing the bind failures.
2) Added instrumentation to report the port for http when the bind
failure happens, so that we can dig through the log to find the last
started service.
3) Fixed the resource loader to throw error when resource is missing
instead of failing with NPE.
4) Fixed Streaming Client to throw the actual error instead of failing
with NPE on bind failures.
5) Increased the sleep time for Zone Rebalance test as 2 ms is not
enough on my machine. 5 ms sort of fixes the problem, but only time will
tell
