### PR TITLE
Make VoldemortClientShell adminClient use user-defined properties file

### DIFF
--- a/src/java/voldemort/VoldemortClientShell.java
+++ b/src/java/voldemort/VoldemortClientShell.java
@@ -113,7 +113,7 @@ public class VoldemortClientShell {
         try {
             factory = new SocketStoreClientFactory(clientConfig);
             client = factory.getStoreClient(storeName);
-            adminClient = new AdminClient(bootstrapUrl, new AdminClientConfig(), new ClientConfig());
+            adminClient = new AdminClient(bootstrapUrl, new AdminClientConfig(), clientConfig);
 
             storeDef = StoreUtils.getStoreDef(factory.getStoreDefs(), storeName);
 


### PR DESCRIPTION
adminClient now uses the same ClientConfig as the SocketStoreClient so that it too can get the overrides passed in by a user defined config file.