### PR TITLE
Forklift tool schema comparison

### DIFF
--- a/src/java/voldemort/serialization/avro/AvroGenericSerializer.java
+++ b/src/java/voldemort/serialization/avro/AvroGenericSerializer.java
@@ -75,4 +75,30 @@ public class AvroGenericSerializer implements Serializer<Object> {
             throw new SerializationException(e);
         }
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((typeDef == null) ? 0 : typeDef.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(this == obj)
+            return true;
+        if(obj == null)
+            return false;
+        if(getClass() != obj.getClass())
+            return false;
+        AvroGenericSerializer other = (AvroGenericSerializer) obj;
+        if(typeDef == null) {
+            if(other.typeDef != null)
+                return false;
+        } else if(!typeDef.equals(other.typeDef))
+            return false;
+        return true;
+    }
+
 }

--- a/src/java/voldemort/serialization/avro/versioned/AvroVersionedGenericSerializer.java
+++ b/src/java/voldemort/serialization/avro/versioned/AvroVersionedGenericSerializer.java
@@ -167,6 +167,55 @@ public class AvroVersionedGenericSerializer implements Serializer<Object> {
         } catch(IOException e) {
             throw new SerializationException(e);
         }
-
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((newestVersion == null) ? 0 : newestVersion.hashCode());
+        for(Map.Entry<Integer, String> versionedSchema: typeDefVersions.entrySet()) {
+            Schema schema = Schema.parse(versionedSchema.getValue());
+            result = (prime * result) + schema.hashCode();
+        }
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(this == obj)
+            return true;
+        if(obj == null)
+            return false;
+        if(getClass() != obj.getClass())
+            return false;
+        AvroVersionedGenericSerializer other = (AvroVersionedGenericSerializer) obj;
+        if(newestVersion == null) {
+            if(other.newestVersion != null)
+                return false;
+        } else if(!newestVersion.equals(other.newestVersion))
+            return false;
+
+        if(typeDefVersions == null) {
+            if(other.typeDefVersions != null)
+                return false;
+        } else if(typeDefVersions.size() != other.typeDefVersions.size()) {
+            return false;
+        } else {
+            for(Map.Entry<Integer, String> versionedSchema: typeDefVersions.entrySet()) {
+                Schema schema = Schema.parse(versionedSchema.getValue());
+                String otherTypeDef = other.typeDefVersions.get(versionedSchema.getKey());
+                if(otherTypeDef == null) {
+                    // Other schema is not present
+                    return false;
+                }
+                Schema otherSchema = Schema.parse(otherTypeDef);
+                if(!schema.equals(otherSchema)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
 }

--- a/src/java/voldemort/serialization/json/JsonTypeSerializer.java
+++ b/src/java/voldemort/serialization/json/JsonTypeSerializer.java
@@ -571,4 +571,32 @@ public class JsonTypeSerializer implements Serializer<Object> {
             return size;
         }
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (hasVersion ? 1231 : 1237);
+        result = prime * result + ((typeDefVersions == null) ? 0 : typeDefVersions.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(this == obj)
+            return true;
+        if(obj == null)
+            return false;
+        if(getClass() != obj.getClass())
+            return false;
+        JsonTypeSerializer other = (JsonTypeSerializer) obj;
+        if(hasVersion != other.hasVersion)
+            return false;
+        if(typeDefVersions == null) {
+            if(other.typeDefVersions != null)
+                return false;
+        } else if(!typeDefVersions.equals(other.typeDefVersions))
+            return false;
+        return true;
+    }
 }

--- a/test/common/voldemort/config/DST-two-stores-replicated.xml
+++ b/test/common/voldemort/config/DST-two-stores-replicated.xml
@@ -124,7 +124,7 @@
     </key-serializer>
     <value-serializer>
       <type>json</type>
-      <schema-info>string</schema-info>
+      <schema-info>"string"</schema-info>
     </value-serializer>
   </store> 
   <store>

--- a/test/common/voldemort/config/SRC-two-stores-replicated.xml
+++ b/test/common/voldemort/config/SRC-two-stores-replicated.xml
@@ -120,7 +120,7 @@
     </key-serializer>
     <value-serializer>
       <type>json</type>
-      <schema-info>[string]</schema-info>
+      <schema-info>["string"]</schema-info>
     </value-serializer>
   </store>
   <store>

--- a/test/unit/voldemort/utils/ClusterForkLiftToolTest.java
+++ b/test/unit/voldemort/utils/ClusterForkLiftToolTest.java
@@ -455,6 +455,8 @@ public class ClusterForkLiftToolTest {
                 fail("Incompatible types should have failed");
             } catch(VoldemortApplicationException e) {
 
+            } catch(Exception e) {
+                throw new RuntimeException(" Got wrong type exception for store " + store, e);
             }
 
             ClusterForkLiftTool forkLiftTool = new ClusterForkLiftTool(srcBootStrapUrl,


### PR DESCRIPTION
1) ignore-schema-check was handled but not exposed as a parameter.
Seems like joptSimpleParser will error out, if the parameters are not
set up correctly.

2) Serializers are compared using string which resulted in lot more
error. Using the Schema comparison based on Avro and JSON now. Most of
the code here is auto generated (except for AVroGenericVersioned) where
I modified some code by hand.

3) Fixed invalid stores xml.