### PR TITLE
Fixes to data cleanup job test

### DIFF
--- a/src/java/voldemort/utils/EventThrottler.java
+++ b/src/java/voldemort/utils/EventThrottler.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 public class EventThrottler {
 
     private static final Logger logger = Logger.getLogger(EventThrottler.class);
-    private static final long DEFAULT_CHECK_INTERVAL_MS = 50;
+    private static final long DEFAULT_CHECK_INTERVAL_MS = 1000;
     private static final String THROTTLER_NAME = "event-throttler";
 
     private final long maxRatePerSecond;


### PR DESCRIPTION
This includes a trivial fix for a broken test. Another commit also changes a default internal setting of the EventThrottler so that it makes more sense in the general case.