### PR TITLE
add additional keepalive settings to avoid client connection leaks

### DIFF
--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008-2012 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -185,8 +185,10 @@ public class VoldemortConfig implements Serializable {
     private boolean socketKeepAlive;
 
     private boolean useNioConnector;
+    private boolean nioConnectorKeepAlive;
     private int nioConnectorSelectors;
     private int nioAdminConnectorSelectors;
+    private boolean nioAdminConnectorKeepAlive;
     private int nioAcceptorBacklog;
 
     private int clientSelectors;
@@ -441,12 +443,14 @@ public class VoldemortConfig implements Serializable {
         this.socketKeepAlive = props.getBoolean("socket.keepalive", false);
 
         this.useNioConnector = props.getBoolean("enable.nio.connector", true);
+        this.nioConnectorKeepAlive = props.getBoolean("nio.connector.keepalive", false);
         this.nioConnectorSelectors = props.getInt("nio.connector.selectors",
                                                   Math.max(8, Runtime.getRuntime()
                                                                      .availableProcessors()));
         this.nioAdminConnectorSelectors = props.getInt("nio.admin.connector.selectors",
                                                        Math.max(8, Runtime.getRuntime()
                                                                           .availableProcessors()));
+        this.nioAdminConnectorKeepAlive = props.getBoolean("nio.admin.connector.keepalive", false);
         // a value <= 0 forces the default to be used
         this.nioAcceptorBacklog = props.getInt("nio.acceptor.backlog", 256);
 
@@ -3466,6 +3470,40 @@ public class VoldemortConfig implements Serializable {
      */
     public void setRocksdbEnableReadLocks(boolean rocksdbEnableReadLocks) {
         this.rocksdbEnableReadLocks = rocksdbEnableReadLocks;
+    }
+
+    /**
+     * If set to true client connections to the nio admin server will have SO_KEEPALIVE on,
+     * to tell OS to close dead client connections
+     * <ul>
+     * <li>Property :"nio.admin.connector.keepalive"</li>
+     * <li>Default : "false"</li>
+     * </ul>
+     * @param nioAdminConnectorKeepAlive
+     */
+    public void setNioAdminConnectorKeepAlive(boolean nioAdminConnectorKeepAlive) {
+        this.nioAdminConnectorKeepAlive = nioAdminConnectorKeepAlive;
+    }
+    public boolean isNioAdminConnectorKeepAlive() {
+        return nioAdminConnectorKeepAlive;
+    }
+
+    /**
+     * If set to true client connections to the server will have SO_KEEPALIVE on,
+     * to tell OS to close dead client connections
+     * <ul>
+     * <li>Property :"nio.connector.keepalive"</li>
+     * <li>Default : "false"</li>
+     * </ul>
+     *
+     * @param nioConnectorKeepAlive
+     */
+    public void setNioConnectorKeepAlive(boolean nioConnectorKeepAlive) {
+        this.nioConnectorKeepAlive = nioConnectorKeepAlive;
+    }
+
+    public boolean isNioConnectorKeepAlive() {
+        return nioConnectorKeepAlive;
     }
 
 }

--- a/src/java/voldemort/server/VoldemortServer.java
+++ b/src/java/voldemort/server/VoldemortServer.java
@@ -245,6 +245,7 @@ public class VoldemortServer extends AbstractService {
                 NioSocketService nioSocketService = new NioSocketService(clientRequestHandlerFactory,
                                                                          identityNode.getSocketPort(),
                                                                          voldemortConfig.getSocketBufferSize(),
+                                                                         voldemortConfig.isNioConnectorKeepAlive(),
                                                                          voldemortConfig.getNioConnectorSelectors(),
                                                                          "nio-socket-server",
                                                                          voldemortConfig.isJmxEnabled(),
@@ -305,6 +306,7 @@ public class VoldemortServer extends AbstractService {
                 services.add(new NioSocketService(adminRequestHandlerFactory,
                                                   identityNode.getAdminPort(),
                                                   voldemortConfig.getAdminSocketBufferSize(),
+                                                  voldemortConfig.isNioAdminConnectorKeepAlive(),
                                                   voldemortConfig.getNioAdminConnectorSelectors(),
                                                   "admin-server",
                                                   voldemortConfig.isJmxEnabled(),
@@ -437,7 +439,7 @@ public class VoldemortServer extends AbstractService {
 
             @Override
             public void run() {
-                if(server.isStarted())
+                if (server.isStarted())
                     server.stop();
             }
         });

--- a/src/java/voldemort/server/niosocket/NioSelectorManager.java
+++ b/src/java/voldemort/server/niosocket/NioSelectorManager.java
@@ -101,16 +101,20 @@ public class NioSelectorManager extends SelectorManager {
 
     private final int socketBufferSize;
 
+    private final boolean socketKeepAlive;
+
     private final NioSelectorManagerStats stats;
 
     public NioSelectorManager(InetSocketAddress endpoint,
                               RequestHandlerFactory requestHandlerFactory,
-                              int socketBufferSize) {
+                              int socketBufferSize,
+                              boolean socketKeepAlive) {
         this.endpoint = endpoint;
         this.socketChannelQueue = new ConcurrentLinkedQueue<SocketChannel>();
         this.requestHandlerFactory = requestHandlerFactory;
         this.socketBufferSize = socketBufferSize;
         this.stats = new NioSelectorManagerStats();
+        this.socketKeepAlive = socketKeepAlive;
     }
 
     public void accept(SocketChannel socketChannel) {
@@ -144,6 +148,7 @@ public class NioSelectorManager extends SelectorManager {
 
                     socketChannel.socket().setTcpNoDelay(true);
                     socketChannel.socket().setReuseAddress(true);
+                    socketChannel.socket().setKeepAlive(socketKeepAlive);
                     socketChannel.socket().setSendBufferSize(socketBufferSize);
 
                     if(socketChannel.socket().getReceiveBufferSize() != this.socketBufferSize)

--- a/src/java/voldemort/server/niosocket/NioSocketService.java
+++ b/src/java/voldemort/server/niosocket/NioSocketService.java
@@ -72,17 +72,19 @@ public class NioSocketService extends AbstractSocketService {
 
     private final int socketBufferSize;
 
+    private final boolean socketKeepAlive;
+
     private final int acceptorBacklog;
 
     private final StatusManager statusManager;
 
     private final Thread acceptorThread;
-
     private final Logger logger = Logger.getLogger(getClass());
 
     public NioSocketService(RequestHandlerFactory requestHandlerFactory,
                             int port,
                             int socketBufferSize,
+                            boolean socketKeepAlive,
                             int selectors,
                             String serviceName,
                             boolean enableJmx,
@@ -90,6 +92,7 @@ public class NioSocketService extends AbstractSocketService {
         super(ServiceType.SOCKET, port, serviceName, enableJmx);
         this.requestHandlerFactory = requestHandlerFactory;
         this.socketBufferSize = socketBufferSize;
+        this.socketKeepAlive=socketKeepAlive;
         this.acceptorBacklog = acceptorBacklog;
 
         try {
@@ -124,7 +127,8 @@ public class NioSocketService extends AbstractSocketService {
             for(int i = 0; i < selectorManagers.length; i++) {
                 selectorManagers[i] = new NioSelectorManager(endpoint,
                                                              requestHandlerFactory,
-                                                             socketBufferSize);
+                                                             socketBufferSize,
+                                                             socketKeepAlive);
                 selectorManagerThreadPool.execute(selectorManagers[i]);
             }
 

--- a/test/common/voldemort/ServerTestUtils.java
+++ b/test/common/voldemort/ServerTestUtils.java
@@ -154,6 +154,7 @@ public class ServerTestUtils {
             socketService = new NioSocketService(requestHandlerFactory,
                                                  port,
                                                  bufferSize,
+                                                 false,
                                                  coreConnections,
                                                  "client-request-service",
                                                  false,


### PR DESCRIPTION
Extended server.properties to include booleans 
* nio.connector.keepalive 
* nio.admin.connector.keepalive

This will set SO_KEEPALIVE on the client connections in order to have the OS automatically close half open client connections

 