### PR TITLE
Fix for QuotaLimitingStore: Passing storestats for the current store ins...

### DIFF
--- a/src/java/voldemort/server/storage/StorageService.java
+++ b/src/java/voldemort/server/storage/StorageService.java
@@ -879,10 +879,11 @@ public class StorageService extends AbstractService {
             // Wrap everything under the rate limiting store (barring the
             // metadata store)
             if(voldemortConfig.isEnableQuotaLimiting() && !isMetadata) {
+                StoreStats currentStoreStats = statStore.getStats();
                 FileBackedCachingStorageEngine quotaStore = (FileBackedCachingStorageEngine) storeRepository.getStorageEngine(SystemStoreConstants.SystemStoreName.voldsys$_store_quotas.toString());
                 QuotaLimitStats quotaStats = new QuotaLimitStats(this.aggregatedQuotaStats);
                 QuotaLimitingStore rateLimitingStore = new QuotaLimitingStore(store,
-                                                                              this.storeStats,
+                                                                              currentStoreStats,
                                                                               quotaStats,
                                                                               quotaStore);
                 if(voldemortConfig.isJmxEnabled()) {


### PR DESCRIPTION
...tead of the aggregate

The current QuotaLimitingStore limits requests by comparing the current aggregate value against the per store quota value. Changing this so that we compare per store current throughput value with the per store quota value.
