### PR TITLE
Client do not remove dead connections

### DIFF
--- a/src/java/voldemort/common/nio/AbstractSelectorManager.java
+++ b/src/java/voldemort/common/nio/AbstractSelectorManager.java
@@ -16,6 +16,7 @@
 
 package voldemort.common.nio;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.SelectionKey;
@@ -23,6 +24,7 @@ import java.nio.channels.Selector;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
@@ -150,6 +152,11 @@ public abstract class AbstractSelectorManager implements Runnable {
                         logger.trace("Closing SelectionKey's channel");
 
                     sk.channel().close();
+
+                    Object attachment = sk.attachment();
+                    if(attachment instanceof Closeable) {
+                        IOUtils.closeQuietly((Closeable) attachment);
+                    }
                 } catch(Exception e) {
                     if(logger.isEnabledFor(Level.WARN))
                         logger.warn(e.getMessage(), e);

--- a/src/java/voldemort/common/nio/SelectorManagerWorker.java
+++ b/src/java/voldemort/common/nio/SelectorManagerWorker.java
@@ -117,12 +117,14 @@ public abstract class SelectorManagerWorker implements Runnable {
         } catch(CancelledKeyException e) {
             close();
         } catch(EOFException e) {
+            // EOFException is expected, hence no logging, otherwise this block
+            // could be combined with IOException
             reportException(e);
             close();
         } catch(IOException e) {
-            reportException(e);
             logger.info("Connection reset from " + socketChannel.socket() + " with message - "
                         + e.getMessage());
+            reportException(e);
             close();
         } catch(Throwable t) {
             logger.error("Caught throwable from " + socketChannel.socket(), t);

--- a/src/java/voldemort/utils/pool/QueuedKeyedResourcePool.java
+++ b/src/java/voldemort/utils/pool/QueuedKeyedResourcePool.java
@@ -130,7 +130,6 @@ public class QueuedKeyedResourcePool<K, V> extends KeyedResourcePool<K, V> {
      */
     public V internalNonBlockingGet(K key) throws Exception {
         Pool<V> resourcePool = getResourcePoolForKey(key);
-        V resource = null;
         return attemptNonBlockingCheckout(key, resourcePool);
     }
 


### PR DESCRIPTION
Added more tests, this is ready to be merged in.

When Server grace fully closes a connection, client ignores the
connection close. After this an operation that gets this connection
fails with EOFException as read/write returns -1 which causes the
operation to fail. Mostly this is fine as the backup operation generaly
succeeds, but when a cluster is bounced due to upgrade or other reasons,
and if a client ends up caching all dead connections, it causes the
operation to fail.

After a client operation is done, previously the socket is registered
with the selector for no-intention. For the next operation we start with
write.

With this change, the socket will be left in read mode. So FIN packet
from the server will be processed and the socket will be closed. Any
connection checkout from the pool needs to validate the connection.
There is a race condition as the returned connection from the cache
could still be killed later, that is handled as well.

AysncRequestHandler close is called so the stream resources are freed.

Test is added to verify this situation.