### PR TITLE
Releasing Voldemort 1.8.12

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,5 +46,5 @@ javac.version=1.5
 scalac.version=2.10
 
 ## Release
-curr.release=1.8.11
+curr.release=1.8.12
 

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,11 @@
+Release 1.8.12 on 08/11/2014
+
+* Speeds up vector clock serialization.
+* Adds a clean up task in the Gradle build that fixes an intermittent issue with builds on mac.
+* Expands test configurations.
+* Some fixes and clean ups in the C++ client.
+* Rewrites RequestCounter so that it leverages the Tehuti metrics lib.
+
 Release 1.8.11 on 08/01/2014
 
 * Expose http decoder parameters as config


### PR DESCRIPTION
Release 1.8.12 on 08/11/2014
- Speeds up vector clock serialization.
- Adds a clean up task in the Gradle build that fixes an intermittent issue with builds on mac.
- Expands test configurations.
- Some fixes and clean ups in the C++ client.
- Rewrites RequestCounter so that it leverages the Tehuti metrics lib.
