### PR TITLE
Disk quota child branch

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsDirectory.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsDirectory.java
@@ -130,4 +130,8 @@ public class HdfsDirectory {
         return checkSumComparison;
     }
 
+    public ReadOnlyStorageMetadata getMetadata() {
+        return this.metadata;
+    }
+
 }

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -43,6 +43,7 @@ import voldemort.store.readonly.FileFetcher;
 import voldemort.store.readonly.ReadOnlyStorageMetadata;
 import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
 import voldemort.store.readonly.mr.utils.HadoopUtils;
+import voldemort.store.readonly.swapper.InvalidBootstrapURLException;
 import voldemort.utils.ByteUtils;
 import voldemort.utils.EventThrottler;
 import voldemort.utils.JmxUtils;
@@ -155,7 +156,8 @@ public class HdfsFetcher implements FileFetcher {
                 ", fetcher socket timeout = " + socketTimeout + " ms.");
     }
 
-    public File fetch(String source, String dest) throws IOException {
+    @Override
+    public File fetch(String source, String dest) throws Exception {
         return fetch(source, dest, null, null, -1, null);
     }
 
@@ -165,7 +167,7 @@ public class HdfsFetcher implements FileFetcher {
                       AsyncOperationStatus status,
                       String storeName,
                       long pushVersion,
-                      MetadataStore metadataStore) throws IOException {
+                      MetadataStore metadataStore) throws Exception {
 
         ObjectName jmxName = null;
         HdfsCopyStats stats = null;
@@ -208,22 +210,14 @@ public class HdfsFetcher implements FileFetcher {
             } else {
                 return null;
             }
-        } catch(QuotaExceededException e) {
-            if(stats != null) {
-                stats.reportError("File fetcher failed for due to QuotaExceededException for destination "
-                                          + destinationFile,
-                                  e);
-            }
-            throw e;
-
         } catch(Exception e) {
             if(stats != null) {
                 stats.reportError("File fetcher failed for destination " + destinationFile, e);
             }
             String errorMessage = "Error thrown while trying to get data from Hadoop filesystem : ";
-            logger.error(errorMessage);
+            logger.error(errorMessage, e);
             if(e instanceof VoldemortException) {
-                throw (VoldemortException) e;
+                throw e;
             } else {
                 throw new VoldemortException(errorMessage, e);
             }
@@ -297,35 +291,13 @@ public class HdfsFetcher implements FileFetcher {
                  */
 
                 if(diskQuotaSizeInKB != null) {
-                    Long diskQuotaInKB = Long.parseLong(diskQuotaSizeInKB.getValue());
-                    String logMessage = "Store: " + storeName + ", Destination: "
-                                        + dest.getAbsolutePath() + ", Expected disk size in KB: "
-                                        + (estimatedDiskSize / ByteUtils.BYTES_PER_KB)
-                                        + ", Disk quota size in KB: " + diskQuotaInKB;
-                    if(logger.isDebugEnabled()) {
-                        logger.error(logMessage);
-                    }
-                    if(diskQuotaInKB == 0L){
-                        String errorMessage = "This store: \'"
-                                              + storeName
-                                              + "\' does not belong to this Voldemort cluster. Please use a valid bootstrap url.";
-                        logger.error(errorMessage);
-                        throw new VoldemortException(errorMessage);
-                    }
-                    // check if there is still sufficient quota left for this push
-                    Long estimatedDiskSizeNeeded = (estimatedDiskSize / ByteUtils.BYTES_PER_KB) ;
-                    if(estimatedDiskSizeNeeded >= diskQuotaInKB) {
-                        String errorMessage = "Quota Exceeded for " + logMessage;
-                        logger.error(errorMessage);
-                        throw new QuotaExceededException(errorMessage);
-                    }
+                    checkIfQuotaExceeded(diskQuotaSizeInKB, storeName, dest, estimatedDiskSize);
                 } else {
                     if(logger.isDebugEnabled()) {
                         logger.debug("store: " + storeName + " is a Non Quota type store.");
                     }
                 }
                 Map<HdfsFile, byte[]> fileCheckSumMap = fetchStrategy.fetch(directory, dest);
-
                 return directory.validateCheckSum(fileCheckSumMap);
 
             } else if(allowFetchOfFiles) {
@@ -342,6 +314,34 @@ public class HdfsFetcher implements FileFetcher {
             if(adminClient != null) {
                 adminClient.close();
             }
+        }
+    }
+
+    private void checkIfQuotaExceeded(Versioned<String> diskQuotaSizeInKB,
+                            String storeName,
+                            File dest,
+                            Long estimatedDiskSize) {
+        Long diskQuotaInKB = Long.parseLong(diskQuotaSizeInKB.getValue());
+        String logMessage = "Store: " + storeName + ", Destination: " + dest.getAbsolutePath()
+                            + ", Expected disk size in KB: "
+                            + (estimatedDiskSize / ByteUtils.BYTES_PER_KB)
+                            + ", Disk quota size in KB: " + diskQuotaInKB;
+        if(logger.isDebugEnabled()) {
+            logger.error(logMessage);
+        }
+        if(diskQuotaInKB == 0L) {
+            String errorMessage = "This store: \'"
+                                  + storeName
+                                  + "\' does not belong to this Voldemort cluster. Please use a valid bootstrap url.";
+            logger.error(errorMessage);
+            throw new InvalidBootstrapURLException(errorMessage);
+        }
+        // check if there is still sufficient quota left for this push
+        Long estimatedDiskSizeNeeded = (estimatedDiskSize / ByteUtils.BYTES_PER_KB);
+        if(estimatedDiskSizeNeeded >= diskQuotaInKB) {
+            String errorMessage = "Quota Exceeded for " + logMessage;
+            logger.error(errorMessage);
+            throw new QuotaExceededException(errorMessage);
         }
     }
 

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -642,11 +642,18 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
         try {
             adminClientPerCluster.get(url).storeMgmtOps.addStore(newStoreDef, nodeIDs);
 
-            // set Zero Quota for new stores that are created as part of build
-            Long quotaValue = 0L;
-            adminClientPerCluster.get(url).quotaMgmtOps.setQuota(storeName,
-                                                                 QuotaType.STORAGE_SPACE.toString(),
-                                                                 quotaValue.toString());
+            // only if there are nodes that need the store definition to be
+            // created we set quota to 0 in all nodes.
+            if(!nodeIDs.isEmpty()) {
+                // set Zero Quota for new stores that are created as part of
+                // build
+                Long quotaValue = 0L;
+                log.info("New incoming push for Store: " + storeName
+                         + " .Setting quota for this new store to 0.");
+                adminClientPerCluster.get(url).quotaMgmtOps.setQuota(storeName,
+                                                                     QuotaType.STORAGE_SPACE.toString(),
+                                                                     quotaValue.toString());
+            }
         }
         catch(VoldemortException ve) {
             throw new RuntimeException("Exception while adding store to nodes in cluster URL" + url, ve);

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -16,44 +16,6 @@
 
 package voldemort.store.readonly.mr.azkaban;
 
-import azkaban.jobExecutor.AbstractJob;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.protobuf.UninitializedMessageException;
-import org.apache.avro.Schema;
-import org.apache.commons.lang.Validate;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.log4j.Logger;
-import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
-import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
-import voldemort.client.protocol.pb.VAdminProto;
-import voldemort.cluster.Cluster;
-import voldemort.cluster.Node;
-import voldemort.serialization.DefaultSerializerFactory;
-import voldemort.serialization.SerializerDefinition;
-import voldemort.serialization.json.JsonTypeDefinition;
-import voldemort.server.VoldemortConfig;
-import voldemort.store.StoreDefinition;
-import voldemort.store.UnreachableStoreException;
-import voldemort.store.readonly.checksum.CheckSum;
-import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
-import voldemort.store.readonly.disk.KeyValueWriter;
-import voldemort.store.readonly.hooks.BuildAndPushHook;
-import voldemort.store.readonly.hooks.BuildAndPushStatus;
-import voldemort.store.readonly.mr.azkaban.VoldemortStoreBuilderJob.VoldemortStoreBuilderConf;
-import voldemort.store.readonly.mr.utils.AvroUtils;
-import voldemort.store.readonly.mr.utils.HadoopUtils;
-import voldemort.store.readonly.mr.utils.JsonSchema;
-import voldemort.store.readonly.mr.utils.VoldemortUtils;
-import voldemort.store.readonly.swapper.*;
-import voldemort.utils.Props;
-import voldemort.utils.ReflectUtils;
-import voldemort.utils.Utils;
-
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -74,6 +36,50 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
+import org.apache.avro.Schema;
+import org.apache.commons.lang.Validate;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.log4j.Logger;
+
+import voldemort.VoldemortException;
+import voldemort.client.ClientConfig;
+import voldemort.client.protocol.admin.AdminClient;
+import voldemort.client.protocol.admin.AdminClientConfig;
+import voldemort.client.protocol.pb.VAdminProto;
+import voldemort.cluster.Cluster;
+import voldemort.cluster.Node;
+import voldemort.serialization.DefaultSerializerFactory;
+import voldemort.serialization.SerializerDefinition;
+import voldemort.serialization.json.JsonTypeDefinition;
+import voldemort.server.VoldemortConfig;
+import voldemort.store.StoreDefinition;
+import voldemort.store.UnreachableStoreException;
+import voldemort.store.quota.QuotaType;
+import voldemort.store.readonly.checksum.CheckSum;
+import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
+import voldemort.store.readonly.disk.KeyValueWriter;
+import voldemort.store.readonly.hooks.BuildAndPushHook;
+import voldemort.store.readonly.hooks.BuildAndPushStatus;
+import voldemort.store.readonly.mr.azkaban.VoldemortStoreBuilderJob.VoldemortStoreBuilderConf;
+import voldemort.store.readonly.mr.utils.AvroUtils;
+import voldemort.store.readonly.mr.utils.HadoopUtils;
+import voldemort.store.readonly.mr.utils.JsonSchema;
+import voldemort.store.readonly.mr.utils.VoldemortUtils;
+import voldemort.store.readonly.swapper.DeleteAllFailedFetchStrategy;
+import voldemort.store.readonly.swapper.DisableStoreOnFailedNodeFailedFetchStrategy;
+import voldemort.store.readonly.swapper.FailedFetchStrategy;
+import voldemort.store.readonly.swapper.RecoverableFailedFetchException;
+import voldemort.utils.Props;
+import voldemort.utils.ReflectUtils;
+import voldemort.utils.Utils;
+import azkaban.jobExecutor.AbstractJob;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.protobuf.UninitializedMessageException;
 
 public class VoldemortBuildAndPushJob extends AbstractJob {
 
@@ -325,7 +331,7 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
                                              + "is not the same as " + clusterRhs.getName());
         }
     }
-    
+
     private void checkForPreconditions(boolean build, boolean push) {
         if (!build && !push) {
             throw new RuntimeException(" Both build and push cannot be false ");
@@ -354,7 +360,7 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
          */
 
         log.info("Requesting block-level compression codec expected by Server");
-        
+
         List<String> supportedCodecs;
         try{
             supportedCodecs = adminClientPerCluster.get(clusterURLs.get(0))
@@ -366,7 +372,7 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
             // return here
             return null;
         }
-        
+
         String codecList = "[ ";
         for(String str: supportedCodecs) {
             codecList += str + " ";
@@ -619,7 +625,7 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
                 "\n" + newStoreDef.diff(remoteStoreDef, thisName, otherName);
         return message;
     }
-    
+
     private void addStore(String description, String owners, String url, StoreDefinition newStoreDef, List<Integer> nodeIDs) {
         if (description.length() == 0) {
             throw new RuntimeException("Description field missing in store definition. "
@@ -635,6 +641,12 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
         }
         try {
             adminClientPerCluster.get(url).storeMgmtOps.addStore(newStoreDef, nodeIDs);
+
+            // set Zero Quota for new stores that are created as part of build
+            Long quotaValue = 0L;
+            adminClientPerCluster.get(url).quotaMgmtOps.setQuota(storeName,
+                                                                 QuotaType.STORAGE_SPACE.toString(),
+                                                                 quotaValue.toString());
         }
         catch(VoldemortException ve) {
             throw new RuntimeException("Exception while adding store to nodes in cluster URL" + url, ve);

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/HadoopStoreBuilderCollisionTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/HadoopStoreBuilderCollisionTest.java
@@ -157,7 +157,7 @@ public class HadoopStoreBuilderCollisionTest {
     }
 
     @Test
-    public void testCollision() throws IOException {
+    public void testCollision() throws Exception {
         testCollisionWithParams(500, 10);
         try {
             testCollisionWithParams(2 * (Short.MAX_VALUE + 1), (Short.MAX_VALUE + 1));
@@ -166,7 +166,7 @@ public class HadoopStoreBuilderCollisionTest {
     }
 
     @SuppressWarnings( { "unchecked" })
-    public void testCollisionWithParams(int totalElements, int maxCollisions) throws IOException {
+    public void testCollisionWithParams(int totalElements, int maxCollisions) throws Exception {
 
         assertEquals(totalElements % maxCollisions, 0);
 

--- a/src/java/voldemort/client/protocol/admin/AdminClient.java
+++ b/src/java/voldemort/client/protocol/admin/AdminClient.java
@@ -917,9 +917,8 @@ public class AdminClient implements Closeable {
                     String errorMessage = "Failed while waiting for async task ("
                             + description + ") at " + nodeName
                             + " to finish";
-                    if(e instanceof QuotaExceededException){
-                        String reason = ((QuotaExceededException) e).getMessage();
-                        throw new QuotaExceededException(errorMessage + "Reason: " + reason);
+                    if(e instanceof VoldemortException) {
+                        throw (VoldemortException) e;
                     } else {
                         throw new VoldemortException(errorMessage, e);
                     }
@@ -4233,6 +4232,9 @@ public class AdminClient implements Closeable {
 
             List<Integer> liveNodes = Lists.newArrayList(currentCluster.getNodeIds());
             liveNodes.removeAll(failedNodes);
+            if(liveNodes.isEmpty()) {
+                return false;
+            }
             Integer randomIndex = (int) (Math.random() * liveNodes.size());
             Integer randomNodeId = liveNodes.get(randomIndex);
 

--- a/src/java/voldemort/store/ErrorCodeMapper.java
+++ b/src/java/voldemort/store/ErrorCodeMapper.java
@@ -25,6 +25,7 @@ import voldemort.VoldemortUnsupportedOperationalException;
 import voldemort.server.rebalance.AlreadyRebalancingException;
 import voldemort.server.rebalance.VoldemortRebalancingException;
 import voldemort.store.quota.QuotaExceededException;
+import voldemort.store.readonly.swapper.InvalidBootstrapURLException;
 import voldemort.store.rebalancing.ProxyUnreachableException;
 import voldemort.store.slop.SlopStreamingDisabledException;
 import voldemort.store.views.UnsupportedViewOperationException;
@@ -62,6 +63,7 @@ public class ErrorCodeMapper {
         codeToException.put((short) 16, VoldemortUnsupportedOperationalException.class);
         codeToException.put((short) 17, QuotaExceededException.class);
         codeToException.put((short) 18, SlopStreamingDisabledException.class);
+        codeToException.put((short) 19, InvalidBootstrapURLException.class);
 
         exceptionToCode = new HashMap<Class<? extends VoldemortException>, Short>();
         for(Map.Entry<Short, Class<? extends VoldemortException>> entry: codeToException.entrySet())

--- a/src/java/voldemort/store/readonly/FileFetcher.java
+++ b/src/java/voldemort/store/readonly/FileFetcher.java
@@ -29,14 +29,15 @@ public interface FileFetcher {
      * @param dest
      * @return
      * @throws IOException
+     * @throws Exception
      */
     @Deprecated
-    public File fetch(String source, String dest) throws IOException;
+    public File fetch(String source, String dest) throws IOException, Exception;
 
     public File fetch(String source,
                       String dest,
                       AsyncOperationStatus status,
                       String storeName,
                       long pushVersion,
-                      MetadataStore metadataStore) throws IOException;
+                      MetadataStore metadataStore) throws IOException, Exception;
 }

--- a/src/java/voldemort/store/readonly/checksum/CheckSumMetadata.java
+++ b/src/java/voldemort/store/readonly/checksum/CheckSumMetadata.java
@@ -1,9 +1,8 @@
-package voldemort.store.readonly;
+package voldemort.store.readonly.checksum;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.HashMap;
@@ -11,41 +10,39 @@ import java.util.Map;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.hadoop.fs.FSDataInputStream;
 
 import voldemort.serialization.json.JsonReader;
 import voldemort.serialization.json.JsonWriter;
-import voldemort.store.readonly.checksum.CheckSum;
-import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
+import voldemort.store.readonly.ReadOnlyStorageMetadata;
 
 import com.google.common.collect.Maps;
 
-public class ReadOnlyStorageMetadata {
+public class CheckSumMetadata {
 
-    public final static String FORMAT = "format";
-    public final static String CHECKSUM_TYPE = "checksum-type";
-    public final static String CHECKSUM = "checksum";
-    public final static String DISK_SIZE_IN_BYTES = "disk_size_in_bytes";
+    public final static String DATA_FILE_SIZE_IN_BYTES = "data_file_size_in_bytes";
+    public final static String INDEX_FILE_SIZE_IN_BYTES = "index_file_size_in_bytes";
 
     private Map<String, Object> properties;
 
-    public ReadOnlyStorageMetadata() {
+    public CheckSumMetadata() {
         this.properties = new HashMap<String, Object>();
     }
 
-    public ReadOnlyStorageMetadata(Map<String, Object> prop) {
+    public CheckSumMetadata(Map<String, Object> prop) {
         this();
         this.properties.putAll(prop);
     }
 
-    public ReadOnlyStorageMetadata(String json) {
+    public CheckSumMetadata(String json) {
         this();
         JsonReader reader = new JsonReader(new StringReader(json));
         properties.putAll(reader.readObject());
     }
 
-    public ReadOnlyStorageMetadata(File metadataFile) throws IOException {
+    public CheckSumMetadata(FSDataInputStream checkSumMetadataFile) throws IOException {
         this();
-        BufferedReader reader = new BufferedReader(new FileReader(metadataFile.getAbsolutePath()));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(checkSumMetadataFile));
         JsonReader jsonReader = new JsonReader(reader);
         properties.putAll(jsonReader.readObject());
     }
@@ -71,14 +68,6 @@ public class ReadOnlyStorageMetadata {
 
     public Object get(String key) {
         return properties.get(key);
-    }
-
-    public CheckSumType getCheckSumType() {
-        String checkSumType = (String) get(CHECKSUM_TYPE);
-        if(checkSumType == null) {
-            return CheckSumType.NONE;
-        }
-        return CheckSum.fromString(checkSumType);
     }
 
     public byte[] getCheckSum() throws DecoderException {
@@ -107,7 +96,7 @@ public class ReadOnlyStorageMetadata {
         if(o == null || getClass() != o.getClass())
             return false;
 
-        ReadOnlyStorageMetadata that = (ReadOnlyStorageMetadata) o;
+        CheckSumMetadata that = (CheckSumMetadata) o;
 
         Map<String, Object> thisMap = this.getAll();
         Map<String, Object> thatMap = that.getAll();
@@ -140,7 +129,7 @@ public class ReadOnlyStorageMetadata {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("ReadOnlyStorageMetadata( ");
+        StringBuilder sb = new StringBuilder("CheckSumMetadata( ");
         sb.append("\n");
         for(String key: this.properties.keySet()) {
             sb.append(key + " : " + properties.get(key) + ",");
@@ -150,5 +139,4 @@ public class ReadOnlyStorageMetadata {
 
         return sb.toString();
     }
-
 }

--- a/src/java/voldemort/store/readonly/swapper/DisableStoreOnFailedNodeFailedFetchStrategy.java
+++ b/src/java/voldemort/store/readonly/swapper/DisableStoreOnFailedNodeFailedFetchStrategy.java
@@ -1,11 +1,14 @@
 package voldemort.store.readonly.swapper;
 
-import com.google.common.collect.Lists;
-import voldemort.client.protocol.admin.AdminClient;
-import voldemort.cluster.Node;
-
 import java.util.List;
 import java.util.Map;
+
+import voldemort.client.protocol.admin.AdminClient;
+import voldemort.cluster.Node;
+import voldemort.store.quota.QuotaExceededException;
+import voldemort.store.readonly.swapper.AdminStoreSwapper.Response;
+
+import com.google.common.collect.Lists;
 
 /**
 *
@@ -22,13 +25,32 @@ public class DisableStoreOnFailedNodeFailedFetchStrategy extends FailedFetchStra
     @Override
     protected boolean dealWithIt(String storeName,
                                  long pushVersion,
-                                 Map<Node, AdminStoreSwapper.Response> fetchResponseMap) throws Exception {
+                                 Map<Node, AdminStoreSwapper.Response> fetchResponseMap)
+            throws Exception {
+        int numQuotaExceptions = 0;
         List<Integer> failedNodes = Lists.newArrayList();
-        for (Map.Entry<Node, AdminStoreSwapper.Response> entry: fetchResponseMap.entrySet()) {
-            if (!entry.getValue().isSuccessful()) {
-                failedNodes.add(entry.getKey().getId());
+        for(Map.Entry<Node, AdminStoreSwapper.Response> entry: fetchResponseMap.entrySet()) {
+            // Only consider non Quota related exceptions as Failures.
+            Response response = entry.getValue();
+            if(!response.isSuccessful()) {
+                // Check if there are any exceptions due to Quota
+                if(response.getException() instanceof QuotaExceededException) {
+                    numQuotaExceptions++;
+                } else {
+                    failedNodes.add(entry.getKey().getId());
+                }
             }
         }
-        return adminClient.readonlyOps.handleFailedFetch(failedNodes, storeName, pushVersion, extraInfo);
+        // QuotaException trumps all others
+        if(numQuotaExceptions > 0) {
+            logger.error("We cannot use "
+                         + getClass().getSimpleName()
+                         + " because there are QuotaExceededExceptions that caused fetch failures...");
+            return false;
+        }
+        return adminClient.readonlyOps.handleFailedFetch(failedNodes,
+                                                         storeName,
+                                                         pushVersion,
+                                                         extraInfo);
     }
 }

--- a/src/java/voldemort/store/readonly/swapper/InvalidBootstrapURLException.java
+++ b/src/java/voldemort/store/readonly/swapper/InvalidBootstrapURLException.java
@@ -1,0 +1,33 @@
+package voldemort.store.readonly.swapper;
+
+import voldemort.VoldemortException;
+
+/**
+ * This Exception is thrown when a new RO store is attempted to be pushed to a
+ * voldemort cluster without being onboarded formally. Whereas onboarding would
+ * have created the store definition and allocated sufficient disk quota for the
+ * store before BnP starts.
+ * 
+ * @author bsakthee
+ * 
+ */
+
+public class InvalidBootstrapURLException extends VoldemortException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidBootstrapURLException(String message) {
+        super(message);
+    }
+
+    public InvalidBootstrapURLException(String message, Throwable t) {
+        super(message, t);
+    }
+
+    public static InvalidBootstrapURLException wrap(String s, Throwable t) {
+        if(t instanceof InvalidBootstrapURLException) {
+            return new InvalidBootstrapURLException(s, t.getCause());
+        }
+        return new InvalidBootstrapURLException(s, t);
+    }
+}

--- a/src/java/voldemort/utils/ByteUtils.java
+++ b/src/java/voldemort/utils/ByteUtils.java
@@ -60,6 +60,7 @@ public class ByteUtils {
 
     public static final int BYTES_PER_MB = 1048576;
     public static final long BYTES_PER_GB = 1073741824;
+    public static final int BYTES_PER_KB = 1024;
 
     public static MessageDigest getDigest(String algorithm) {
         try {


### PR DESCRIPTION


In this commit I have added a basic disk quota mechanism for Read Only Voldemort, which is described below:

Client side changes:
1. The way checksum for index and data files is serialized to disk is changed in this commit and is similar to ReadOnlyStorageMetadata class. Now each checksum file has two information: 1) checksum and 2) file size (either data file size or index file size).
2. The reducers compute the bytes written to index and data files and finally add this information to the corresponding checksum file mentioned above.
3. After the Map/Reduce job is complete, the azkaban job iterates through each checksum file and constructs a metadata file for each pair that contains checksum of checksums for that pair. This is same as previous implementation. However, in addition to checksum of checksums, the metadata file is also modified to contain the estimated disk size (for both data and index files) for that pair of .
4. AdminStoreSwapper is modified to handle QuotaExceededException when invoking fetch on each node. DisableStoreOnFailedNodeFailedFetchStrategy will return false if there are QuotaExceededException s when trying to check the possibility of swap. In presence of Quota Exceptions all succeeded fetches will be reverted and data gets deleted.

Server side changes;
1. For stores that are part of the QuotaStore, it is assumed that a valid quota is predefined during the on-boarding process. The HDFS fetcher class fetches the estimated disk space needed (in bytes) for a pair from the metadata file. It also gets the quota size (in KB) for the same pair.
2. Quota check is done using the following algorithm:

    Determine if quota needs to be checked for the incoming push. For old stores quota is not checked. They will be quota-ed in future.
    For new stores, check if the store was just created as part of build and push. It is assumed that new store that are on-boarded via some process (or manually) before the BnP starts have predefined quotas. So all stores that are created only during build phase are assumed to be invalid stores (possibly a push to the wrong bootstrap url) and quota is set to 0 as part of store creation to prevent the pushes to take place. If the store was properly on-boarded a non zero quota value would have been set. Check if there is sufficient quota left for a new push.
    If quota exceeds for an incoming push for a pair, the push is failed. QuotaExceededException is thrown and is propagated to the client for handling failed fetches.

