### PR TITLE
Unregister the "-streaming-stats" mbean correctly

### DIFF
--- a/src/java/voldemort/server/StoreRepository.java
+++ b/src/java/voldemort/server/StoreRepository.java
@@ -185,7 +185,7 @@ public class StoreRepository {
         // register streaming stats object for the store
         if(streamingStatsMap != null) {
             JmxUtils.unregisterMbean(JmxUtils.createObjectName(this.getClass().getCanonicalName(),
-                                                               storeName));
+                                                               storeName + "-streaming-stats"));
             streamingStatsMap.remove(storeName);
             // lazily unregister the aggregated mbean
             if(storageEngines.size() == 1) {


### PR DESCRIPTION
This avoids littering up the logs with JMX exceptions like this

2015/06/04 23:55:58.105 ERROR [JmxUtils] [voldemort-admin-server-t21] [voldemort] [] Error unregistering mbean
javax.management.InstanceNotFoundException: voldemort.server.StoreRepository:type=cmp_comparative_insights
        at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getMBean(DefaultMBeanServerInterceptor.java:1095)
        at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.exclusiveUnregisterMBean(DefaultMBeanServerInterceptor.java:427)
        at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.unregisterMBean(DefaultMBeanServerInterceptor.java:415)
        at com.sun.jmx.mbeanserver.JmxMBeanServer.unregisterMBean(JmxMBeanServer.java:546)
        at voldemort.utils.JmxUtils.unregisterMbean(JmxUtils.java:348)
        at voldemort.server.StoreRepository.removeStorageEngine(StoreRepository.java:187)
        at voldemort.server.storage.StorageService.removeEngine(StorageService.java:749)
        at voldemort.server.protocol.admin.AdminServiceRequestHandler.handleDeleteStore(AdminServiceRequestHandler.java:1487)
        at voldemort.server.protocol.admin.AdminServiceRequestHandler.handleRequest(AdminServiceRequestHandler.java:238)
        at voldemort.server.niosocket.AsyncRequestHandler.read(AsyncRequestHandler.java:190)
        at voldemort.common.nio.SelectorManagerWorker.run(SelectorManagerWorker.java:105)
        at voldemort.common.nio.SelectorManager.run(SelectorManager.java:214)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)