### PR TITLE
Improving debuggability of read-only fetches.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/BasicFetchStrategy.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/BasicFetchStrategy.java
@@ -99,9 +99,8 @@ public class BasicFetchStrategy implements FetchStrategy {
                     fileCheckSumGenerator = CheckSum.getInstance(checkSumType);
                 }
 
-                logger.info("Starting attempt # " + attempt + " / " + fetcher.getMaxAttempts() +
-                        " to fetch remote file: " + source +
-                        "\nLocal destination: " + dest);
+                logger.info("Starting attempt #" + attempt + "/" + fetcher.getMaxAttempts() +
+                        " to fetch remote file: " + source + " to local destination: " + dest);
 
                 input = new ThrottledInputStream(fs.open(source.getPath()), fetcher.getThrottler(), stats);
 
@@ -141,7 +140,7 @@ public class BasicFetchStrategy implements FetchStrategy {
                         String message = stats.getTotalBytesTransferred() / (1024 * 1024) + " MB copied at "
                                 + format.format(stats.getBytesTransferredPerSecond() / (1024 * 1024)) + " MB/sec"
                                 + ", " + format.format(stats.getPercentCopied()) + " % complete"
-                                + ", attempt: " + attempt + " / " + fetcher.getMaxAttempts()
+                                + ", attempt: #" + attempt + "/" + fetcher.getMaxAttempts()
                                 + ", current file: " + dest.getName();
                         if(this.status != null) {
                             this.status.setStatus(message);

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsCopyStats.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsCopyStats.java
@@ -117,6 +117,7 @@ public class HdfsCopyStats {
             statsFileWriter.newLine();
             statsFileWriter.write("Time, FileName, StartTime(MS), Size, TimeTaken(MS), Attempts #, TotalBytesTransferred, TotalBytesWritten");
             statsFileWriter.newLine();
+            statsFileWriter.flush();
 
         } catch(Exception e) {
             statsFileWriter = null;
@@ -171,6 +172,7 @@ public class HdfsCopyStats {
                 statsFileWriter.write(",");
                 statsFileWriter.write(message);
                 statsFileWriter.newLine();
+                statsFileWriter.flush();
             }
         } catch(IOException e) {
             // ignore errors

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -422,22 +422,6 @@ public class HdfsFetcher implements FileFetcher {
         return maxAttempts;
     }
 
-    // Used by tests
-    @SuppressWarnings("unused")
-    private CheckSum copyFileWithCheckSumTest(FileSystem fs,
-                                              Path source,
-                                              File dest,
-                                              HdfsCopyStats stats,
-                                              CheckSumType checkSumType,
-                                              byte[] buffer) throws IOException {
-
-        FetchStrategy fetchStrategy =
-                new BasicFetchStrategy(this, fs, stats, null, bufferSize);
-        return fetchStrategy.fetch(new HdfsFile(fs.getFileStatus(source)),
-                                   dest,
-                                   checkSumType);
-    }
-
     /*
      * Main method for testing fetching
      */

--- a/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
+++ b/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
@@ -1066,7 +1066,7 @@ public class AdminServiceRequestHandler implements RequestHandler {
                         + storeName + " Generated version " + pushVersion);
             }
 
-            asyncService.submitOperation(requestId, new AsyncOperation(requestId, "Fetch store") {
+            asyncService.submitOperation(requestId, new AsyncOperation(requestId, "Fetch store '" + storeName + "' v" + pushVersion) {
 
                 private String fetchDirPath = null;
 

--- a/src/java/voldemort/server/protocol/admin/AsyncOperation.java
+++ b/src/java/voldemort/server/protocol/admin/AsyncOperation.java
@@ -30,7 +30,7 @@ public abstract class AsyncOperation implements Runnable {
     public void run() {
         updateStatus("Started " + getStatus());
         String previousThreadName = Thread.currentThread().getName();
-        Thread.currentThread().setName(previousThreadName + "; AsyncOperation ID " + status.getId() + ": " + status.getDescription());
+        Thread.currentThread().setName(previousThreadName + "; AsyncOp ID " + status.getId());
         try {
             operate();
         } catch(Exception e) {

--- a/src/java/voldemort/server/protocol/admin/AsyncOperation.java
+++ b/src/java/voldemort/server/protocol/admin/AsyncOperation.java
@@ -29,13 +29,17 @@ public abstract class AsyncOperation implements Runnable {
 
     public void run() {
         updateStatus("Started " + getStatus());
+        String previousThreadName = Thread.currentThread().getName();
+        Thread.currentThread().setName(previousThreadName + "; AsyncOperation ID " + status.getId() + ": " + status.getDescription());
         try {
             operate();
         } catch(Exception e) {
             status.setException(e);
+        } finally {
+            Thread.currentThread().setName(previousThreadName);
+            updateStatus("Finished " + getStatus());
+            markComplete();
         }
-        updateStatus("Finished " + getStatus());
-        markComplete();
     }
 
     @Override


### PR DESCRIPTION
- All SchedulerService threads now have a unique name, instead of being all called "java.util.concurrent.ThreadPoolExecutor$Worker".
- AsyncOperation instances will now override their current thread's name to provide even more detail about what's running, and then restore the original thread name.
- The fetcher loop will report slightly more useful info to the BnP job via the AsyncOperation's status message.
- HdfsCopyStats flush lines as they happen, in order to improve debuggability of stalled or abrupbtly interrupted fetches...