### PR TITLE
update coordinator class name in server script

### DIFF
--- a/bin/voldemort-coordinator.sh
+++ b/bin/voldemort-coordinator.sh
@@ -53,4 +53,4 @@ if [ -z "$VOLD_OPTS" ]; then
   VOLD_OPTS="-Xmx1G -server -Dcom.sun.management.jmxremote"
 fi
 
-java -Dlog4j.configuration=src/java/log4j.properties $VOLD_OPTS -cp $CLASSPATH voldemort.rest.coordinator.CoordinatorService $@
+java -Dlog4j.configuration=src/java/log4j.properties $VOLD_OPTS -cp $CLASSPATH voldemort.rest.coordinator.CoordinatorServer $@


### PR DESCRIPTION
the current `voldemort-coordinator.sh` script references class `voldemort.rest.coordinator.CoordinatorService` which no longer exists. 

although unrelated to this change, i still can't get the coordinator service to return anything but a 404 response, is this service supposed to be functional?