### PR TITLE
Fix SecurityException when running HadoopStoreJobRunner in an oozie java action

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/HadoopStoreJobRunner.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/HadoopStoreJobRunner.java
@@ -281,14 +281,14 @@ public class HadoopStoreJobRunner extends Configured implements Tool {
     }
 
     public static void main(String[] args) {
-        int res;
+        int res = 1; // Init to 1 to please the compiler
         try {
             res = ToolRunner.run(new Configuration(), new HadoopStoreJobRunner(), args);
-            System.exit(res);
         } catch(Exception e) {
             e.printStackTrace();
             System.err.print("\nTry '--help' for more information.");
             System.exit(1);
         }
+        System.exit(res);
     }
 }


### PR DESCRIPTION
Oozie adds a security manager in the launcher to trap System.exit() calls. When it's called an exception is thrown, but trapped. If the exit code is 0 it's considered a successful run.

The main method of HadoopStoreJobRunner unnecessarily catches this exception and fails a successful job by calling `System.exit(1)`. This PR fixes this issue.

For reference: This is what the exception looks like

    java.lang.SecurityException: Intercepted System.exit(0)
            at org.apache.oozie.action.hadoop.LauncherSecurityManager.checkExit(LauncherMapper.java:808)
            at java.lang.Runtime.exit(Runtime.java:107)
            at java.lang.System.exit(System.java:962)
            at voldemort.store.readonly.mr.HadoopStoreJobRunner.main(HadoopStoreJobRunner.java:287)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:606)
            at org.apache.oozie.action.hadoop.LauncherMapper.map(LauncherMapper.java:495)
            at org.apache.hadoop.mapred.MapRunner.run(MapRunner.java:54)
            at org.apache.hadoop.mapred.MapTask.runOldMapper(MapTask.java:428)
            at org.apache.hadoop.mapred.MapTask.run(MapTask.java:340)
            at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:160)
            at java.security.AccessController.doPrivileged(Native Method)
            at javax.security.auth.Subject.doAs(Subject.java:415)
            at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1438)
            at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:155)
    
    Try '--help' for more information.Intercepting System.exit(1)
    Failing Oozie Launcher, Main class [voldemort.store.readonly.mr.HadoopStoreJobRunner], exit code [1]
