### PR TITLE
Junit tests are not running inside eclipse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -506,6 +506,9 @@ dependencies {
 }
 
 eclipse {
+    project {
+        buildCommand  'org.eclipse.jdt.core.javabuilder'
+    }
     jdt {
         // Currently the javac Version of jar is set to 1.5
         // But @Override works differently between both, so overriding here

--- a/test/unit/voldemort/coordinator/CoordinatorRestAPITest.java
+++ b/test/unit/voldemort/coordinator/CoordinatorRestAPITest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2013 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -306,8 +306,13 @@ public class CoordinatorRestAPITest {
             assertEquals("The number of body parts expected is not 1", 1, mp.getCount());
 
             MimeBodyPart part = (MimeBodyPart) mp.getBodyPart(0);
-            VectorClock vc = RestUtils.deserializeVectorClock(part.getHeader(RestMessageHeaders.X_VOLD_VECTOR_CLOCK)[0]);
-            response = (String) part.getContent();
+            VectorClock vc =
+                    RestUtils.deserializeVectorClock(part.getHeader(RestMessageHeaders.X_VOLD_VECTOR_CLOCK)[0]);
+            int contentLength = Integer.parseInt(part.getHeader(RestMessageHeaders.CONTENT_LENGTH)[0]);
+            byte[] bodyPartBytes = new byte[contentLength];
+
+            part.getInputStream().read(bodyPartBytes);
+            response = new String(bodyPartBytes);
 
             responseObj = new TestVersionedValue(response, vc);
 


### PR DESCRIPTION
Java builder property is not set on the .project file which
causes all the tests to fail with the ClassNotFoundException

Some test uses GetContent which causes CoordinatorRestAPITest
to fail.
