### PR TITLE
Add heart beat for NIO Selector

### DIFF
--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -16,7 +16,15 @@
 
 package voldemort.server;
 
-import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Properties;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+
 import voldemort.client.ClientConfig;
 import voldemort.client.DefaultStoreClient;
 import voldemort.client.TimeoutConfig;
@@ -56,13 +64,7 @@ import voldemort.utils.Time;
 import voldemort.utils.UndefinedPropertyException;
 import voldemort.utils.Utils;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.List;
-import java.util.Properties;
-import java.util.Timer;
-import java.util.TimerTask;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Configuration parameters for the voldemort server.
@@ -191,6 +193,7 @@ public class VoldemortConfig implements Serializable {
     private int nioAdminConnectorSelectors;
     private boolean nioAdminConnectorKeepAlive;
     private int nioAcceptorBacklog;
+    private long nioSelectorMaxHeartBeatTimeMs;
 
     private int clientSelectors;
     private TimeoutConfig clientTimeoutConfig;
@@ -455,6 +458,8 @@ public class VoldemortConfig implements Serializable {
         this.nioAdminConnectorKeepAlive = props.getBoolean("nio.admin.connector.keepalive", false);
         // a value <= 0 forces the default to be used
         this.nioAcceptorBacklog = props.getInt("nio.acceptor.backlog", 256);
+        this.nioSelectorMaxHeartBeatTimeMs = props.getLong("nio.selector.max.heart.beat.time.ms", 
+                                                           TimeUnit.MILLISECONDS.convert(3, TimeUnit.MINUTES));
 
         this.clientSelectors = props.getInt("client.selectors", 4);
         this.clientMaxConnectionsPerNode = props.getInt("client.max.connections.per.node", 50);
@@ -2397,6 +2402,14 @@ public class VoldemortConfig implements Serializable {
 
     public int getNioAcceptorBacklog() {
         return nioAcceptorBacklog;
+    }
+
+    public long getNioSelectorMaxHeartBeatTimeMs() {
+        return nioSelectorMaxHeartBeatTimeMs;
+    }
+
+    public void setNioSelectorMaxHeartBeatTimeMs(long nioSelectorMaxHeartBeatTimeMs) {
+        this.nioSelectorMaxHeartBeatTimeMs = nioSelectorMaxHeartBeatTimeMs;
     }
 
     /**

--- a/src/java/voldemort/server/VoldemortServer.java
+++ b/src/java/voldemort/server/VoldemortServer.java
@@ -249,7 +249,8 @@ public class VoldemortServer extends AbstractService {
                                                                          voldemortConfig.getNioConnectorSelectors(),
                                                                          "nio-socket-server",
                                                                          voldemortConfig.isJmxEnabled(),
-                                                                         voldemortConfig.getNioAcceptorBacklog());
+                                                                         voldemortConfig.getNioAcceptorBacklog(),
+                                                                         voldemortConfig.getNioSelectorMaxHeartBeatTimeMs());
                 onlineServices.add(nioSocketService);
             } else {
                 logger.info("Using BIO Connector.");
@@ -310,7 +311,8 @@ public class VoldemortServer extends AbstractService {
                                                   voldemortConfig.getNioAdminConnectorSelectors(),
                                                   "admin-server",
                                                   voldemortConfig.isJmxEnabled(),
-                                                  voldemortConfig.getNioAcceptorBacklog()));
+                                                  voldemortConfig.getNioAcceptorBacklog(),
+                                                  voldemortConfig.getNioSelectorMaxHeartBeatTimeMs()));
             } else {
                 logger.info("Using BIO Connector for Admin Service.");
                 services.add(new SocketService(adminRequestHandlerFactory,

--- a/src/java/voldemort/server/niosocket/NioSelectorManager.java
+++ b/src/java/voldemort/server/niosocket/NioSelectorManager.java
@@ -25,8 +25,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.log4j.Level;
 
+import voldemort.common.nio.AbstractSelectorManager;
 import voldemort.common.nio.CommBufferSizeStats;
-import voldemort.common.nio.SelectorManager;
 import voldemort.server.protocol.RequestHandlerFactory;
 import voldemort.store.stats.Histogram;
 
@@ -91,7 +91,7 @@ import voldemort.store.stats.Histogram;
  * 
  */
 
-public class NioSelectorManager extends SelectorManager {
+public class NioSelectorManager extends AbstractSelectorManager {
 
     private final InetSocketAddress endpoint;
 
@@ -108,7 +108,9 @@ public class NioSelectorManager extends SelectorManager {
     public NioSelectorManager(InetSocketAddress endpoint,
                               RequestHandlerFactory requestHandlerFactory,
                               int socketBufferSize,
-                              boolean socketKeepAlive) {
+                              boolean socketKeepAlive,
+                              long maxHeartBeatTimeMs) {
+        super(maxHeartBeatTimeMs);
         this.endpoint = endpoint;
         this.socketChannelQueue = new ConcurrentLinkedQueue<SocketChannel>();
         this.requestHandlerFactory = requestHandlerFactory;

--- a/src/java/voldemort/server/niosocket/NioSelectorManagerStats.java
+++ b/src/java/voldemort/server/niosocket/NioSelectorManagerStats.java
@@ -3,7 +3,7 @@ package voldemort.server.niosocket;
 import org.apache.commons.lang.mutable.MutableInt;
 
 import voldemort.common.nio.CommBufferSizeStats;
-import voldemort.common.nio.SelectorManager;
+import voldemort.common.nio.AbstractSelectorManager;
 import voldemort.store.stats.Histogram;
 
 /**
@@ -31,7 +31,7 @@ public class NioSelectorManagerStats {
 
         // Theoretically, the delay can be only upto SELECTOR_POLL_MS.
         // But sometimes wallclock time can be higher
-        this.selectTimeMsHistogram = new Histogram(SelectorManager.SELECTOR_POLL_MS * 2,
+        this.selectTimeMsHistogram = new Histogram(AbstractSelectorManager.SELECTOR_POLL_MS * 2,
                                                    1,
                                                    SELECTOR_STATS_RESET_INTERVAL);
         // Not a scientific limit. Not expecting a server thread to handle more

--- a/src/java/voldemort/server/niosocket/NioSocketService.java
+++ b/src/java/voldemort/server/niosocket/NioSocketService.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
@@ -80,6 +81,9 @@ public class NioSocketService extends AbstractSocketService {
 
     private final Thread acceptorThread;
     private final Logger logger = Logger.getLogger(getClass());
+    
+
+    private final long selectorMaxHeartBeatTimeMs;
 
     public NioSocketService(RequestHandlerFactory requestHandlerFactory,
                             int port,
@@ -88,12 +92,15 @@ public class NioSocketService extends AbstractSocketService {
                             int selectors,
                             String serviceName,
                             boolean enableJmx,
-                            int acceptorBacklog) {
+                            int acceptorBacklog,
+                            long selectorMaxHeartBeatTimeMs) {
+
         super(ServiceType.SOCKET, port, serviceName, enableJmx);
         this.requestHandlerFactory = requestHandlerFactory;
         this.socketBufferSize = socketBufferSize;
         this.socketKeepAlive=socketKeepAlive;
         this.acceptorBacklog = acceptorBacklog;
+        this.selectorMaxHeartBeatTimeMs = selectorMaxHeartBeatTimeMs;
 
         try {
             this.serverSocketChannel = ServerSocketChannel.open();
@@ -128,7 +135,8 @@ public class NioSocketService extends AbstractSocketService {
                 selectorManagers[i] = new NioSelectorManager(endpoint,
                                                              requestHandlerFactory,
                                                              socketBufferSize,
-                                                             socketKeepAlive);
+                                                             socketKeepAlive,
+                                                             selectorMaxHeartBeatTimeMs);
                 selectorManagerThreadPool.execute(selectorManagers[i]);
             }
 
@@ -238,30 +246,50 @@ public class NioSocketService extends AbstractSocketService {
                     break;
                 }
 
+                SocketChannel socketChannel = null;
                 try {
-                    SocketChannel socketChannel = serverSocketChannel.accept();
+                    socketChannel = serverSocketChannel.accept();
 
-                    if(socketChannel == null) {
-                        if(logger.isEnabledFor(Level.WARN))
+                    if (socketChannel == null) {
+                        if (logger.isEnabledFor(Level.WARN))
                             logger.warn("Claimed accept but nothing to select");
 
                         continue;
                     }
 
-                    NioSelectorManager selectorManager = selectorManagers[counter.getAndIncrement()
-                                                                          % selectorManagers.length];
-                    selectorManager.accept(socketChannel);
-                } catch(ClosedByInterruptException e) {
+                    int totalSelectors = selectorManagers.length;
+                    boolean isChannelRegistered = false;
+                    for (int i = 0; i < totalSelectors; i++) {
+                        NioSelectorManager selectorManager = selectorManagers[counter.getAndIncrement() % selectorManagers.length];
+                        if (selectorManager.isHealthy()) {
+                            selectorManager.accept(socketChannel);
+                            isChannelRegistered = true;
+                            break;
+                        }
+                    }
+                    if (isChannelRegistered == false) {
+                        // Channel was not registered with any selector.
+                        logger.error("No healthy selector could be found for channel " + socketChannel + " number of selectors "
+                                + totalSelectors + " closing the socket. ");
+                        IOUtils.closeQuietly(socketChannel);
+                    }
+                } catch (ClosedByInterruptException e) {
+                    if (socketChannel != null) {
+                        IOUtils.closeQuietly(socketChannel);
+                    }
                     // If you're *really* interested...
-                    if(logger.isTraceEnabled())
+                    if (logger.isTraceEnabled())
                         logger.trace("Acceptor thread interrupted, closing");
 
                     break;
-                } catch(Exception e) {
-                    if(logger.isEnabledFor(Level.WARN))
+                } catch (Exception e) {
+                    if (socketChannel != null) {
+                        IOUtils.closeQuietly(socketChannel);
+                    }
+                        if(logger.isEnabledFor(Level.WARN))
                         logger.warn(e.getMessage(), e);
+                    }
                 }
-            }
 
             if(logger.isInfoEnabled())
                 logger.info("Server has stopped listening for connections on port " + port);

--- a/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutorFactory.java
+++ b/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutorFactory.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
-import voldemort.common.nio.SelectorManager;
+import voldemort.common.nio.AbstractSelectorManager;
 import voldemort.store.StoreTimeoutException;
 import voldemort.store.UnreachableStoreException;
 import voldemort.store.nonblockingstore.NonblockingStoreCallback;
@@ -344,7 +344,11 @@ public class ClientRequestExecutorFactory implements
         }
     }
 
-    private class ClientRequestSelectorManager extends SelectorManager {
+    private class ClientRequestSelectorManager extends AbstractSelectorManager {
+
+        public ClientRequestSelectorManager() {
+            super(TimeUnit.MILLISECONDS.convert(3, TimeUnit.MINUTES));
+        }
 
         private final Queue<ClientRequestExecutor> registrationQueue = new ConcurrentLinkedQueue<ClientRequestExecutor>();
 

--- a/test/unit/voldemort/server/socket/NioSelectorManagerTest.java
+++ b/test/unit/voldemort/server/socket/NioSelectorManagerTest.java
@@ -1,0 +1,160 @@
+package voldemort.server.socket;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import voldemort.ServerTestUtils;
+import voldemort.client.protocol.RequestFormatFactory;
+import voldemort.client.protocol.RequestFormatType;
+import voldemort.server.AbstractSocketService;
+import voldemort.server.RequestRoutingType;
+import voldemort.server.StoreRepository;
+import voldemort.server.protocol.RequestHandlerFactory;
+import voldemort.store.SleepyStore;
+import voldemort.store.Store;
+import voldemort.store.UnreachableStoreException;
+import voldemort.store.memory.InMemoryStorageEngine;
+import voldemort.store.nonblockingstore.NonblockingStoreCallback;
+import voldemort.store.socket.SocketDestination;
+import voldemort.store.socket.clientrequest.ClientRequestExecutor;
+import voldemort.store.socket.clientrequest.ClientRequestExecutorPool;
+import voldemort.store.socket.clientrequest.GetClientRequest;
+import voldemort.utils.ByteArray;
+
+
+@RunWith(Parameterized.class)
+public class NioSelectorManagerTest {
+
+    private int port;
+    private ClientRequestExecutorPool pool;
+    private AbstractSocketService socketService;
+    private RequestHandlerFactory factory;
+    private SocketDestination dest1;
+    private SleepyStore<ByteArray, byte[], byte[]> sleepyStore;
+
+    private final static String STORE_NAME = "test";
+
+    // This can be never below the selector poll time of 500 ms.
+    private final long MAX_HEART_BEAT_MS = 600;
+    private final int numSelectors;
+
+    public NioSelectorManagerTest(int numSelectors) {
+        this.numSelectors = numSelectors;
+    }
+
+    @Parameters
+    public static Collection<Object[]> configs() {
+        return Arrays.asList(new Object[][] { { 1 }, { 2 } });
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        this.port = ServerTestUtils.findFreePort();
+
+        StoreRepository repository = new StoreRepository();
+        sleepyStore = new SleepyStore<ByteArray, byte[], byte[]>(Long.MAX_VALUE, new InMemoryStorageEngine<ByteArray, byte[], byte[]>(STORE_NAME));
+        repository.addLocalStore(sleepyStore);
+        repository.addRoutedStore(sleepyStore);
+        this.pool = new ClientRequestExecutorPool(50, 300, 250, 32 * 1024);
+        this.dest1 = new SocketDestination("localhost", port, RequestFormatType.VOLDEMORT_V1);
+
+        final Store<ByteArray, byte[], byte[]> socketStore = pool.create(STORE_NAME, "localhost", port, RequestFormatType.VOLDEMORT_V1, RequestRoutingType.NORMAL);
+        factory = ServerTestUtils.getSocketRequestHandlerFactory(repository);
+        socketService = ServerTestUtils.getSocketService(true, factory, port, numSelectors, 10, 1000, MAX_HEART_BEAT_MS);
+        socketService.start();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        this.pool.close();
+        this.socketService.stop();
+    }
+
+    private GetClientRequest getClientRequest() {
+        GetClientRequest clientRequest =
+                new GetClientRequest(STORE_NAME,
+                                     new RequestFormatFactory().getRequestFormat(dest1.getRequestFormatType()),
+                                     RequestRoutingType.ROUTED,
+                                     new ByteArray(new byte[] { 1, 2, 3 }),
+                                     null);
+
+        return clientRequest;
+    }
+
+    private NonblockingStoreCallback getCallBack() {
+        final AtomicInteger cancelledEvents = new AtomicInteger(0);
+
+        NonblockingStoreCallback callback = new NonblockingStoreCallback() {
+
+            @Override
+            public void requestComplete(Object result, long requestTime) {
+                if (result instanceof UnreachableStoreException)
+                    cancelledEvents.incrementAndGet();
+                else
+                    fail("The request must have failed with UnreachableException" + result);
+            }
+        };
+        return callback;
+    }
+
+    @Test
+    public void testSelectorHeartBeat() throws Exception {
+        // Open a request so that Sleepy store hangs.
+        pool.submitAsync(dest1, getClientRequest(), getCallBack(), 250, "get");
+
+        // wait for MAX heart beat + some more time so that the selector
+        // threads should be marked dead
+        Thread.sleep(MAX_HEART_BEAT_MS + 50);
+
+        // submitAsync creates two connections if no connection is available when 
+        // the request is submitted. First when trying to get a connection for the
+        // request, if not it calls proceesLoop which creates one more.
+        try {
+            pool.checkout(dest1);
+        } catch (Exception ex) {
+
+        }
+
+        // If the server is started with single selector, all the requests to the server should
+        // fail with IOException as the Server should close the connection because of not
+        // receiving the heart beats
+
+        // If the server is started with more than one selector, the requests should succeed
+        // and should not be assigned to the hung selector.
+
+        // Note that, this is just checking out a connection and not doing any operation on it
+        // If an operation is attempted, the operation will time out as the store being used
+        // here sleeps for infinite time
+        for (int i = 0; i < 20; i++) {
+            try {
+                ClientRequestExecutor executor = pool.checkout(dest1);
+                if (numSelectors == 1) {
+                    fail("Single selector expected an exception");
+                } else {
+                    assertNotNull("multiple selector should have valid executor", executor);
+                }
+            } catch (UnreachableStoreException ex) {
+                if (numSelectors > 1) {
+                    fail("more than one selector, no exception should be observed" + ex);
+                } else {
+                    assertTrue("inner exception should be instance of IOException", ex.getCause() instanceof IOException);
+                }
+            }
+        }
+
+        sleepyStore.releaseThreads();
+    }
+}


### PR DESCRIPTION
On Voldemort Server, when there is a disk crash the selector
gets hung. Acceptor still keeps on accepting sockets and
after a while the file descriptor limit is reached
and everything is in a hung state. No JVM stack or heap dump.

Now a selector heart beat is added and if the selector is past the
max heart beat time ( defaults to 3 minutes) the acceptor will
stop assigning connections to this selector. If all selectors
are unhealthy ( past max heart beat time) acceptor will close
the socket so that client can recover from these errors faster.