### PR TITLE
Implement the truncate function in the RocksDB storage engine. This f…

### DIFF
--- a/src/java/voldemort/store/rocksdb/PartitionPrefixedRocksDbStorageEngine.java
+++ b/src/java/voldemort/store/rocksdb/PartitionPrefixedRocksDbStorageEngine.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksIterator;
 
@@ -23,21 +25,23 @@ public class PartitionPrefixedRocksDbStorageEngine extends RocksDbStorageEngine 
 
     public PartitionPrefixedRocksDbStorageEngine(String storeName,
                                                  RocksDB rdbStore,
+                                                 ColumnFamilyHandle storeHandle,
+                                                 ColumnFamilyOptions storeOptions,
                                                  int lockStripes,
                                                  RoutingStrategy routingStrategy,
                                                  boolean enableReadLocks) {
-        super(storeName, rdbStore, lockStripes, enableReadLocks);
+        super(storeName, rdbStore, storeHandle, storeOptions, lockStripes, enableReadLocks);
         this.routingStrategy = routingStrategy;
     }
 
     @Override
     public ClosableIterator<Pair<ByteArray, Versioned<byte[]>>> entries(int partition) {
-        return new RocksdbEntriesIterator(this.getRocksDB().newIterator(), partition);
+        return new RocksdbEntriesIterator(getRocksDbIterator(), partition);
     }
 
     @Override
     public ClosableIterator<ByteArray> keys(int partition) {
-        return new RocksdbKeysIterator(this.getRocksDB().newIterator(), partition);
+        return new RocksdbKeysIterator(getRocksDbIterator(), partition);
     }
 
     private ByteArray validateAndConstructKey(ByteArray key) {

--- a/test/unit/voldemort/store/AbstractStorageEngineTest.java
+++ b/test/unit/voldemort/store/AbstractStorageEngineTest.java
@@ -153,6 +153,11 @@ public abstract class AbstractStorageEngineTest extends AbstractByteArrayStoreTe
                 it.close();
             }
         }
+
+        // Verify that the store is still useable after the truncate.
+        assertEquals(0, engine.get(key1, null).size());
+        engine.put(key1, v1, null);
+        assertEquals(1, engine.get(key1, null).size());
     }
 
     @Test

--- a/test/unit/voldemort/store/rocksdb/RocksdbStorageEngineTest.java
+++ b/test/unit/voldemort/store/rocksdb/RocksdbStorageEngineTest.java
@@ -9,7 +9,6 @@ import java.util.Random;
 import org.apache.commons.io.FileDeleteStrategy;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -76,16 +75,4 @@ public class RocksdbStorageEngineTest extends AbstractStorageEngineTest {
             FileDeleteStrategy.FORCE.delete(datadir);
         }
     }
-
-    // The functionalities below are not ready yet:
-
-    @Ignore
-    @Override
-    public void testTruncate() throws Exception {}
-
-    @Override
-    public void testKeyIterationWithSerialization() {}
-
-    @Override
-    public void testIterationWithSerialization() {}
 }


### PR DESCRIPTION
…unctionality is required by

the delete store command.  It is implemented using a non default Column Family named after the store.
This approach could be extended to allow multiple stores to be supported by a single RocksDB
database. It is, however, not backwards compatible with the existing code. A data migration
would be required to support existing stores.