### PR TITLE
ConnectionException is not catastrophic

### DIFF
--- a/src/java/voldemort/client/protocol/admin/SocketPool.java
+++ b/src/java/voldemort/client/protocol/admin/SocketPool.java
@@ -90,7 +90,7 @@ public class SocketPool {
 
             return sas;
         } catch(Exception e) {
-            throw new UnreachableStoreException("Failure while checking out socket for "
+            throw UnreachableStoreException.wrap("Failure while checking out socket for "
                                                 + destination + ": ", e);
         }
     }

--- a/src/java/voldemort/cluster/failuredetector/FailureDetectorConfig.java
+++ b/src/java/voldemort/cluster/failuredetector/FailureDetectorConfig.java
@@ -19,6 +19,7 @@ package voldemort.cluster.failuredetector;
 import java.net.ConnectException;
 import java.net.NoRouteToHostException;
 import java.net.UnknownHostException;
+import java.nio.channels.UnresolvedAddressException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -58,7 +59,8 @@ public class FailureDetectorConfig {
 
     public static final List<String> DEFAULT_CATASTROPHIC_ERROR_TYPES = ImmutableList.of(ConnectException.class.getName(),
                                                                                          UnknownHostException.class.getName(),
-                                                                                         NoRouteToHostException.class.getName());
+                                                                                         NoRouteToHostException.class.getName(),
+                                                                                         UnresolvedAddressException.class.getName());
 
     public static final long DEFAULT_REQUEST_LENGTH_THRESHOLD = 5000;
 

--- a/src/java/voldemort/store/UnreachableStoreException.java
+++ b/src/java/voldemort/store/UnreachableStoreException.java
@@ -36,4 +36,11 @@ public class UnreachableStoreException extends VoldemortException {
         super(s, t);
     }
 
+    public static UnreachableStoreException wrap(String s, Throwable t) {
+        if(t instanceof UnreachableStoreException) {
+            return new UnreachableStoreException(s, t.getCause());
+        }
+        return new UnreachableStoreException(s, t);
+    }
+
 }

--- a/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutorPool.java
+++ b/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutorPool.java
@@ -210,7 +210,8 @@ public class ClientRequestExecutorPool implements SocketStoreFactory {
             // in this catch. Even if it was, clientRequestExecutore.close()
             // checks in the SocketDestination resource and so is not safe to
             // call.
-            throw new UnreachableStoreException("Failure while checking out socket for "
+
+            throw UnreachableStoreException.wrap("Failure while checking out socket for "
                                                 + destination + ": ", e);
         } finally {
             if(stats != null) {
@@ -236,6 +237,16 @@ public class ClientRequestExecutorPool implements SocketStoreFactory {
             throw new VoldemortException("Failure while checking in socket for " + destination
                                          + ": ", e);
         }
+    }
+
+
+    /**
+     * Used only for testing. Don't take a production dependency
+     * 
+     * @return queuedpool
+     */
+    public QueuedKeyedResourcePool<SocketDestination, ClientRequestExecutor> internalGetQueuedPool() {
+        return this.queuedPool;
     }
 
     /**

--- a/src/java/voldemort/store/socket/clientrequest/NonblockingStoreCallbackClientRequest.java
+++ b/src/java/voldemort/store/socket/clientrequest/NonblockingStoreCallbackClientRequest.java
@@ -125,7 +125,8 @@ public class NonblockingStoreCallbackClientRequest<T> implements ClientRequest<T
     @Override
     public void timeOut() {
         clientRequest.timeOut();
-        invokeCallback(new StoreTimeoutException("ClientRequestExecutor timed out. Cannot complete request."),
+        invokeCallback(new StoreTimeoutException("ClientRequestExecutor timed out for destination "
+                                                 + destination),
                        (System.nanoTime() - startNs) / Time.NS_PER_MS);
         executorPool.checkin(destination, clientRequestExecutor);
     }

--- a/src/java/voldemort/utils/pool/KeyedResourcePool.java
+++ b/src/java/voldemort/utils/pool/KeyedResourcePool.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2012 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -41,7 +41,7 @@ import voldemort.utils.Utils;
  * <li>allocates resources in FIFO order
  * <li>Pools are per key and there is no global maximum pool limit.
  * </ul>
- * 
+ *
  * Invariants that this implementation does not guarantee:
  * <ul>
  * <li>A checked in resource was previously checked out. (I.e., user can use
@@ -55,7 +55,7 @@ import voldemort.utils.Utils;
  * or let its reference to the resource lapse without checking the resource in
  * or destroying the resource.)
  * </ul>
- * 
+ *
  * Phrased differently, the following is expected of the user of this class:
  * <ul>
  * <li>A checked out resource is checked in exactly once.
@@ -84,7 +84,7 @@ public class KeyedResourcePool<K, V> {
 
     /**
      * Create a new pool
-     * 
+     *
      * @param <K> The type of the keys
      * @param <V> The type of the values
      * @param factory The factory that creates objects
@@ -98,7 +98,7 @@ public class KeyedResourcePool<K, V> {
 
     /**
      * Create a new pool using the defaults
-     * 
+     *
      * @param <K> The type of the keys
      * @param <V> The type of the values
      * @param factory The factory that creates objects
@@ -114,11 +114,11 @@ public class KeyedResourcePool<K, V> {
      * one. If no resources are available and we are already at the max size
      * then block for up to the maximum time specified. When we hit the maximum
      * time, if we still have not retrieved a valid resource throw an exception.
-     * 
+     *
      * This method is guaranteed to either return a valid resource in the pool
      * timeout + object creation time or throw an exception. If an exception is
      * thrown, resource is guaranteed to be destroyed.
-     * 
+     *
      * @param key The key to checkout the resource for
      * @return The resource
      */
@@ -187,7 +187,7 @@ public class KeyedResourcePool<K, V> {
      * attempt to create a new resource (up to the max allowed for the pool).
      * This method does not block per se. However, creating a resource may be
      * (relatively) expensive. This method either returns null or a resource.
-     * 
+     *
      * This method is the only way in which new resources are created for the
      * pool. So, non blocking checkouts must be attempted to populate the
      * resource pool.
@@ -222,7 +222,7 @@ public class KeyedResourcePool<K, V> {
      * it to the pool. This method is cheap to call even if the pool is full
      * (i.e., the first thing it does is looks a the current size of the pool
      * relative to the max pool size.
-     * 
+     *
      * @param key
      * @param objectFactory
      * @return True if and only if a resource was successfully added to the
@@ -230,7 +230,7 @@ public class KeyedResourcePool<K, V> {
      * @throws Exception if there are issues creating a new object, or
      *         destroying newly created object that could not be added to the
      *         pool.
-     * 
+     *
      */
     private boolean attemptGrow(K key, ResourceFactory<K, V> objectFactory, Pool<V> pool)
             throws Exception {
@@ -303,13 +303,13 @@ public class KeyedResourcePool<K, V> {
     }
 
     public void reportException(K key, Exception e) {
-        Pool<V> resourcePool = resourcePoolMap.get(key);
+        Pool<V> resourcePool = getResourcePoolForKey(key);
         resourcePool.reportException(e);
     }
 
     /**
      * Check the given resource back into the pool
-     * 
+     *
      * @param key The key for the resource
      * @param resource The resource
      */
@@ -363,7 +363,7 @@ public class KeyedResourcePool<K, V> {
      * Reset a specific resource pool. Destroys all of the idle resources in the
      * pool. This method does not affect whether the pool is "open" in the sense
      * of permitting new resources to be added to it.
-     * 
+     *
      * @param key The key for the pool to reset.
      */
     public void reset(K key) {
@@ -377,7 +377,7 @@ public class KeyedResourcePool<K, V> {
 
     /**
      * Count the number of existing resources for a specific pool.
-     * 
+     *
      * @param key The key
      * @return The count of existing resources. Returns 0 if no pool exists for
      *         given key.
@@ -400,7 +400,7 @@ public class KeyedResourcePool<K, V> {
      * Count the total number of existing resources for all pools. The result is
      * "approximate" in the face of concurrency since individual pools can
      * change size during the aggregate count.
-     * 
+     *
      * @return The (approximate) aggregate count of existing resources.
      */
     public int getTotalResourceCount() {
@@ -412,7 +412,7 @@ public class KeyedResourcePool<K, V> {
 
     /**
      * Count the number of checked in (idle) resources for a specific pool.
-     * 
+     *
      * @param key The key
      * @return The count of checked in resources. Returns 0 if no pool exists
      *         for given key.
@@ -435,7 +435,7 @@ public class KeyedResourcePool<K, V> {
      * Count the total number of checked in (idle) resources across all pools.
      * The result is "approximate" in the face of concurrency since individual
      * pools can have resources checked in, or out, during the aggregate count.
-     * 
+     *
      * @return The (approximate) aggregate count of checked in resources.
      */
     public int getCheckedInResourceCount() {
@@ -447,7 +447,7 @@ public class KeyedResourcePool<K, V> {
 
     /**
      * Count the number of blocking gets for a specific key.
-     * 
+     *
      * @param key The key
      * @return The count of blocking gets. Returns 0 if no pool exists for given
      *         key.
@@ -470,7 +470,7 @@ public class KeyedResourcePool<K, V> {
      * Count the total number of blocking gets across all pools. The result is
      * "approximate" in the face of concurrency since blocking gets for
      * individual pools can be issued or serviced during the aggregate count.
-     * 
+     *
      * @return The (approximate) aggregate count of blocking gets.
      */
     public int getBlockingGetsCount() {
@@ -493,7 +493,7 @@ public class KeyedResourcePool<K, V> {
      * A fixed size pool that uses an ArrayBlockingQueue. The pool grows to no
      * more than some specified maxPoolSize. The pool creates new resources in
      * the face of existing resources being destroyed.
-     * 
+     *
      */
     protected static class Pool<V> {
 
@@ -503,13 +503,16 @@ public class KeyedResourcePool<K, V> {
         final private BlockingQueue<V> queue;
         private final BlockingQueue<Pair<Long, Exception>> asyncExceptions;
 
-        final long EXCEPTION_REPORT_TIME_MS = TimeUnit.MILLISECONDS.convert(3, TimeUnit.SECONDS);
+        private final long excpetionReportTimeMS;
         final int EXCEPTION_COUNT_MAX = 300;
 
         public Pool(ResourcePoolConfig resourcePoolConfig) {
             this.maxPoolSize = resourcePoolConfig.getMaxPoolSize();
             queue = new ArrayBlockingQueue<V>(this.maxPoolSize, resourcePoolConfig.isFair());
             this.asyncExceptions = new ArrayBlockingQueue<Pair<Long, Exception>>(EXCEPTION_COUNT_MAX);
+            long configExceptionReportTime = resourcePoolConfig.getTimeout(TimeUnit.MILLISECONDS) * 2;
+            long MAX_EXCEPTION_REPORT_TIME = TimeUnit.MILLISECONDS.convert(30, TimeUnit.SECONDS);
+            excpetionReportTimeMS = Math.min(configExceptionReportTime, MAX_EXCEPTION_REPORT_TIME);
         }
 
         public void reportException(Exception e) {
@@ -518,16 +521,23 @@ public class KeyedResourcePool<K, V> {
 
         private void throwReportedExceptions() throws Exception {
             Pair<Long, Exception> entry;
+            int skippedExceptionCount = 0;
             while(true) {
                 entry = asyncExceptions.poll();
                 if(entry == null) {
+                    if(skippedExceptionCount > 0) {
+                        logger.info(" All Exceptions were expired exceptions. Count "
+                                    + skippedExceptionCount);
+                    }
                     return;
                 }
+
                 long elapsedTime = System.currentTimeMillis() - entry.getFirst();
-                if(elapsedTime <= EXCEPTION_REPORT_TIME_MS) {
+                skippedExceptionCount++;
+                if(elapsedTime <= excpetionReportTimeMS) {
                     Exception e = entry.getSecond();
                     logger.info(" Throwing remembered exception. time elapsed (ms) " + elapsedTime
-                                + "Exception "
+                                + ". Exception : "
                                 + e.getMessage());
                     throw e;
                 }

--- a/test/unit/voldemort/server/niosocket/NonRespondingSocketService.java
+++ b/test/unit/voldemort/server/niosocket/NonRespondingSocketService.java
@@ -1,0 +1,32 @@
+package voldemort.server.niosocket;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+
+public class NonRespondingSocketService {
+
+    private final ServerSocket serverSocket;
+    public NonRespondingSocketService(int port) throws IOException {
+        // server socket with single element backlog queue (1) and dynamicaly
+        // allocated port (0)
+        serverSocket = new ServerSocket(port, 1);
+        // just get the allocated port
+        port = serverSocket.getLocalPort();
+        // fill backlog queue by this request so consequent requests will be
+        // blocked
+        new Socket().connect(serverSocket.getLocalSocketAddress());
+
+    }
+
+    public void start() {
+
+    }
+
+    public void stop() throws IOException {
+        if(serverSocket != null && !serverSocket.isClosed()) {
+            serverSocket.close();
+        }
+    }
+}


### PR DESCRIPTION
I believe this will be the last fix in making the Voldemort Client deals with Server failures in a robust 
manner.

The 2 main fixes are for, clear the queue when a node is marked down ( currently they are left to timeout).
When the process hits the zombie state, deal with it as if the process is dead to recover from those errors faster.

1) If a connection timesout or fails during protocol negotiation,
they are treated as normal errors instead of catastrophic errors.
Connection timeout was a regression from NIO connect fix. Protocol
negotiation timeout is a new change to detect the failed servers
faster.
2) When a node is marked down, the outstanding queued requests are
not failed and let them go through the connection creation cycle.
When there is no outstanding requests they can wait infinitely until
the next request comes up.
3) UnreachableStoreException is sometimes double wrapped. This causes
the catastrophic errors to be not detected accurately. Created an utility
method, when you are not sure if the thrown exception could be
UnreachableStoreException use this method, which handles this case
correctly.
4) In non-blocking connect if the DNS does not resolve the Java throws
UnresolvedAddressException instead of UnknownHostException. Probably an
issue in java. Also UnresolvedAddressException is not derived from IOException
but from IllegalArgumentException which is weird. Fixed the code to handle
this.
5) Tuned the remembered exceptions timeout to twice the connection timeout.
Previously it was hardcoded to 3 seconds, which was too aggressive when the
connection for some use cases where set to more than 5 seconds.

Added unit tests to verify all the above cases.