### PR TITLE
Bug fix for BnP HA

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -459,7 +459,7 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
             } catch(VoldemortException e) {
                 log.error("Exception during cluster equality check", e);
                 fail("Exception during cluster equality check: " + e.toString());
-                return;
+                throw e;
             }
 
             String reducerOutputCompressionCodec = getMatchingServerSupportedCompressionCodec();

--- a/src/java/voldemort/store/readonly/StoreVersionManager.java
+++ b/src/java/voldemort/store/readonly/StoreVersionManager.java
@@ -199,9 +199,9 @@ public class StoreVersionManager {
         try {
             disabledMarker.createNewFile();
         } catch (IOException e) {
-            throw new PersistenceFailureException(
-                    "Failed to create the disabled marker for version " + version + " in rootDir: " + rootDir +
-                            "\nThe store/version will remain disabled only until the next restart.", e);
+            throw new PersistenceFailureException("Failed to create the disabled marker at path: " +
+                                                  disabledMarker.getAbsolutePath() + "\nThe store/version " +
+                                                  "will remain disabled only until the next restart.", e);
         }
     }
 
@@ -217,20 +217,29 @@ public class StoreVersionManager {
         File disabledMarker = getDisabledMarkerFile(version);
         if (disabledMarker.exists()) {
             if (!disabledMarker.delete()) {
-                throw new PersistenceFailureException(
-                        "Failed to delete the disabled marker for version " + version + " in rootDir: " + rootDir +
-                                "\nThe store/version will remain enabled only until the next restart.");
+                throw new PersistenceFailureException("Failed to create the disabled marker at path: " +
+                                                      disabledMarker.getAbsolutePath() + "\nThe store/version " +
+                                                      "will remain enabled only until the next restart.");
             }
         }
     }
 
+    /**
+     * Gets the '.disabled' file for a given version of this store. That file may or may not
+     * exist.
+     *
+     * @param version of the store for which to get the '.disabled' file.
+     * @return an instance of {@link File} pointing to the '.disabled' file.
+     * @throws PersistenceFailureException if the requested version cannot be found.
+     */
     private File getDisabledMarkerFile(long version) throws PersistenceFailureException {
         File[] versionDirArray = ReadOnlyUtils.getVersionDirs(rootDir, version, version);
         if (versionDirArray.length == 0) {
-            throw new PersistenceFailureException("getDisabledMarkerFile did not find the requested version on disk. " +
-                    "Version: " + version + ", rootDir: " + rootDir);
+            throw new PersistenceFailureException("getDisabledMarkerFile did not find the requested version directory" +
+                                                  " on disk. Version: " + version + ", rootDir: " + rootDir);
         }
-        return versionDirArray[0];
+        File disabledMarkerFile = new File(versionDirArray[0], DISABLED_MARKER_NAME);
+        return disabledMarkerFile;
     }
 
     private void removeVersion(long version) {

--- a/test/unit/voldemort/store/readonly/StoreVersionManagerTest.java
+++ b/test/unit/voldemort/store/readonly/StoreVersionManagerTest.java
@@ -1,0 +1,83 @@
+package voldemort.store.readonly;
+
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import junit.framework.TestCase;
+import voldemort.TestUtils;
+import voldemort.store.PersistenceFailureException;
+
+import java.io.File;
+
+/**
+ * Basic tests for {@link StoreVersionManager}
+ */
+public class StoreVersionManagerTest extends TestCase {
+    private File rootDir, version0, version1;
+    private StoreVersionManager storeVersionManager;
+    @Before
+    public void setUp() {
+        rootDir = TestUtils.createTempDir();
+        version0 = new File(rootDir, "version-0");
+        version1 = new File(rootDir, "version-1");
+        Assert.assertTrue("Failed to create version directory!", version0.mkdir());
+        Assert.assertTrue("Failed to create version directory!", version1.mkdir());
+        storeVersionManager = new StoreVersionManager(rootDir);
+        storeVersionManager.syncInternalStateFromFileSystem();
+    }
+
+    @Test
+    public void testDisableStoreVersion() {
+        // Validate that state got synced properly from the filesystem
+        Assert.assertFalse("Did not expect to have any store version disabled.",
+                           storeVersionManager.hasAnyDisabledVersion());
+
+        // Disable a store version
+        storeVersionManager.disableStoreVersion(0);
+
+        // Validate that the in-memory state changed accordingly
+        Assert.assertTrue("Expected in-memory state to have some store version disabled.",
+                           storeVersionManager.hasAnyDisabledVersion());
+        Assert.assertTrue("Expected in-memory state to have store version 1 enabled.",
+                          storeVersionManager.isCurrentVersionEnabled());
+
+        // Verify that another instance of StoreVersionManager, freshly synced from disk, also has proper state.
+        StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir);
+        storeVersionManager2.syncInternalStateFromFileSystem();
+        Assert.assertTrue("Expected persistent state to have some store version disabled.",
+                          storeVersionManager2.hasAnyDisabledVersion());
+        Assert.assertTrue("Expected persistent state to have store version 1 enabled.",
+                          storeVersionManager2.isCurrentVersionEnabled());
+    }
+
+    @Test
+    public void testDisableStoreVersionOnReadOnlyStorage() {
+        // Validate that state got synced properly from the filesystem
+        Assert.assertFalse("Did not expect to have any store version disabled.",
+                           storeVersionManager.hasAnyDisabledVersion());
+
+        // Simulate the filesystem becoming read-only underneath us
+        version0.setReadOnly();
+
+        // Disable a store version
+        try {
+            storeVersionManager.disableStoreVersion(0);
+            Assert.fail("Did not get a PersistenceFailureException when trying to disableStoreVersion on a read-only filesystem.");
+        } catch (PersistenceFailureException e) {
+            // expected
+        }
+
+        // Validate that the in-memory state changed accordingly
+        Assert.assertTrue("Expected in-memory state to have some store version disabled.",
+                          storeVersionManager.hasAnyDisabledVersion());
+        Assert.assertTrue("Expected in-memory state to have store version 1 enabled.",
+                          storeVersionManager.isCurrentVersionEnabled());
+
+        // Verify that another instance of StoreVersionManager, freshly synced from disk, does NOT have proper state.
+        StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir);
+        storeVersionManager2.syncInternalStateFromFileSystem();
+        Assert.assertFalse("Expected persistent state to have no version disabled.",
+                          storeVersionManager2.hasAnyDisabledVersion());
+    }
+
+}


### PR DESCRIPTION
- StoreVersionManager.getDisabledMarkerFile() did not look for the right file name.
- Also added unit tests and better log messages for this.

Debuggability improvements in AdminServiceRequestHandler:
- More exceptions now logged with their full stacktrace on the server-side.
- The request info is now printed in a more readable format.

BnP job will now fail properly when clusters are inconsistent, rather than just exiting.