### PR TITLE
voldemort-shell support for properties file overrides

### DIFF
--- a/bin/voldemort-shell.bat
+++ b/bin/voldemort-shell.bat
@@ -17,17 +17,10 @@ REM limitations under the License.
 REM
 REM ** This Windows BAT file is not tested with each Voldemort release. **
 
-set argC=0
-for %%a in (%*) do set /a argC+=1
-if %argC% geq 2 goto :continue
-echo "USAGE: bin/voldemort-shell.bat store_name bootstrap_url [command_file] [--client-zone-id <zone-id>]"
-goto :eof
-:continue
-
 setlocal
 SET BASE_DIR=%~dp0..
 
-call "%BASE_DIR%\bin\run-class.bat" jline.ConsoleRunner voldemort.VoldemortClientShell %*
+call "%BASE_DIR%\bin\run-class.bat" jline.ConsoleRunner voldemort.VoldemortClientShell %* --voldemort-shell bat
 
 endlocal
 

--- a/bin/voldemort-shell.sh
+++ b/bin/voldemort-shell.sh
@@ -16,12 +16,6 @@
 #  limitations under the License.
 #
 
-if [ $# -lt 2 ];
-then
-	echo 'USAGE: bin/voldemort-shell.sh store_name bootstrap_url [command_file] [--client-zone-id <zone-id>]'
-	exit 1
-fi
-
 base_dir=$(dirname $0)/..
 
-$base_dir/bin/run-class.sh jline.ConsoleRunner voldemort.VoldemortClientShell $@
+$base_dir/bin/run-class.sh jline.ConsoleRunner voldemort.VoldemortClientShell $@ --voldemort-shell sh

--- a/src/java/voldemort/VoldemortClientShell.java
+++ b/src/java/voldemort/VoldemortClientShell.java
@@ -151,21 +151,38 @@ public class VoldemortClientShell {
     public static void main(String[] args) throws Exception {
 
         OptionParser parser = new OptionParser();
-        parser.accepts("client-zone-id", "client zone id for zone routing")
+        parser.accepts("client-zone-id", "Client zone id for zone routing")
               .withRequiredArg()
               .describedAs("zone-id")
               .ofType(Integer.class);
+        parser.accepts("config-file", "A properties file that contains client config properties")
+              .withRequiredArg()
+              .describedAs("file");
+        parser.accepts("help", "Print this help message")
+              .isForHelp();
+        parser.accepts("voldemort-shell", "Suffix of shell script; used to format help output."
+                                          + " Examples of script suffixes: sh, bat, app")
+              .withRequiredArg()
+              .describedAs("script_suffix");
         OptionSet options = parser.parse(args);
 
         List<String> nonOptions = (List<String>) options.nonOptionArguments();
-        if(nonOptions.size() < 2 || nonOptions.size() > 3) {
-            System.err.println("Usage: java VoldemortClientShell store_name bootstrap_url [command_file] [options]");
+        if(nonOptions.size() < 2 || nonOptions.size() > 3 || options.has("help")) {
+            if (options.has("voldemort-shell")) {
+                System.err.println("Usage: voldemort-shell."
+                                    + options.valueOf("voldemort-shell")
+                                    + " store_name bootstrap_url [command_file] [options]");
+            } else {
+                System.err.println("Usage: java VoldemortClientShell store_name bootstrap_url [command_file] [options]");
+            }
             parser.printHelpOn(System.err);
             System.exit(-1);
         }
 
         String storeName = nonOptions.get(0);
         String bootstrapUrl = nonOptions.get(1);
+        String configFile = (String) options.valueOf("config-file");
+        ClientConfig clientConfig = null;
         BufferedReader inputReader = null;
         boolean fileInput = false;
 
@@ -180,9 +197,15 @@ public class VoldemortClientShell {
             Utils.croak("Failure to open input stream: " + e.getMessage());
         }
 
-        ClientConfig clientConfig = new ClientConfig().setBootstrapUrls(bootstrapUrl)
-                                                      .setEnableLazy(false)
-                                                      .setRequestFormatType(RequestFormatType.VOLDEMORT_V3);
+        if (configFile != null) {
+            clientConfig = new ClientConfig(new File(configFile));
+        } else {
+            clientConfig = new ClientConfig();
+        }
+
+        clientConfig.setBootstrapUrls(bootstrapUrl)
+                    .setEnableLazy(false)
+                    .setRequestFormatType(RequestFormatType.VOLDEMORT_V3);
 
         if(options.has("client-zone-id")) {
             clientConfig.setClientZoneId((Integer) options.valueOf("client-zone-id"));


### PR DESCRIPTION
Adding the ability to pass in a properties file to the voldemort-shell to override default client config settings. This is not intended to include support for the AdminClient features in the voldemort-shell at this point in time.

New help output:
```
[nobody@null voldemort]$ bin/voldemort-shell.sh --help
Usage: voldemort-shell.sh store_name bootstrap_url [command_file] [options]
Option                               Description                           
------                               -----------                           
--client-zone-id <Integer: zone-id>  Client zone id for zone routing       
--config-file <file>                 A properties file that contains client
                                       config properties                   
--help                               Print this help message                     
--voldemort-shell <script_suffix>    Suffix of shell script; used to format
                                       help output. Examples of script     
                                       suffixes: sh, bat, app
```

Normal run without a properties file:
```
[nobody@null voldemort]$ bin/voldemort-shell.sh stotch_test_3 tcp://voldemort-test-cluster.dev.demo.null:10103 --client-zone-id 0 
[18:49:38,229 voldemort.common.service.VoldemortService] INFO Starting scheduler-service [main]
[18:49:38,279 voldemort.client.ZenStoreClient] INFO Bootstrapping metadata for store stotch_test_3 [main]
[18:49:38,557 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [0] Attempting to get raw store [stotch_test_3]  [main]
[18:49:39,378 voldemort.client.ZenStoreClient] INFO Creating system stores for store stotch_test_3 [main]
[18:49:39,379 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [0] Attempting to get raw store [voldsys$_client_registry]  [main]
[18:49:39,388 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [0] Attempting to get raw store [voldsys$_metadata_version_persistence]  [main]
[18:49:39,394 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [0] Attempting to get raw store [voldsys$_store_quotas]  [main]
[18:49:39,604 voldemort.client.ZenStoreClient] INFO Metadata version check thread started. Frequency = Every 5000 ms [main]
[18:49:39,909 voldemort.client.scheduler.ClientRegistryRefresher] INFO Initial version obtained from client registry: version(1:1) ts:1446518979908 [main]
[18:49:39,909 voldemort.client.ZenStoreClient] INFO Client registry refresher thread started, refresh interval: 43200 seconds [main]
[18:49:39,909 voldemort.client.ZenStoreClient] INFO Voldemort client created: .stotch_test_3@null:nobody/git/stotch/voldemort
bootstrapTime=1446518979399
context=
deploymentPath=nobody/git/stotch/voldemort
localHostName=null
sequence=0
storeName=stotch_test_3
updateTime=1446518978233
releaseVersion=1.10.2
clusterMetadataVersion=0
max_connections=50
max_total_connections=500
connection_timeout_ms=500
socket_timeout_ms=5000
routing_timeout_ms=5000
client_zone_id=0
failuredetector_implementation=voldemort.cluster.failuredetector.ThresholdFailureDetector
failuredetector_threshold=95
failuredetector_threshold_count_minimum=30
failuredetector_threshold_interval=300000
failuredetector_threshold_async_recovery_interval=10000
 [main]
[18:49:40,213 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [-1] Attempting to get raw store [voldsys$_metadata_version_persistence]  [main]
[18:49:40,459 voldemort.store.routed.PipelineRoutedStore] WARN Client Zone is not specified. Default to Zone 0. The servers could be in a remote zone [main]
[18:49:40,459 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [-1] Attempting to get raw store [voldsys$_store_quotas]  [main]
[18:49:40,544 voldemort.store.routed.PipelineRoutedStore] WARN Client Zone is not specified. Default to Zone 0. The servers could be in a remote zone [main]
Established connection to stotch_test_3 via tcp://voldemort-test-cluster.dev.demo.null:10103
> get '0'
null
> put '0' '"test0"'
> get '0'
version(2:1) ts:1446519001878: test0
> delete '0'
```

Example properties file:
```
[nobody@null voldemort]$ cat ~/tmp/client.properties 
connection_timeout_ms=1000
socket_timeout_ms=1000
routing_timeout_ms=1000
max_connections=5
max_total_connections=10
```

Running with the properties file:
```
[nobody@null voldemort]$ bin/voldemort-shell.sh stotch_test_3 tcp://voldemort-test-cluster.dev.demo.null:10103 --client-zone-id 0 --config-file ~/tmp/client.properties 
[19:08:06,793 voldemort.common.service.VoldemortService] INFO Starting scheduler-service [main]
[19:08:06,843 voldemort.client.ZenStoreClient] INFO Bootstrapping metadata for store stotch_test_3 [main]
[19:08:07,116 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [0] Attempting to get raw store [stotch_test_3]  [main]
[19:08:07,913 voldemort.client.ZenStoreClient] INFO Creating system stores for store stotch_test_3 [main]
[19:08:07,914 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [0] Attempting to get raw store [voldsys$_client_registry]  [main]
[19:08:07,922 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [0] Attempting to get raw store [voldsys$_metadata_version_persistence]  [main]
[19:08:07,927 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [0] Attempting to get raw store [voldsys$_store_quotas]  [main]
[19:08:08,140 voldemort.client.ZenStoreClient] INFO Metadata version check thread started. Frequency = Every 5000 ms [main]
[19:08:08,509 voldemort.client.scheduler.ClientRegistryRefresher] INFO Initial version obtained from client registry: version(1:1, 13:2) ts:1446520088508 [main]
[19:08:08,509 voldemort.client.ZenStoreClient] INFO Client registry refresher thread started, refresh interval: 43200 seconds [main]
[19:08:08,509 voldemort.client.ZenStoreClient] INFO Voldemort client created: .stotch_test_3@null:nobody/git/stotch/voldemort
bootstrapTime=1446520087933
context=
deploymentPath=nobody/git/stotch/voldemort
localHostName=null
sequence=0
storeName=stotch_test_3
updateTime=1446520086797
releaseVersion=1.10.2
clusterMetadataVersion=0
max_connections=5
max_total_connections=10
connection_timeout_ms=1000
socket_timeout_ms=1000
routing_timeout_ms=1000
client_zone_id=0
failuredetector_implementation=voldemort.cluster.failuredetector.ThresholdFailureDetector
failuredetector_threshold=95
failuredetector_threshold_count_minimum=30
failuredetector_threshold_interval=300000
failuredetector_threshold_async_recovery_interval=10000
 [main]
[19:08:08,809 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [-1] Attempting to get raw store [voldsys$_metadata_version_persistence]  [main]
[19:08:09,055 voldemort.store.routed.PipelineRoutedStore] WARN Client Zone is not specified. Default to Zone 0. The servers could be in a remote zone [main]
[19:08:09,056 voldemort.client.AbstractStoreClientFactory] INFO Client zone-id [-1] Attempting to get raw store [voldsys$_store_quotas]  [main]
[19:08:09,143 voldemort.store.routed.PipelineRoutedStore] WARN Client Zone is not specified. Default to Zone 0. The servers could be in a remote zone [main]
Established connection to stotch_test_3 via tcp://voldemort-test-cluster.dev.demo.null:10103
> put '0' '"test0"'
> get '0'          
version(2:1) ts:1446520095984: test0
> delete '0'
```

Note the changes in the client config above match those of the properties file.

Batched commit messages:
```
Removing the redundant argument check so that the VoldemortClientShell.java option parser can be used to query help

Removing the redundant argument check so that the VoldemortClientShell.java option parser can be used to query help

Augmented help and added an option for passing in a properties file

The shell now passes in an option that tells VoldemortClientShell that it is being called from voldemort-shell.sh so that it can properly format the help output

The shell now passes in an option that tells VoldemortClientShell that it is being called from voldemort-shell.sh so that it can properly format the help output

Made help for --voldemort-shell option more 'helpful'

Mistakenly bumped up a greaterthan check on the positional arguments ... Rolling that back

Rewording --help helper text to be more helpful
```