### PR TITLE
Output stats file for RO files download

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -405,7 +405,7 @@ dependencies {
 
     // commons io is used at many places
     // IOUtils, FileUtils and ByteArrayOutputStream
-    compile 'commons-io:commons-io:1.4'
+    compile 'commons-io:commons-io:2.1'
 
     // LZF compression strategy for store and tests.
     compile 'com.ning:compress-lzf:0.9.1'
@@ -536,7 +536,7 @@ dependencies {
     // conflict resolution is not done properly across sourceSets
     // and we end up with 2 versions of few jars like ( log4j, servlet etc. )
     compile 'commons-configuration:commons-configuration:1.6'
-    compile 'org.apache.hadoop:hadoop-core:1.0.4'
+    compile 'org.apache.hadoop:hadoop-core:1.2.1'
 
     compile 'com.linkedin.pegasus:r2:1.8.3'
     compile 'com.linkedin.pegasus:data:1.8.3'
@@ -568,6 +568,7 @@ eclipse {
     }
     classpath {
         defaultOutputDir = project.file('classes')
+        downloadSources=true
         file {
             // SourceSets creates multiple src/java in .classpath with varying includes
             // But eclipse 4.3 is complaining about duplicate classpaths

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsCopyStats.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsCopyStats.java
@@ -1,0 +1,226 @@
+package voldemort.store.readonly.fetcher;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+
+import voldemort.annotations.jmx.JmxGetter;
+import voldemort.utils.Time;
+
+public class HdfsCopyStats {
+
+    private final String sourceFile;
+    private final long startTimeMS;
+    private volatile long bytesSinceLastReport;
+    private volatile long totalBytesCopied;
+    private volatile long lastReportNs;
+    private volatile long totalBytes;
+
+    private BufferedWriter statsFileWriter = null;
+    public static final String STATS_DIRECTORY = ".stats";
+    private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    private static final Logger logger = Logger.getLogger(HdfsCopyStats.class);
+
+    private static void deleteExtraStatsFiles(File statsDirectory, int maxStatsFile) {
+        if(maxStatsFile <= 0) {
+            return;
+        }
+
+        try {
+            File[] files = statsDirectory.listFiles();
+            // One more stats file will be created for the current run.
+            int allowedStatsFile = maxStatsFile - 1;
+
+            if(files.length <= allowedStatsFile) {
+                return;
+            }
+
+            Arrays.sort(files, new Comparator<File>() {
+
+                @Override
+                public int compare(File f1, File f2) {
+                    return Long.valueOf(f2.lastModified()).compareTo(f1.lastModified());
+                }
+            });
+
+            for(int i = allowedStatsFile; i < files.length; i++) {
+                files[i].delete();
+            }
+        } catch(Exception e) {
+            logger.error("Error during cleanup of stats file directory", e);
+        }
+
+    }
+
+    public static File getStatDir(File destination) {
+        // Downloading is happening on the top level directory, no place to
+        // create summary
+        File destParent = destination.getParentFile();
+        if(destParent == null) {
+            return null;
+        }
+
+        return new File(destParent, STATS_DIRECTORY);
+    }
+
+    private void initializeStatsFile(File destination,
+                                     boolean enableStatsFile,
+                                     int maxVersionsStatsFile,
+                                     boolean isFileCopy) {
+        // Stats file is disabled in the config
+        if(enableStatsFile == false) {
+            return;
+        }
+        
+        // Downloading just a file(test), stats are not required.
+        if(isFileCopy) {
+            return;
+        }
+        
+        
+        File statsDirectory = getStatDir(destination);
+        if(statsDirectory == null) {
+            return;
+        }
+        try {
+            if(statsDirectory.exists() == false) {
+                statsDirectory.mkdirs();
+            }
+            
+            if(statsDirectory.exists() == false) {
+                logger.info("Could not create stats directory for destination " + destination);
+                return;
+            }
+
+            deleteExtraStatsFiles(statsDirectory, maxVersionsStatsFile);
+
+            String destName = destination.getName();
+            File statsFile = new File(statsDirectory, destName);
+            statsFile.createNewFile();
+
+            statsFileWriter = new BufferedWriter(new FileWriter(statsFile));
+            statsFileWriter.write("Starting fetch at " + startTimeMS + "MS from "
+                                  + sourceFile);
+            statsFileWriter.newLine();
+            statsFileWriter.write("Time, FileName, StartTime(MS), Size, TimeTaken(MS), Attempts #, TotalBytes");
+            statsFileWriter.newLine();
+
+        } catch(Exception e) {
+            statsFileWriter = null;
+            logger.error("Error during stats directory for destination " + destination, e);
+            return;
+        }
+    }
+
+    public HdfsCopyStats(String source,
+                         File destination,
+                         boolean enableStatsFile,
+                         int maxVersionsStatsFile,
+                         boolean isFileCopy,
+                         long totalBytes) {
+        this.sourceFile = source;
+        this.totalBytesCopied = 0L;
+        this.bytesSinceLastReport = 0L;
+        this.totalBytes = totalBytes;
+        this.lastReportNs = System.nanoTime();
+        this.startTimeMS = System.currentTimeMillis();
+        initializeStatsFile(destination, enableStatsFile, maxVersionsStatsFile, isFileCopy);
+    }
+
+    public void recordBytes(long bytes) {
+        this.totalBytesCopied += bytes;
+        this.bytesSinceLastReport += bytes;
+    }
+
+    public void reset() {
+        this.bytesSinceLastReport = 0;
+        this.lastReportNs = System.nanoTime();
+    }
+
+    public long getBytesSinceLastReport() {
+        return bytesSinceLastReport;
+    }
+    
+    private void reportStats(String message) {
+        try {
+            if(statsFileWriter != null) {
+                statsFileWriter.write(dateFormat.format(new Date()));
+                statsFileWriter.write(",");
+                statsFileWriter.write(message);
+                statsFileWriter.newLine();
+            }
+        } catch(IOException e) {
+            // ignore errors
+        }
+
+    }
+
+    public void reportError(String message, Throwable t) {
+        if(statsFileWriter != null && t != null) {
+            reportStats(message + " Error Message : " + t.getMessage());
+            PrintWriter pw = new PrintWriter(statsFileWriter);
+            t.printStackTrace(pw);
+        }
+    }
+
+    public void reportFileError(File file,int attempts, long startTimeMS, Throwable t) {
+        long nowMS = System.currentTimeMillis();
+        String message = " Error occured during file download " + file.getName()
+                         + " after attempts " + attempts + " time elapsed " + (nowMS - startTimeMS)
+                         + " MS.";
+        reportError(message, t);
+    }
+
+    public void reportFileDownloaded(File file,
+                                     long startTimeMS,
+                                     long fileSize,
+                                     long timeTakenMS,
+                                     int attempts,
+                                     long totalBytesDownloaded) {
+        reportStats(file.getName() + "," + startTimeMS + "," + fileSize + "," + timeTakenMS + ","
+                    + attempts + "," + totalBytesDownloaded);
+    }
+
+    public void complete() {
+        long nowMS = System.currentTimeMillis() ;
+        reportStats(" Completed at " + nowMS + "MS. Total bytes Copied " + totalBytesCopied
+                    + " . Expected Total bytes " + totalBytes + " . Time taken(MS) "
+                    + (nowMS - startTimeMS));
+        if(statsFileWriter != null) {
+            IOUtils.closeQuietly(statsFileWriter);
+        }
+    }
+
+    public double getPercentCopied() {
+        if(totalBytes == 0) {
+            return 0.0;
+        } else {
+            return (double) (totalBytesCopied * 100) / (double) totalBytes;
+        }
+    }
+
+    @JmxGetter(name = "totalBytesCopied", description = "The total number of bytes copied so far in this transfer.")
+    public long getTotalBytesCopied() {
+        return totalBytesCopied;
+    }
+
+    @JmxGetter(name = "bytesPerSecond", description = "The rate of the transfer in bytes/second.")
+    public double getBytesPerSecond() {
+        double ellapsedSecs = (System.nanoTime() - lastReportNs) / (double) Time.NS_PER_SECOND;
+        return bytesSinceLastReport / ellapsedSecs;
+    }
+
+    @JmxGetter(name = "filename", description = "The file path being copied.")
+    public String getFilename() {
+        return this.sourceFile;
+    }
+}

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFile.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFile.java
@@ -40,6 +40,12 @@ public class HdfsFile implements Comparable<HdfsFile> {
         return type;
     }
 
+    public long getSize() {
+        if(fs.isDir())
+            return -1;
+        return fs.getLen();
+    }
+
     @Override
     public boolean equals(Object other) {
         if(this == other) {

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsCopyStatsTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsCopyStatsTest.java
@@ -1,0 +1,122 @@
+package voldemort.store.readonly.fetcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class HdfsCopyStatsTest {
+
+    private final File testSourceDir;
+    private File destination;
+    private final boolean enableStatsFile;
+    private final int maxStatsFile;
+    private final boolean isFileCopy;
+    private File statsDir;
+
+    @Parameters
+    public static Collection<Object[]> configs() {
+        return Arrays.asList(new Object[][] { { false }, { true } });
+    }
+
+    public HdfsCopyStatsTest(boolean enableStatsFile) {
+        testSourceDir = HDFSFetcherAdvancedTest.createTempDir();
+        destination = new File(testSourceDir.getAbsolutePath() + "_dest");
+        statsDir = HdfsCopyStats.getStatDir(destination);
+        this.enableStatsFile = enableStatsFile;
+        this.maxStatsFile = 4;
+        isFileCopy = false;
+    }
+
+    @Test
+    public void testCopyStats() throws Exception {
+        destination = new File(testSourceDir.getAbsolutePath() + "_dest");
+        statsDir = HdfsCopyStats.getStatDir(destination);
+        if(statsDir != null)
+            HDFSFetcherAdvancedTest.deleteDir(statsDir);
+        List<String> expectedStatsFile = new ArrayList<String>();
+        for(int i = 0; i < maxStatsFile + 2; i++) {
+            destination = new File(testSourceDir.getAbsolutePath() + "_dest" + i);
+            String destName = destination.getName();
+            expectedStatsFile.add(destName);
+            // Sleep to get last modified time stamp different for all files
+            // linux timestamp has second granularity, so sleep for a second
+            Thread.sleep(1000);
+            HdfsCopyStats stats = new HdfsCopyStats(testSourceDir.getAbsolutePath(),
+                                                    destination,
+                                                    enableStatsFile,
+                                                    maxStatsFile,
+                                                    isFileCopy,
+                                                    1000);
+
+            Random r = new Random();
+            for(int j = 0; j < 10; j++) {
+                File file = new File(destination, "file" + i);
+                stats.reportFileDownloaded(file,
+                                           System.currentTimeMillis(),
+                                           r.nextInt(),
+                                           r.nextLong(),
+                                           r.nextInt(),
+                                           r.nextLong());
+                
+               
+            }
+            Exception e = r.nextBoolean() ? null : new Exception();
+            stats.reportFileError(new File(destination, "error"), r.nextInt(), r.nextLong(), e);
+
+            stats.reportError("MyMessage", e);
+            stats.complete();
+
+            if(destination != null)
+                HDFSFetcherAdvancedTest.deleteDir(destination);
+        }
+
+        statsDir = HdfsCopyStats.getStatDir(destination);
+        if(enableStatsFile && isFileCopy == false) {
+            assertTrue("stats dir exists", statsDir.exists());
+
+            File[] statsFiles = statsDir.listFiles();
+            assertEquals("Number of files should be equal to the maxStatsFiles",
+                         maxStatsFile,
+                         statsFiles.length);
+            
+            List<String> actualStatsFile = new ArrayList<String>();
+            for(File statFile : statsFiles) {
+                assertTrue("Size of the stat file should be greater than zero",
+                           statFile.length() > 0);
+                actualStatsFile.add(statFile.getName());
+            }
+
+            while(expectedStatsFile.size() > maxStatsFile) {
+                expectedStatsFile.remove(0);
+            }
+
+            assertEquals("Expected and actual files are different",
+                         expectedStatsFile,
+                         actualStatsFile);
+        } else {
+            assertFalse("statsDir " + statsDir + " should not exist", statsDir.exists());
+        }
+        cleanUp();
+
+    }
+
+    public void cleanUp() {
+        if(testSourceDir != null)
+            HDFSFetcherAdvancedTest.deleteDir(testSourceDir);
+        if(statsDir != null)
+            HDFSFetcherAdvancedTest.deleteDir(statsDir);
+    }
+}

--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -158,7 +158,8 @@ public class VoldemortConfig implements Serializable {
     private String readOnlykerberosRealm;
     private String fileFetcherClass;
     private String readOnlyCompressionCodec;
-
+    private boolean readOnlyStatsFileEnabled;
+    private int readOnlyMaxVersionsStatsFile;
 
     // flag to indicate if we will mlock and pin index pages in memory
     private boolean useMlock;
@@ -355,6 +356,8 @@ public class VoldemortConfig implements Serializable {
                                                      VoldemortConfig.DEFAULT_KERBEROS_REALM);
         this.fileFetcherClass = props.getString("file.fetcher.class",
                                                 VoldemortConfig.DEFAULT_FILE_FETCHER_CLASS);
+        this.readOnlyStatsFileEnabled = props.getBoolean("readonly.stats.file.enabled", true);
+        this.readOnlyMaxVersionsStatsFile = props.getInt("readonly.stats.file.max.versions", 1000);
 
         // To set the Voldemort RO server compression codec to GZIP, explicitly
         // set this
@@ -3251,6 +3254,22 @@ public class VoldemortConfig implements Serializable {
 
     public String getFileFetcherClass() {
         return this.fileFetcherClass;
+    }
+
+    public boolean isReadOnlyStatsFileEnabled() {
+        return readOnlyStatsFileEnabled;
+    }
+
+    public void setReadOnlyStatsFileEnabled(boolean readOnlyStatsFileEnabled) {
+        this.readOnlyStatsFileEnabled = readOnlyStatsFileEnabled;
+    }
+
+    public int getReadOnlyMaxVersionsStatsFile() {
+        return readOnlyMaxVersionsStatsFile;
+    }
+
+    public void setReadOnlyMaxVersionsStatsFile(int readOnlyMaxVersionsStatsFile) {
+        this.readOnlyMaxVersionsStatsFile = readOnlyMaxVersionsStatsFile;
     }
 
     public String getReadOnlyCompressionCodec() {


### PR DESCRIPTION
.stats directory will be created and will contain last X (default: 50)
stats file.

If a version-X is fetched a file with the same name as this directory
name will contain the stats for this download.

The stats file will contain the individual file name, time it took to download
and few other information.

Added unit tests for the HdfsCopyStatsTest

Sample Output of one file.

Starting fetch at 1431673167472MS from webhdfs://blah/node-0
Time, FileName, StartTime(MS), Size, TimeTaken(MS), Attempts , TotalBytes
2015-05-15 06:59:27.567,.metadata,1431673167509,86,58,0,86
2015-05-15 06:59:27.628,145_1_0.data,1431673167588,39,40,0,39
2015-05-15 06:59:27.663,413_0_0.data,1431673167628,37,35,0,37
2015-05-15 06:59:27.712,145_1_0.index,1431673167663,12,49,0,12
2015-05-15 06:59:27.757,413_0_0.index,1431673167712,12,45,0,12
2015-05-15 06:59:27.759, Completed at 1431673167759MS. Total bytes Copied 186 . Expected Total bytes 186 . Time taken(MS) 287