### PR TITLE
Output Checksum to Stats File

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/BasicFetchStrategy.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/BasicFetchStrategy.java
@@ -1,12 +1,5 @@
 package voldemort.store.readonly.fetcher;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.log4j.Logger;
-import voldemort.server.protocol.admin.AsyncOperationStatus;
-import voldemort.store.readonly.checksum.CheckSum;
-import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
-
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -17,6 +10,14 @@ import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.log4j.Logger;
+
+import voldemort.server.protocol.admin.AsyncOperationStatus;
+import voldemort.store.readonly.checksum.CheckSum;
+import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
 
 
 public class BasicFetchStrategy implements FetchStrategy {
@@ -159,11 +160,12 @@ public class BasicFetchStrategy implements FetchStrategy {
                     }
                 }
                 stats.reportFileDownloaded(dest,
-                        startTimeMS,
-                        source.getSize(),
-                        System.currentTimeMillis() - startTimeMS,
-                        attempt,
-                        totalBytesRead);
+                                           startTimeMS,
+                                           source.getSize(),
+                                           System.currentTimeMillis() - startTimeMS,
+                                           attempt,
+                                           totalBytesRead,
+                                           fileCheckSumGenerator);
                 logger.info("Completed copy of " + source + " to " + dest);
                 success = true;
             } catch (IOException e) {

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsCopyStats.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsCopyStats.java
@@ -14,6 +14,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
 import voldemort.annotations.jmx.JmxGetter;
+import voldemort.store.readonly.checksum.CheckSum;
+import voldemort.utils.ByteUtils;
 import voldemort.utils.Time;
 
 /**
@@ -30,6 +32,7 @@ public class HdfsCopyStats {
     private volatile long lastReportNs;
     private final HdfsPathInfo pathInfo;
 
+    private File statsFile;
     private BufferedWriter statsFileWriter = null;
     public static final String STATS_DIRECTORY = ".stats";
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
@@ -77,6 +80,11 @@ public class HdfsCopyStats {
         return new File(destParent, STATS_DIRECTORY);
     }
 
+    public File getStatsFile() {
+        return this.statsFile;
+    }
+
+    private static final int STATS_VERSION = 3;
     private void initializeStatsFile(File destination,
                                      boolean enableStatsFile,
                                      int maxVersionsStatsFile,
@@ -107,15 +115,20 @@ public class HdfsCopyStats {
 
             deleteExtraStatsFiles(statsDirectory, maxVersionsStatsFile);
 
-            String destName = destination.getName();
-            File statsFile = new File(statsDirectory, destName);
+            String destName = destination.getName() + ".stats-v" + STATS_VERSION;
+            this.statsFile = new File(statsDirectory, destName);
             statsFile.createNewFile();
 
-            statsFileWriter = new BufferedWriter(new FileWriter(statsFile));
+            statsFileWriter = new BufferedWriter(new FileWriter(statsFile, true));
             statsFileWriter.write("Starting fetch at " + startTimeMS + "MS from " + sourceFile
                                   + " . Info: " + pathInfo);
             statsFileWriter.newLine();
-            statsFileWriter.write("Time, FileName, StartTime(MS), Size, TimeTaken(MS), Attempts #, TotalBytesTransferred, TotalBytesWritten");
+            /*
+             * When you add or remove columns, increase the version number
+             * STATS_VERSION so that script might be able to make automatic
+             * parsing of the columns
+             */
+            statsFileWriter.write("Time, FileName, StartTime(MS), Size, TimeTaken(MS), Attempts #, TotalBytesTransferred, TotalBytesWritten, CheckSum");
             statsFileWriter.newLine();
             statsFileWriter.flush();
 
@@ -203,9 +216,17 @@ public class HdfsCopyStats {
                                      long fileSize,
                                      long timeTakenMS,
                                      int attempts,
-                                     long totalBytesWritten) {
+                                     long totalBytesWritten,
+                                     CheckSum checkSum) {
+        String fileCheckSum;
+        if(checkSum != null) {
+            fileCheckSum = ByteUtils.toHexString(checkSum.getCheckSum());
+        } else {
+            fileCheckSum = "NO_CHECKSUM";
+        }
         reportStats(file.getName() + "," + startTimeMS + "," + fileSize + "," + timeTakenMS + ","
-                + attempts + "," + totalBytesTransferred + "," + totalBytesWritten);
+                    + attempts + "," + totalBytesTransferred + "," + totalBytesWritten + ","
+                    + fileCheckSum);
     }
 
     public void complete() {

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsCopyStatsTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsCopyStatsTest.java
@@ -52,7 +52,6 @@ public class HdfsCopyStatsTest {
         for(int i = 0; i < maxStatsFile + 2; i++) {
             destination = new File(testSourceDir.getAbsolutePath() + "_dest" + i);
             String destName = destination.getName();
-            expectedStatsFile.add(destName);
             // Sleep to get last modified time stamp different for all files
             // linux timestamp has second granularity, so sleep for a second
             Thread.sleep(1000);
@@ -63,6 +62,10 @@ public class HdfsCopyStatsTest {
                                                     isFileCopy,
                                                     HdfsPathInfo.getTestObject(1000));
 
+            if(stats.getStatsFile() != null) {
+                expectedStatsFile.add(stats.getStatsFile().getName());
+            }
+
             Random r = new Random();
             for(int j = 0; j < 10; j++) {
                 File file = new File(destination, "file" + i);
@@ -71,7 +74,8 @@ public class HdfsCopyStatsTest {
                                            r.nextInt(),
                                            r.nextLong(),
                                            r.nextInt(),
-                                           r.nextLong());
+                                           r.nextLong(),
+                                           null);
 
             }
             Exception e = r.nextBoolean() ? null : new Exception();


### PR DESCRIPTION
1) Output Checksum to stats file, can be used for individual file
validation
2) Open the stats file in append only mode, so when a version is pushed
deleted and re-pushed we have some history in the stats file.