### PR TITLE
ReadOnlyReplicationHelperCLI: do not rely on down node

### DIFF
--- a/src/java/voldemort/client/protocol/admin/AdminClient.java
+++ b/src/java/voldemort/client/protocol/admin/AdminClient.java
@@ -3307,18 +3307,19 @@ public class AdminClient implements Closeable {
 
         /**
          * Given the cluster metadata, retrieves the list of store definitions.
-         * 
-         * <br>
-         * 
          * It also checks if the store definitions are consistent across the
-         * cluster
-         * 
+         * cluster, except for one specific node.
+         *
          * @param cluster The cluster metadata
+         * @param nodeId Do not check this node, we don't trust it right now.
+	 *		May be -1 to check every node.
          * @return List of store definitions
          */
-        public List<StoreDefinition> getCurrentStoreDefinitions(Cluster cluster) {
+        public List<StoreDefinition> getCurrentStoreDefinitionsExcept(Cluster cluster, int nodeId) {
             List<StoreDefinition> storeDefs = null;
             for(Node node: cluster.getNodes()) {
+		if (node.getId() == nodeId)
+		    continue;
                 List<StoreDefinition> storeDefList = metadataMgmtOps.getRemoteStoreDefList(node.getId())
                                                                     .getValue();
                 if(storeDefs == null) {
@@ -3339,6 +3340,18 @@ public class AdminClient implements Closeable {
                 return storeDefs;
             }
         }
+
+        /**
+         * Given the cluster metadata, retrieves the list of store definitions.
+         * It also checks if the store definitions are consistent across the
+         * cluster
+         *
+         * @param cluster The cluster metadata
+         * @return List of store definitions
+         */
+        public List<StoreDefinition> getCurrentStoreDefinitions(Cluster cluster) {
+	    return getCurrentStoreDefinitionsExcept(cluster, -1);
+	}
 
         /**
          * Given a list of store definitions, cluster and admin client returns a

--- a/src/java/voldemort/tools/ReadOnlyReplicationHelperCLI.java
+++ b/src/java/voldemort/tools/ReadOnlyReplicationHelperCLI.java
@@ -163,20 +163,22 @@ public class ReadOnlyReplicationHelperCLI {
     }
 
     /**
-     * Analyze read-only storage file replication info
-     * 
+     * Analyze read-only storage file replication info, for replicating
+     * the partitions on the given nodeId.  Note that because that node
+     * is being replicated, we cannot rely on the node being up or
+     * consistent, so we carefully avoid talking to it.
+     *
      * @param cluster
      * @param nodeId
-     * @return List of read-only replicaiton info in format of:
+     * @return List of read-only replication info in format of:
      *         store_name,src_node_id,src_file_name,dest_file_name
      */
     public static List<String> getReadOnlyReplicationInfo(AdminClient adminClient,
                                                           Integer nodeId,
                                                           Boolean local) {
         List<String> infoList = Lists.newArrayList();
-        List<StoreDefinition> storeDefs = adminClient.metadataMgmtOps.getRemoteStoreDefList()
-                                                                     .getValue();
-        Cluster cluster = adminClient.metadataMgmtOps.getRemoteCluster(nodeId).getValue();
+        Cluster cluster = adminClient.getAdminClientCluster();
+        List<StoreDefinition> storeDefs = adminClient.rebalanceOps.getCurrentStoreDefinitionsExcept(cluster, nodeId);
 
         for(StoreDefinition storeDef: storeDefs) {
             String storeName = storeDef.getName();
@@ -196,15 +198,6 @@ public class ReadOnlyReplicationHelperCLI {
 			     ReadOnlyStorageConfiguration.TYPE_NAME);
                 continue;
 	    }
-	    storageFormat = adminClient.readonlyOps.getROStorageFormat(nodeId, storeName);
-	    if(!storageFormat.equals(ReadOnlyStorageFormat.READONLY_V2.getCode())) {
-                logger.error("Store " + storeName +
-			     " cannot be restored, as it has storage format = " +
-                             storageFormat +
-			     " instead of " +
-			     ReadOnlyStorageFormat.READONLY_V2.getCode());
-                continue;
-            }
 
             logger.info("Processing store " + storeName);
 


### PR DESCRIPTION
When building a list of partitions to be copied between nodes
to restore a down node, don't expect to be able to fetch any
useful metadata from the down node.

v2: better method naming per feedback from athirupathi