### PR TITLE
Ensure that all the AbstractStorageEngineTest tests get run by all th…

### DIFF
--- a/test/unit/voldemort/store/AbstractStorageEngineTest.java
+++ b/test/unit/voldemort/store/AbstractStorageEngineTest.java
@@ -42,6 +42,7 @@ public abstract class AbstractStorageEngineTest extends AbstractByteArrayStoreTe
 
     public abstract StorageEngine<ByteArray, byte[], byte[]> getStorageEngine();
 
+    @Test
     public void testGetNoEntries() {
         ClosableIterator<Pair<ByteArray, Versioned<byte[]>>> it = null;
         try {
@@ -55,6 +56,7 @@ public abstract class AbstractStorageEngineTest extends AbstractByteArrayStoreTe
         }
     }
 
+    @Test
     public void testGetNoKeys() {
         ClosableIterator<ByteArray> it = null;
         try {
@@ -68,6 +70,7 @@ public abstract class AbstractStorageEngineTest extends AbstractByteArrayStoreTe
         }
     }
 
+    @Test
     public void testKeyIterationWithSerialization() {
         StorageEngine<ByteArray, byte[], byte[]> store = getStorageEngine();
         StorageEngine<String, String, String> stringStore = new SerializingStorageEngine<String, String, String>(store,
@@ -88,6 +91,7 @@ public abstract class AbstractStorageEngineTest extends AbstractByteArrayStoreTe
         iter.close();
     }
 
+    @Test
     public void testIterationWithSerialization() {
         StorageEngine<ByteArray, byte[], byte[]> store = getStorageEngine();
         StorageEngine<String, String, String> stringStore = SerializingStorageEngine.wrap(store,
@@ -109,6 +113,7 @@ public abstract class AbstractStorageEngineTest extends AbstractByteArrayStoreTe
         iter.close();
     }
 
+    @Test
     public void testPruneOnWrite() {
         StorageEngine<ByteArray, byte[], byte[]> engine = getStorageEngine();
         Versioned<byte[]> v1 = new Versioned<byte[]>(new byte[] { 1 }, TestUtils.getClock(1));
@@ -122,6 +127,7 @@ public abstract class AbstractStorageEngineTest extends AbstractByteArrayStoreTe
         assertEquals(1, engine.get(key, null).size());
     }
 
+    @Test
     public void testTruncate() throws Exception {
         StorageEngine<ByteArray, byte[], byte[]> engine = getStorageEngine();
         Versioned<byte[]> v1 = new Versioned<byte[]>(new byte[] { 1 });


### PR DESCRIPTION
…e subclasses.

Add the @Test annotation to several tests.  Without that annotation it appears that
those subclasses that are parameterized do not run these specific test cases.  This
is most likely a base gradle issue.  Perhaps somewhat related to:

https://issues.gradle.org/browse/GRADLE-3112

Here is an example of the test results before and after the change:

$ grep STARTED test-before.logs | grep testGetNoKeys
voldemort.store.memory.CacheStorageEngineTest > testGetNoKeys STARTED
voldemort.store.memory.InMemoryStorageEngineTest > testGetNoKeys STARTED
voldemort.store.memory.SlowStorageEngineTest > testGetNoKeys STARTED
voldemort.store.mysql.MysqlStorageEngineTest > testGetNoKeys STARTED

$ grep STARTED test-after.logs | grep testGetNoKeys
voldemort.store.rocksdb.RocksdbStorageEngineTest > testGetNoKeys[0] STARTED
voldemort.store.rocksdb.RocksdbStorageEngineTest > testGetNoKeys[1] STARTED
voldemort.store.memory.CacheStorageEngineTest > testGetNoKeys STARTED
voldemort.store.memory.InMemoryStorageEngineTest > testGetNoKeys STARTED
voldemort.store.memory.SlowStorageEngineTest > testGetNoKeys STARTED
voldemort.store.bdb.BdbStorageEngineTest > testGetNoKeys[0] STARTED
voldemort.store.bdb.BdbStorageEngineTest > testGetNoKeys[1] STARTED
voldemort.store.mysql.MysqlStorageEngineTest > testGetNoKeys STARTED

Note that this change will uncover some RocksDB issues:

$ grep FAILURE test-after.logs | grep Rock
testFinished: test testKeyIterationWithSerialization[0](voldemort.store.rocksdb.RocksdbStorageEngineTest), result: FAILURE
testFinished: test testIterationWithSerialization[0](voldemort.store.rocksdb.RocksdbStorageEngineTest), result: FAILURE
testFinished: test testTruncate[0](voldemort.store.rocksdb.RocksdbStorageEngineTest), result: FAILURE
testFinished: test testKeyIterationWithSerialization[1](voldemort.store.rocksdb.RocksdbStorageEngineTest), result: FAILURE
testFinished: test testIterationWithSerialization[1](voldemort.store.rocksdb.RocksdbStorageEngineTest), result: FAILURE
testFinished: test testTruncate[1](voldemort.store.rocksdb.RocksdbStorageEngineTest), result: FAILURE

Perhaps these test need to be disabled before this change is made.


