### PR TITLE
Fix the RocksDB iteration logic for keys and entries.  The problems a…

### DIFF
--- a/src/java/voldemort/store/rocksdb/PartitionPrefixedRocksDbStorageEngine.java
+++ b/src/java/voldemort/store/rocksdb/PartitionPrefixedRocksDbStorageEngine.java
@@ -123,7 +123,7 @@ public class PartitionPrefixedRocksDbStorageEngine extends RocksDbStorageEngine 
                 }
                 byte[] valueEntry = innerIterator.value();
                 innerIterator.next();
-                ByteArray key = new ByteArray(keyEntry);
+                ByteArray key = new ByteArray(StoreBinaryFormat.extractKey(keyEntry));
                 for(Versioned<byte[]> val: StoreBinaryFormat.fromByteArray(valueEntry)) {
                     cache.add(new Pair<ByteArray, Versioned<byte[]>>(key, val));
                 }
@@ -181,7 +181,7 @@ public class PartitionPrefixedRocksDbStorageEngine extends RocksDbStorageEngine 
                 }
 
                 this.innerIterator.next();
-                cache = new ByteArray(keyEntry);
+                cache = new ByteArray(StoreBinaryFormat.extractKey(keyEntry));
                 return true;
             }
             return false;
@@ -189,12 +189,14 @@ public class PartitionPrefixedRocksDbStorageEngine extends RocksDbStorageEngine 
 
         @Override
         public ByteArray next() {
-            if(cache != null) {
+            if(cache == null) {
                 if(!fetchnextKey()) {
                     throw new NoSuchElementException("Iterate to end");
                 }
             }
-            return cache;
+            ByteArray result = cache;
+            cache = null;
+            return result;
         }
 
         @Override

--- a/test/unit/voldemort/store/rocksdb/RocksdbStorageEngineAPITest.java
+++ b/test/unit/voldemort/store/rocksdb/RocksdbStorageEngineAPITest.java
@@ -61,9 +61,7 @@ public class RocksdbStorageEngineAPITest {
         props.setProperty("voldemort.home", "tmp/voldemort");
 
         voldemortConfig = new VoldemortConfig(props);
-        if(this.prefixPartitionId) {
-            voldemortConfig.setRocksdbPrefixKeysWithPartitionId(true);
-        }
+        voldemortConfig.setRocksdbPrefixKeysWithPartitionId(this.prefixPartitionId);
         this.rocksDbConfig = new RocksDbStorageConfiguration(voldemortConfig);
         this.rocksDbStore = (RocksDbStorageEngine) rocksDbConfig.getStore(TestUtils.makeStoreDefinition("test"),
                                                                           TestUtils.makeSingleNodeRoutingStrategy());

--- a/test/unit/voldemort/store/rocksdb/RocksdbStorageEngineTest.java
+++ b/test/unit/voldemort/store/rocksdb/RocksdbStorageEngineTest.java
@@ -55,9 +55,7 @@ public class RocksdbStorageEngineTest extends AbstractStorageEngineTest {
         props.setProperty("voldemort.home", "tmp/voldemort");
 
         voldemortConfig = new VoldemortConfig(props);
-        if(this.prefixPartitionId) {
-            voldemortConfig.setRocksdbPrefixKeysWithPartitionId(true);
-        }
+        voldemortConfig.setRocksdbPrefixKeysWithPartitionId(this.prefixPartitionId);
         this.rocksDbConfig = new RocksDbStorageConfiguration(voldemortConfig);
         this.rocksDbStore = (RocksDbStorageEngine) rocksDbConfig.getStore(TestUtils.makeStoreDefinition("test"),
                                                                           TestUtils.makeSingleNodeRoutingStrategy());
@@ -84,12 +82,4 @@ public class RocksdbStorageEngineTest extends AbstractStorageEngineTest {
     @Ignore
     @Override
     public void testTruncate() throws Exception {}
-
-    @Ignore
-    @Override
-    public void testKeyIterationWithSerialization() {}
-
-    @Ignore
-    @Override
-    public void testIterationWithSerialization() {}
 }


### PR DESCRIPTION
…ddressed include:

1) Key and entry iterators failed to strip prefix from keys (if required).
2) RocksdbStorageEngineTest failed to test BdbStorageEngine (all tests).
3) Both Key iterators would miss first entry and then iterate off the end.
With these changes I was able to remove the Ignore annotation from 2 tests.