### PR TITLE
Registering individual store quota stats instead of aggregate to the Mbe...

### DIFF
--- a/src/java/voldemort/server/storage/StorageService.java
+++ b/src/java/voldemort/server/storage/StorageService.java
@@ -887,7 +887,7 @@ public class StorageService extends AbstractService {
                                                                               quotaStats,
                                                                               quotaStore);
                 if(voldemortConfig.isJmxEnabled()) {
-                    JmxUtils.registerMbean(this.aggregatedQuotaStats,
+                    JmxUtils.registerMbean(quotaStats,
                                            JmxUtils.createObjectName("voldemort.store.quota",
                                                                      store.getName()
                                                                              + "-quota-limit-stats"));


### PR DESCRIPTION
...an server

Currently all the individual store quota metrics (in ingraphs) show the same (aggregate) values. Changing this to a per store Quota stats metric.
