### PR TITLE
Fix the Krati entries iterator to properly handle key collisions.

### DIFF
--- a/contrib/krati/src/java/voldemort/store/krati/KratiStorageEngine.java
+++ b/contrib/krati/src/java/voldemort/store/krati/KratiStorageEngine.java
@@ -105,7 +105,8 @@ public class KratiStorageEngine extends AbstractStorageEngine<ByteArray, byte[],
                 // TODO: Move to DynamicDataStore code
                 ByteBuffer bb = ByteBuffer.wrap(returnedBytes);
                 int cnt = bb.getInt();
-                if(cnt > 0) {
+                // Loop over all keys at this index
+                for(int i = 0; i < cnt; i++) {
                     int keyLen = bb.getInt();
                     byte[] key = new byte[keyLen];
                     bb.get(key);

--- a/test/unit/voldemort/store/AbstractStorageEngineTest.java
+++ b/test/unit/voldemort/store/AbstractStorageEngineTest.java
@@ -232,6 +232,35 @@ public abstract class AbstractStorageEngineTest extends AbstractByteArrayStoreTe
         }
     }
 
+    @Test
+    public void testEntryIteration() {
+        final int numPut = 10000;
+        final StorageEngine<ByteArray, byte[], byte[]> store = getStorageEngine();
+        
+        for(int i = 0; i < numPut; i++) {
+            String key = "key-" + i;
+            String value = "Value for " + key;
+            store.put(new ByteArray(key.getBytes()), new Versioned<byte[]>(value.getBytes()), null);
+        }
+        
+        int numGet = 0;
+        ClosableIterator<Pair<ByteArray, Versioned<byte[]>>> it = null;
+        
+        try {
+            it = store.entries();
+            while (it.hasNext()) {
+                it.next();
+                numGet++;
+            }
+        } finally {
+            if (it != null) {
+                it.close();
+            }
+        }
+        
+        assertEquals("Iterator returned by the call to entries() did not contain the expected number of values", numPut, numGet);
+    }
+
     @SuppressWarnings("unused")
     private boolean remove(List<byte[]> list, byte[] item) {
         Iterator<byte[]> it = list.iterator();


### PR DESCRIPTION
When using Krati the Fetch command does not always return the expected number of key/value pairs.  The larger the store the more likely that the number of key/value pairs returned would be less than expected.  I tracked this issue down to what I think is a very simple bug in the KratiStorageEngine code - if there are key collisions at an index then the current iterator returned by the call to the entries method only returns the first key at that index.

This update contains a fix for this problem and a new test case that demonstrates the problem.