### PR TITLE
Add a 'binary' format to the fetch-entries admin command so that it w…

### DIFF
--- a/src/java/voldemort/tools/admin/AdminParserUtils.java
+++ b/src/java/voldemort/tools/admin/AdminParserUtils.java
@@ -76,6 +76,8 @@ public class AdminParserUtils {
     // defined argument strings
     public static final String ARG_FORMAT_HEX = "hex";
     public static final String ARG_FORMAT_JSON = "json";
+    // This format creates a file compatible with the update-entries command
+    public static final String ARG_FORMAT_BINARY = "binary";
 
     /**
      * Adds OPT_ALL_NODES option to OptionParser, without argument.
@@ -170,9 +172,9 @@ public class AdminParserUtils {
      * @param required Tells if this option is required or optional
      */
     public static void acceptsFormat(OptionParser parser) {
-        parser.accepts(OPT_FORMAT, "format of key or entry, could be hex or json")
+        parser.accepts(OPT_FORMAT, "format of key or entry, could be hex, json or binary")
               .withRequiredArg()
-              .describedAs("hex | json")
+              .describedAs("hex | json | binary")
               .ofType(String.class);
     }
 


### PR DESCRIPTION
…ill create

a file compatible with the update-entries command.  For consistency sake add
this same format to the fetch-keys command.

My testing indicates that the fetch-entries command no longer produces a file format consistent with what the update-entries command expects.  To address this I defined a new output format called 'binary' that does match what the update-entries command expects (the old 'non ascii' format).  I considered several options:

1) Modify 'hex' format back to what it was before commit 2e880fcfc8 (I think) redefined the 'non ascii' format (which became the 'hex' format).
2) Modify the update-entries command to read the current 'hex' format.
3) Add a new 'binary' format consistent with the old 'non ascii' format.

I selected the third option because it preserved all the existing behavior.

Adding the 'binary' format (back) to the fetch-keys command was a somewhat arbitrary choice.