### PR TITLE
Fixed NetworkClassLoader bug when running in Windows OS

### DIFF
--- a/src/java/voldemort/utils/NetworkClassLoader.java
+++ b/src/java/voldemort/utils/NetworkClassLoader.java
@@ -61,6 +61,8 @@ public class NetworkClassLoader extends ClassLoader {
         // Using File.separatorChar in Windows fails. paths for
         // Class#getResource() must be forward slashes in order to work
         // correctly.
+        // See:
+        // https://blogs.atlassian.com/2006/12/how_to_use_file_separator_when/
         String filename = cl.getName().replace('.', '/') + ".class";
         InputStream in = null;
         logger.debug("NetworkClassloader dumpClass() :" + cl.getCanonicalName());


### PR DESCRIPTION
Using File.separatorChar in Windows fails. Paths for Class#getResource() must be forward slashes in order to work correctly.

Otherwise it's generating NullPointerExceptions in Windows.
