### PR TITLE
Protection against data corruption.

### DIFF
--- a/src/java/voldemort/common/nio/SelectorManagerWorker.java
+++ b/src/java/voldemort/common/nio/SelectorManagerWorker.java
@@ -125,9 +125,7 @@ public abstract class SelectorManagerWorker implements Runnable {
                         + e.getMessage());
             close();
         } catch(Throwable t) {
-            if(logger.isEnabledFor(Level.ERROR))
-                logger.error(t.getMessage(), t);
-
+            logger.error("Caught throwable from " + socketChannel.socket(), t);
             close();
         }
     }

--- a/src/java/voldemort/server/protocol/vold/VoldemortNativeRequestHandler.java
+++ b/src/java/voldemort/server/protocol/vold/VoldemortNativeRequestHandler.java
@@ -105,7 +105,7 @@ public class VoldemortNativeRequestHandler extends AbstractRequestHandler implem
         try {
             requestHandler.parseRequest(inputStream);
             requestHandler.processRequest();
-        } catch ( VoldemortException e) {
+        } catch (VoldemortException e) {
             // Put generates lot of ObsoleteVersionExceptions, suppress them
             // they are harmless and indicates normal mode of operation.
             if(!(e instanceof ObsoleteVersionException)) {

--- a/src/java/voldemort/store/readonly/ReadOnlyStorageConfiguration.java
+++ b/src/java/voldemort/store/readonly/ReadOnlyStorageConfiguration.java
@@ -46,6 +46,7 @@ public class ReadOnlyStorageConfiguration implements StorageConfiguration {
     private final int nodeId;
     private RoutingStrategy routingStrategy = null;
     private final int deleteBackupMs;
+    private final int maxValueBufferAllocationSize;
     private final VoldemortConfig voldConfig;
 
     public ReadOnlyStorageConfiguration(VoldemortConfig config) {
@@ -56,6 +57,7 @@ public class ReadOnlyStorageConfiguration implements StorageConfiguration {
                                                                                                    .trim()));
         this.nodeId = config.getNodeId();
         this.deleteBackupMs = config.getReadOnlyDeleteBackupMs();
+        this.maxValueBufferAllocationSize = config.getReadOnlyMaxValueBufferAllocationSize();
         this.voldConfig = config;
     }
 
@@ -79,7 +81,8 @@ public class ReadOnlyStorageConfiguration implements StorageConfiguration {
                                                                 new File(storageDir,
                                                                          storeDef.getName()),
                                                                 numBackups,
-                                                                deleteBackupMs);
+                                                                deleteBackupMs,
+                                                                maxValueBufferAllocationSize);
         ObjectName objName = JmxUtils.createObjectName(JmxUtils.getPackageName(store.getClass()),
                                                        storeDef.getName() );
         JmxUtils.registerMbean(ManagementFactory.getPlatformMBeanServer(),


### PR DESCRIPTION
If index or data files are somehow corrupted, or mismatched (meaning
that the index file from one store/version gets used in combination
with a data file for another store/version), then the server gets into
bad buffer allocation problems, causing IllegalArgumentExceptions and
potentially OOMing in the process. This commit makes it easier to
debug the issues and protect against the OOMs. Changes include:

- Disallow allocation of negative size buffers.
- Disallow allocation of excessively large value buffers (configurable,
  max 25 MB by default).
- Disallow allocation of a buffer which would go past the data file's
  length.
- Server-side logs now print out the file name and key (in hex) which
  triggered the problem.
- Server-side logs now print out the socket name and stacktrace when
  SelectorManagerWorker catches a Throwable.
- Client-side will report an "internal server error" when any of the
  bad allocation scenarios described above happen.
- Slight optimization in the allocation strategy while reading the
  key/values in a data file.