### PR TITLE
Removed the set quota admin op from BnP.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -641,22 +641,9 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
         }
         try {
             adminClientPerCluster.get(url).storeMgmtOps.addStore(newStoreDef, nodeIDs);
-
-            // only if there are nodes that need the store definition to be
-            // created we set quota to 0 in all nodes.
-            if(!nodeIDs.isEmpty()) {
-                // set Zero Quota for new stores that are created as part of
-                // build
-                Long quotaValue = 0L;
-                log.info("New incoming push for Store: " + storeName
-                         + " .Setting quota for this new store to 0.");
-                adminClientPerCluster.get(url).quotaMgmtOps.setQuota(storeName,
-                                                                     QuotaType.STORAGE_SPACE.toString(),
-                                                                     quotaValue.toString());
-            }
         }
         catch(VoldemortException ve) {
-            throw new RuntimeException("Exception while adding store to nodes in cluster URL" + url, ve);
+            throw new RuntimeException("Exception while adding store to nodes in cluster URL: " + url, ve);
         }
     }
 


### PR DESCRIPTION
The default quota for new stores is now controlled by a server-side config, so this is redundant (and harmful to users who do not wish to use quotas in this manner).

@bhasudha, can you review this, since you know most about disk quotas? I thought this is the way we intended the quotas to work, but just in case there might be side-effects I'm not thinking of... Thanks (: