### PR TITLE
Iteration 1: Disk Quota

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsDirectory.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsDirectory.java
@@ -130,4 +130,8 @@ public class HdfsDirectory {
         return checkSumComparison;
     }
 
+    public ReadOnlyStorageMetadata getMetadata() {
+        return this.metadata;
+    }
+
 }

--- a/src/java/voldemort/store/readonly/checksum/CheckSumMetadata.java
+++ b/src/java/voldemort/store/readonly/checksum/CheckSumMetadata.java
@@ -1,9 +1,8 @@
-package voldemort.store.readonly;
+package voldemort.store.readonly.checksum;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.HashMap;
@@ -11,41 +10,39 @@ import java.util.Map;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.hadoop.fs.FSDataInputStream;
 
 import voldemort.serialization.json.JsonReader;
 import voldemort.serialization.json.JsonWriter;
-import voldemort.store.readonly.checksum.CheckSum;
-import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
+import voldemort.store.readonly.ReadOnlyStorageMetadata;
 
 import com.google.common.collect.Maps;
 
-public class ReadOnlyStorageMetadata {
+public class CheckSumMetadata {
 
-    public final static String FORMAT = "format";
-    public final static String CHECKSUM_TYPE = "checksum-type";
-    public final static String CHECKSUM = "checksum";
-    public final static String DISK_SIZE_IN_BYTES = "disk_size_in_bytes";
+    public final static String DATA_FILE_SIZE_IN_BYTES = "data_file_size_in_bytes";
+    public final static String INDEX_FILE_SIZE_IN_BYTES = "index_file_size_in_bytes";
 
     private Map<String, Object> properties;
 
-    public ReadOnlyStorageMetadata() {
+    public CheckSumMetadata() {
         this.properties = new HashMap<String, Object>();
     }
 
-    public ReadOnlyStorageMetadata(Map<String, Object> prop) {
+    public CheckSumMetadata(Map<String, Object> prop) {
         this();
         this.properties.putAll(prop);
     }
 
-    public ReadOnlyStorageMetadata(String json) {
+    public CheckSumMetadata(String json) {
         this();
         JsonReader reader = new JsonReader(new StringReader(json));
         properties.putAll(reader.readObject());
     }
 
-    public ReadOnlyStorageMetadata(File metadataFile) throws IOException {
+    public CheckSumMetadata(FSDataInputStream checkSumMetadataFile) throws IOException {
         this();
-        BufferedReader reader = new BufferedReader(new FileReader(metadataFile.getAbsolutePath()));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(checkSumMetadataFile));
         JsonReader jsonReader = new JsonReader(reader);
         properties.putAll(jsonReader.readObject());
     }
@@ -71,14 +68,6 @@ public class ReadOnlyStorageMetadata {
 
     public Object get(String key) {
         return properties.get(key);
-    }
-
-    public CheckSumType getCheckSumType() {
-        String checkSumType = (String) get(CHECKSUM_TYPE);
-        if(checkSumType == null) {
-            return CheckSumType.NONE;
-        }
-        return CheckSum.fromString(checkSumType);
     }
 
     public byte[] getCheckSum() throws DecoderException {
@@ -107,7 +96,7 @@ public class ReadOnlyStorageMetadata {
         if(o == null || getClass() != o.getClass())
             return false;
 
-        ReadOnlyStorageMetadata that = (ReadOnlyStorageMetadata) o;
+        CheckSumMetadata that = (CheckSumMetadata) o;
 
         Map<String, Object> thisMap = this.getAll();
         Map<String, Object> thatMap = that.getAll();
@@ -140,7 +129,7 @@ public class ReadOnlyStorageMetadata {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("ReadOnlyStorageMetadata( ");
+        StringBuilder sb = new StringBuilder("CheckSumMetadata( ");
         sb.append("\n");
         for(String key: this.properties.keySet()) {
             sb.append(key + " : " + properties.get(key) + ",");
@@ -150,5 +139,4 @@ public class ReadOnlyStorageMetadata {
 
         return sb.toString();
     }
-
 }

--- a/src/java/voldemort/store/readonly/swapper/DisableStoreOnFailedNodeFailedFetchStrategy.java
+++ b/src/java/voldemort/store/readonly/swapper/DisableStoreOnFailedNodeFailedFetchStrategy.java
@@ -1,11 +1,14 @@
 package voldemort.store.readonly.swapper;
 
-import com.google.common.collect.Lists;
-import voldemort.client.protocol.admin.AdminClient;
-import voldemort.cluster.Node;
-
 import java.util.List;
 import java.util.Map;
+
+import voldemort.client.protocol.admin.AdminClient;
+import voldemort.cluster.Node;
+import voldemort.store.quota.QuotaExceededException;
+import voldemort.store.readonly.swapper.AdminStoreSwapper.Response;
+
+import com.google.common.collect.Lists;
 
 /**
 *
@@ -22,13 +25,32 @@ public class DisableStoreOnFailedNodeFailedFetchStrategy extends FailedFetchStra
     @Override
     protected boolean dealWithIt(String storeName,
                                  long pushVersion,
-                                 Map<Node, AdminStoreSwapper.Response> fetchResponseMap) throws Exception {
+                                 Map<Node, AdminStoreSwapper.Response> fetchResponseMap)
+            throws Exception {
+        int numQuotaExceptions = 0;
         List<Integer> failedNodes = Lists.newArrayList();
-        for (Map.Entry<Node, AdminStoreSwapper.Response> entry: fetchResponseMap.entrySet()) {
-            if (!entry.getValue().isSuccessful()) {
-                failedNodes.add(entry.getKey().getId());
+        for(Map.Entry<Node, AdminStoreSwapper.Response> entry: fetchResponseMap.entrySet()) {
+            // Only consider non Quota related exceptions as Failures.
+            Response response = entry.getValue();
+            if(!response.isSuccessful()) {
+                // Check if there are any exceptions due to Quota
+                if(response.getException() instanceof QuotaExceededException) {
+                    numQuotaExceptions++;
+                } else {
+                    failedNodes.add(entry.getKey().getId());
+                }
             }
         }
-        return adminClient.readonlyOps.handleFailedFetch(failedNodes, storeName, pushVersion, extraInfo);
+        // QuotaException trumps all others
+        if(numQuotaExceptions > 0) {
+            logger.error("We cannot use "
+                         + getClass().getSimpleName()
+                         + " because there are QuotaExceededExceptions that caused fetch failures...");
+            return false;
+        }
+        return adminClient.readonlyOps.handleFailedFetch(failedNodes,
+                                                         storeName,
+                                                         pushVersion,
+                                                         extraInfo);
     }
 }

--- a/src/java/voldemort/utils/ByteUtils.java
+++ b/src/java/voldemort/utils/ByteUtils.java
@@ -60,6 +60,7 @@ public class ByteUtils {
 
     public static final int BYTES_PER_MB = 1048576;
     public static final long BYTES_PER_GB = 1073741824;
+    public static final int BYTES_PER_KB = 1024;
 
     public static MessageDigest getDigest(String algorithm) {
         try {


### PR DESCRIPTION
In this commit I have added a basic disk quota mechanism for Read Only Voldemort, which is described below:

Client side changes:
1. The way checksum for index and data files is serialized to disk is changed in this commit and is similar to ReadOnlyStorageMetadata class. Now each checksum file has two information: 1) checksum and 2) file size (either data file size or index file size). 
2. The reducers compute the bytes written to index and data files and finally add this information to the corresponding checksum file mentioned above.
3. After the Map/Reduce job is complete, the azkaban job iterates through each checksum file and constructs a metadata file for each pair<node,store> that contains checksum of checksums  for that pair<node,store>. This is same as previous implementation. However, in addition to checksum of checksums, the metadata file is also modified to contain the estimated disk size (for both data and index files) for that pair of <node,store>.
4. AdminStoreSwapper is modified to handle QuotaExceededException when invoking fetch on each node. DisableStoreOnFailedNodeFailedFetchStrategy will return false if there are QuotaExceededException s when trying to check the possibility of swap. In presence of Quota Exceptions all succeeded fetches will be reverted and data gets deleted.

Server side changes;
1. For stores that are part of the QuotaStore, it is assumed that a valid quota is predefined during the on-boarding process. The HDFS fetcher class fetches the estimated disk space needed (in bytes) for a <node,store> pair from the metadata file. It also gets the quota size (in KB) for the same <node, store> pair.
2. Quota check is done using the following algorithm:
- Determine if quota needs to be checked for the incoming push. For old stores quota is not checked. They will be quota-ed in future.
- For new stores, check if the store was just created as part of build and push. 
       It is assumed that new store that are on-boarded via some process (or manually) before the BnP starts have predefined quotas. So all stores that are created only during build phase are assumed to be invalid stores (possibly a push to the wrong bootstrap url) and quota is set to 0 as part of store creation to prevent the pushes to take place. 
       If the store was properly on-boarded a non zero quota value would have been set. Check if there is sufficient quota left for a new push.
3. If quota exceeds for an incoming push for a <node. store> pair, the push is failed. QuotaExceededException is thrown and is propagated to the client for handling failed fetches.
