### PR TITLE
Make some modifications to how the benchmarking tool works in local m…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -572,7 +572,7 @@ dependencies {
     compile 'org.apache.hadoop:libthrift:0.5.0.0'
     
     // rocksdb from maven
-    compile 'org.rocksdb:rocksdbjni:3.6.2'
+    compile 'org.rocksdb:rocksdbjni:3.13.1'
 }
 
 eclipse {

--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -146,6 +146,12 @@ public class VoldemortConfig implements Serializable {
     private String rocksdbDataDirectory;
     private boolean rocksdbPrefixKeysWithPartitionId;
     private boolean rocksdbEnableReadLocks;
+    // Options prefixed with the following two values can be used to tune RocksDB performance and are passed directly
+    // to the RocksDB configuration code. See the RocksDB documentation for details:
+    //   https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h
+    //   https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide
+    public static final String ROCKSDB_DB_OPTIONS = "rocksdb.db.options.";
+    public static final String ROCKSDB_CF_OPTIONS = "rocksdb.cf.options.";
 
     private int numReadOnlyVersions;
     private String readOnlyStorageDir;

--- a/test/integration/voldemort/performance/benchmark/Measurement.java
+++ b/test/integration/voldemort/performance/benchmark/Measurement.java
@@ -65,6 +65,7 @@ public class Measurement {
     private int maxLatency = -1;
     private long totalLatency = 0;
     private HashMap<Integer, int[]> returnCodes;
+    private HashMap<Integer, int[]> warningCodes;
     private boolean summaryOnly = false;
 
     public Measurement(String name, boolean summaryOnly) {
@@ -79,17 +80,28 @@ public class Measurement {
         this.minLatency = -1;
         this.maxLatency = -1;
         this.returnCodes = new HashMap<Integer, int[]>();
+        this.warningCodes = new HashMap<Integer, int[]>();
         this.summaryOnly = summaryOnly;
     }
 
     public synchronized void recordReturnCode(int code) {
-        Integer Icode = code;
-        if(!returnCodes.containsKey(Icode)) {
+        Integer key = code;
+        if(!returnCodes.containsKey(key)) {
             int[] val = new int[1];
             val[0] = 0;
-            returnCodes.put(Icode, val);
+            returnCodes.put(key, val);
         }
-        returnCodes.get(Icode)[0]++;
+        returnCodes.get(key)[0]++;
+    }
+
+    public synchronized void recordWarningCode(int code) {
+        Integer key = code;
+        if(!warningCodes.containsKey(key)) {
+            int[] val = new int[1];
+            val[0] = 0;
+            warningCodes.put(key, val);
+        }
+        warningCodes.get(key)[0]++;
     }
 
     public synchronized void recordLatency(int latency) {
@@ -151,12 +163,17 @@ public class Measurement {
         out.println("[" + getName() + "]\t95th(ms): " + nf.format(result.q95Latency));
         out.println("[" + getName() + "]\t99th(ms): " + nf.format(result.q99Latency));
 
-        if(!this.summaryOnly) {
-            for(Integer I: returnCodes.keySet()) {
-                int[] val = returnCodes.get(I);
-                out.println("[" + getName() + "]\tReturn: " + I + "\t" + val[0]);
-            }
+        for(Integer i: returnCodes.keySet()) {
+            int[] val = returnCodes.get(i);
+            out.println("[" + getName() + "]\tReturn: " + VoldemortWrapper.ReturnCode.values()[i] + "\t" + val[0]);
+        }
 
+        for(Integer i: warningCodes.keySet()) {
+            int[] val = returnCodes.get(i);
+            out.println("[" + getName() + "]\tWarning: " + VoldemortWrapper.WarningCode.values()[i] + "\t" + val[0]);
+        }
+
+        if(!this.summaryOnly) {
             for(int i = 0; i < buckets; i++) {
                 out.println("[" + getName() + "]: " + i + "\t" + histogram[i]);
             }

--- a/test/integration/voldemort/performance/benchmark/Metrics.java
+++ b/test/integration/voldemort/performance/benchmark/Metrics.java
@@ -80,6 +80,17 @@ public class Metrics {
         data.get(operation).recordReturnCode(code);
     }
 
+    public void recordWarningCode(String operation, int code) {
+        if(!data.containsKey(operation)) {
+            synchronized(this) {
+                if(!data.containsKey(operation)) {
+                    data.put(operation, constructMeasurement(operation));
+                }
+            }
+        }
+        data.get(operation).recordWarningCode(code);
+    }
+
     public void reset() {
         data.clear();
     }


### PR DESCRIPTION
…ode as part of

an evaluation of the RocksDB strorage engine:

1) Ensure that all the warm up records requested are created to eliminate some
random errors.
2) Modify the mixed operation in local mode to increment the VectorClock to prevent
all iterations from failing due to ObsoleteVersion exceptions.
3) Modify the mixed operation to perform the write even if the read returns nothing
rather than silently passing without performing a write (I considered making this
an error, but, preferred this approach).
4) Add a new Warning count similar to the ReturnCode count to report how often a mixed
operation reads nothing (could be used for other situations).
5) Move the RecordCode report outside the summaryOnly check so that the error counts
are always reported.