### PR TITLE
This change avoids needlessly recreating symlinks.

### DIFF
--- a/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
+++ b/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
@@ -202,11 +202,8 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
             }
             Utils.mkdirs(versionDir);
 
-            // Create symbolic link
-            logger.info("Creating symbolic link for '" + getName() + "' using directory "
-                        + versionDir.getAbsolutePath());
-            Utils.symlink(versionDir.getAbsolutePath(), storeDir.getAbsolutePath() + File.separator
-                    + "latest");
+            // Validate symbolic link, and create it if it doesn't already exist
+            Utils.symlink(versionDir.getAbsolutePath(), storeDir.getAbsolutePath() + File.separator + "latest");
             this.fileSet = new ChunkedFileSet(versionDir, routingStrategy, nodeId, maxValueBufferAllocationSize);
             storeVersionManager.syncInternalStateFromFileSystem();
             this.lastSwapped = System.currentTimeMillis();

--- a/src/java/voldemort/utils/Utils.java
+++ b/src/java/voldemort/utils/Utils.java
@@ -182,7 +182,8 @@ public class Utils {
         Posix posix = (Posix) Native.loadLibrary("c", Posix.class);
         int returnCode = posix.symlink(filePath, symLinkPath);
         if (returnCode < 0)
-            throw new VoldemortException("Unable to create symbolic link for " + filePath);
+            throw new VoldemortException("Unable to create symbolic link for " + filePath +
+                                         " (received return code " + returnCode + ")");
 
         logger.info("Symlink '" + symLink.getParentFile().getName() + "/" + symLink.getName() +
                     "' pointing to '" + file.getName() + "' has been created.");

--- a/src/java/voldemort/utils/Utils.java
+++ b/src/java/voldemort/utils/Utils.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.apache.log4j.Logger;
 import voldemort.VoldemortException;
 import voldemort.cluster.Node;
 
@@ -46,6 +47,8 @@ import com.sun.jna.Native;
  * 
  */
 public class Utils {
+
+    private static final Logger logger = Logger.getLogger(Utils.class);
 
     public static final String NEWLINE = System.getProperty("line.separator");
 
@@ -165,6 +168,8 @@ public class Utils {
             try {
                 if (symLink.getCanonicalFile().equals(file.getCanonicalFile())) {
                     // No need to do anything else, the symlink already points to the right destination
+                    logger.info("Symlink '" + symLink.getParentFile().getName() + "/" + symLink.getName() +
+                                "' pointing to '" + file.getName() + "' already exists. Leaving it as is.");
                     return;
                 }
             } catch (IOException e) {
@@ -178,6 +183,9 @@ public class Utils {
         int returnCode = posix.symlink(filePath, symLinkPath);
         if (returnCode < 0)
             throw new VoldemortException("Unable to create symbolic link for " + filePath);
+
+        logger.info("Symlink '" + symLink.getParentFile().getName() + "/" + symLink.getName() +
+                    "' pointing to '" + file.getName() + "' has been created.");
     }
 
     public interface Posix extends Library {


### PR DESCRIPTION
There are cases (i.e.: emergency situations) where we may want to chmod -w a data directory and recreating the symlinks systematically then prevents the server from being able to start up. This change inspects the symlink which is already present and avoids recreating it if it's already pointing at the right destination.