### PR TITLE
ReadOnlyReplicationHelperCLI: do not rely on down node

### DIFF
--- a/src/java/voldemort/client/protocol/admin/AdminClient.java
+++ b/src/java/voldemort/client/protocol/admin/AdminClient.java
@@ -3307,18 +3307,18 @@ public class AdminClient implements Closeable {
 
         /**
          * Given the cluster metadata, retrieves the list of store definitions.
-         * 
-         * <br>
-         * 
          * It also checks if the store definitions are consistent across the
          * cluster
-         * 
+         *
          * @param cluster The cluster metadata
+         * @param exceptNodeId Do not check this node, we don't trust it right now.
          * @return List of store definitions
          */
-        public List<StoreDefinition> getCurrentStoreDefinitions(Cluster cluster) {
+        public List<StoreDefinition> getCurrentStoreDefinitions(Cluster cluster, int exceptNodeId) {
             List<StoreDefinition> storeDefs = null;
             for(Node node: cluster.getNodes()) {
+		if (node.getId() == exceptNodeId)
+		    continue;
                 List<StoreDefinition> storeDefList = metadataMgmtOps.getRemoteStoreDefList(node.getId())
                                                                     .getValue();
                 if(storeDefs == null) {
@@ -3339,6 +3339,18 @@ public class AdminClient implements Closeable {
                 return storeDefs;
             }
         }
+
+        /**
+         * Given the cluster metadata, retrieves the list of store definitions.
+         * It also checks if the store definitions are consistent across the
+         * cluster
+         *
+         * @param cluster The cluster metadata
+         * @return List of store definitions
+         */
+        public List<StoreDefinition> getCurrentStoreDefinitions(Cluster cluster) {
+	    return getCurrentStoreDefinitions(cluster, -1);
+	}
 
         /**
          * Given a list of store definitions, cluster and admin client returns a


### PR DESCRIPTION
When building a list of partitions to be copied between nodes
to restore a down node, don't expect to be able to fetch any
useful metadata from the down node.