### PR TITLE
Fixed bug unregistering the MBean

### DIFF
--- a/src/java/voldemort/store/routed/PipelineRoutedStore.java
+++ b/src/java/voldemort/store/routed/PipelineRoutedStore.java
@@ -918,7 +918,8 @@ public class PipelineRoutedStore extends RoutedStore {
 
         if(this.jmxEnabled) {
             JmxUtils.unregisterMbean(JmxUtils.createObjectName(JmxUtils.getPackageName(stats.getClass()),
-                                                               getName() + JmxUtils.getJmxId(jmxId)));
+                                                               getName() + "-"
+                                                                       + JmxUtils.getJmxId(jmxId)));
         }
 
         if(exception != null)


### PR DESCRIPTION
Solves exception when unregistering the MBean. The problem is that the MBean is registered with one name and unregistered with a different name.

[2014-06-10 08:55:54,775 voldemort.utils.JmxUtils] ERROR Error unregistering mbean 
javax.management.InstanceNotFoundException: voldemort.store.routed:type=protobufAvail
    at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getMBean(DefaultMBeanServerInterceptor.java:1094)
    at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.exclusiveUnregisterMBean(DefaultMBeanServerInterceptor.java:415)
    at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.unregisterMBean(DefaultMBeanServerInterceptor.java:403)
    at com.sun.jmx.mbeanserver.JmxMBeanServer.unregisterMBean(JmxMBeanServer.java:506)
    at voldemort.utils.JmxUtils.unregisterMbean(JmxUtils.java:348)
    at voldemort.store.routed.PipelineRoutedStore.close(PipelineRoutedStore.java:915)
    at voldemort.store.DelegatingStore.close(DelegatingStore.java:46)
    at voldemort.store.DelegatingStore.close(DelegatingStore.java:46)
    at voldemort.server.storage.StorageService.stopInner(StorageService.java:992)
    at voldemort.common.service.AbstractService.stop(AbstractService.java:74)
    at voldemort.server.VoldemortServer.stopInner(VoldemortServer.java:351)
    at voldemort.common.service.AbstractService.stop(AbstractService.java:74)
    at voldemort.server.VoldemortServer$1.run(VoldemortServer.java:392)
