### PR TITLE
CopyStats Regression

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/FetchStrategy.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/FetchStrategy.java
@@ -1,15 +1,14 @@
 package voldemort.store.readonly.fetcher;
 
-import voldemort.store.readonly.checksum.CheckSum;
-import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+
+import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
 
 
 public interface FetchStrategy {
     public Map<HdfsFile, byte[]> fetch(HdfsDirectory directory, File dest) throws IOException;
 
-    public CheckSum fetch(HdfsFile file, File dest, CheckSumType checkSumType) throws IOException;
+    public byte[] fetch(HdfsFile file, File dest, CheckSumType checkSumType) throws IOException;
 }

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsCopyStats.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsCopyStats.java
@@ -14,7 +14,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
 import voldemort.annotations.jmx.JmxGetter;
-import voldemort.store.readonly.checksum.CheckSum;
 import voldemort.utils.ByteUtils;
 import voldemort.utils.Time;
 
@@ -217,10 +216,10 @@ public class HdfsCopyStats {
                                      long timeTakenMS,
                                      int attempts,
                                      long totalBytesWritten,
-                                     CheckSum checkSum) {
+                                     byte[] checkSum) {
         String fileCheckSum;
         if(checkSum != null) {
-            fileCheckSum = ByteUtils.toHexString(checkSum.getCheckSum());
+            fileCheckSum = ByteUtils.toHexString(checkSum);
         } else {
             fileCheckSum = "NO_CHECKSUM";
         }

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherAdvancedTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherAdvancedTest.java
@@ -93,7 +93,7 @@ public class HdfsFetcherAdvancedTest {
         this.enableStatsFile = enableStatsFile;
     }
 
-    protected CheckSum copyFileWithCheckSumTest(HdfsFetcher fetcher,
+    protected byte[] copyFileWithCheckSumTest(HdfsFetcher fetcher,
                                                 FileSystem fs,
                                                 Path source,
                                                 File dest,
@@ -556,8 +556,14 @@ public class HdfsFetcherAdvancedTest {
                .doAnswer(Mockito.CALLS_REAL_METHODS)
                .when(spyfs)
                .open(source);
-        CheckSum ckSum = copyFileWithCheckSumTest(fetcher, spyfs, source, copyLocation, stats, CheckSumType.MD5, buffer);
-        assertEquals(Arrays.equals(ckSum.getCheckSum(), checksumCalculated), true);
+        byte[] actualCheckSum = copyFileWithCheckSumTest(fetcher,
+                                                         spyfs,
+                                                         source,
+                                                         copyLocation,
+                                                         stats,
+                                                         CheckSumType.MD5,
+                                                         buffer);
+        assertEquals(Arrays.equals(actualCheckSum, checksumCalculated), true);
     }
 
     /*
@@ -580,9 +586,15 @@ public class HdfsFetcherAdvancedTest {
                .read();
         Mockito.doReturn(spyinput).doReturn(input).when(spyfs).open(source);
 
-        CheckSum ckSum = null;
+        byte[] actualCheckSum = null;
         try {
-            ckSum = copyFileWithCheckSumTest(fetcher, spyfs, source, copyLocation, stats, CheckSumType.MD5, buffer);
+            actualCheckSum = copyFileWithCheckSumTest(fetcher,
+                                                      spyfs,
+                                                      source,
+                                                      copyLocation,
+                                                      stats,
+                                                      CheckSumType.MD5,
+                                                      buffer);
         } catch(Exception ex) {
             if(isCompressed) {
                 // This is expected
@@ -591,7 +603,7 @@ public class HdfsFetcherAdvancedTest {
                 Assert.fail("Unexpected exption thrown : " + ex.getMessage());
             }
         }
-        assertEquals(Arrays.equals(ckSum.getCheckSum(), checksumCalculated), true);
+        assertEquals(Arrays.equals(actualCheckSum, checksumCalculated), true);
     }
 
     /*
@@ -609,8 +621,14 @@ public class HdfsFetcherAdvancedTest {
                .doAnswer(Mockito.CALLS_REAL_METHODS)
                .when(spyfs)
                .open(source);
-        CheckSum ckSum = copyFileWithCheckSumTest(fetcher, spyfs, source, copyLocation, stats, CheckSumType.MD5, buffer);
-        assertEquals(Arrays.equals(ckSum.getCheckSum(), checksumCalculated), true);
+        byte[] actualCheckSum = copyFileWithCheckSumTest(fetcher,
+                                                         spyfs,
+                                                         source,
+                                                         copyLocation,
+                                                         stats,
+                                                         CheckSumType.MD5,
+                                                         buffer);
+        assertEquals(Arrays.equals(actualCheckSum, checksumCalculated), true);
     }
 
     /*


### PR DESCRIPTION
MessageDigest.digest() is read once, after it is read
the contents of the digest are reset.

Without knowing this, now started outputting checksum to stats file
which broke the normal flow.

Passing Around MessageDigest is dangerous because of this, so modified
the method to return byte arrays which are then passed around.