### PR TITLE
For testing BnP with sWebHdfs, let Voldemort node can enable or disable SSL separately.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -76,7 +76,8 @@ public class HdfsFetcher implements FileFetcher {
      * {@link AdminServiceRequestHandler#setFetcherClass(voldemort.server.VoldemortConfig)}
      */
     public HdfsFetcher(VoldemortConfig config) {
-        this(config, config.getReadOnlyFetcherMaxBytesPerSecond(),
+        this(config,
+             config.getReadOnlyFetcherMaxBytesPerSecond(),
              config.getReadOnlyFetcherReportingIntervalBytes(),
              config.getReadOnlyFetcherThrottlerInterval(),
              config.getFetcherBufferSize(),

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -75,11 +75,16 @@ public class HdfsFetcher implements FileFetcher {
      * {@link AdminServiceRequestHandler#setFetcherClass(voldemort.server.VoldemortConfig)}
      */
     public HdfsFetcher(VoldemortConfig config) {
-        this(config, config.getReadOnlyFetcherMaxBytesPerSecond(), config.getReadOnlyFetcherReportingIntervalBytes(),
-            config.getReadOnlyFetcherThrottlerInterval(), config.getFetcherBufferSize(),
-            config.getReadOnlyFetchRetryCount(), config.getReadOnlyFetchRetryDelayMs(),
-            config.isReadOnlyStatsFileEnabled(), config.getReadOnlyMaxVersionsStatsFile(),
-            config.getFetcherSocketTimeout());
+        this(config,
+             config.getReadOnlyFetcherMaxBytesPerSecond(),
+             config.getReadOnlyFetcherReportingIntervalBytes(),
+             config.getReadOnlyFetcherThrottlerInterval(),
+             config.getFetcherBufferSize(),
+             config.getReadOnlyFetchRetryCount(),
+             config.getReadOnlyFetchRetryDelayMs(),
+             config.isReadOnlyStatsFileEnabled(),
+             config.getReadOnlyMaxVersionsStatsFile(),
+             config.getFetcherSocketTimeout());
     }
 
 

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherTest.java
@@ -173,27 +173,36 @@ public class HdfsFetcherTest extends TestCase {
 
     }
 
-    public void testReplaceURLByConfig() {
+    public void testModifyURLByConfig() {
         String url = "swebhdfs://localhost:50470/user/testpath";
         Properties properties = new Properties();
         properties.setProperty("node.id", "1");
         properties.setProperty("voldemort.home","/test");
+        //Default configuration. Should not modify url.
         HdfsFetcher fetcher = new HdfsFetcher(new VoldemortConfig(properties));
         //Disable SSL. Url should be replaced.
-        String newUrl = fetcher.replaceURLbyConfig(url);
-        assertEquals(newUrl, "webhdfs://localhost:50070/user/testpath");
+        String newUrl = fetcher.modifyURLbyConfig(url);
+        assertEquals(url, newUrl);
+
+        //Enable modify feature. URL should be replace to webhdfs which is the default.
+        properties.setProperty("readonly.modify", "true");
+        fetcher = new HdfsFetcher(new VoldemortConfig(properties));
+        newUrl = fetcher.modifyURLbyConfig(url);
+        assertEquals("webhdfs://localhost:50070/user/testpath", newUrl);
 
         //Test replacing is correct based on properties in config.
-        properties.setProperty("readonly.hdfs.protocol", "testprotocol");
-        properties.setProperty("readonly.hdfs.port", "12345");
+        properties.setProperty("readonly.modify", "true");
+        properties.setProperty("readonly.modify.protocol", "testprotocol");
+        properties.setProperty("readonly.modify.port", "12345");
         fetcher = new HdfsFetcher(new VoldemortConfig(properties));
-        newUrl = fetcher.replaceURLbyConfig(url);
-        assertEquals(newUrl, "testprotocol://localhost:12345/user/testpath");
+        newUrl = fetcher.modifyURLbyConfig(url);
+        assertEquals("testprotocol://localhost:12345/user/testpath", newUrl) ;
 
-        //Enable SSL. Url should not be replaced.
-        properties.setProperty("readonly.hdfs.ssl", "true");
+        //Local path, should not modifed anything.
+        properties.setProperty("readonly.modify", "true");
         fetcher = new HdfsFetcher(new VoldemortConfig(properties));
-        newUrl = fetcher.replaceURLbyConfig(url);
-        assertEquals(newUrl, url);
+        url = "/testpath/file";
+        newUrl = fetcher.modifyURLbyConfig(url);
+        assertEquals(url, newUrl);
   }
 }

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherTest.java
@@ -26,14 +26,11 @@ import org.apache.commons.io.FileUtils;
 
 import voldemort.TestUtils;
 import voldemort.VoldemortException;
-import voldemort.server.VoldemortConfig;
 import voldemort.store.readonly.ReadOnlyStorageFormat;
 import voldemort.store.readonly.ReadOnlyStorageMetadata;
 import voldemort.store.readonly.checksum.CheckSum;
 import voldemort.store.readonly.checksum.CheckSumTests;
 import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
-import voldemort.utils.Props;
-
 
 /**
  * Tests for the HDFS-based fetcher
@@ -173,36 +170,4 @@ public class HdfsFetcherTest extends TestCase {
 
     }
 
-    public void testModifyURLByConfig() {
-        String url = "swebhdfs://localhost:50470/user/testpath";
-        Properties properties = new Properties();
-        properties.setProperty("node.id", "1");
-        properties.setProperty("voldemort.home","/test");
-        //Default configuration. Should not modify url.
-        HdfsFetcher fetcher = new HdfsFetcher(new VoldemortConfig(properties));
-        //Disable SSL. Url should be replaced.
-        String newUrl = fetcher.modifyURLbyConfig(url);
-        assertEquals(url, newUrl);
-
-        //Enable modify feature. URL should be replace to webhdfs which is the default.
-        properties.setProperty("readonly.modify", "true");
-        fetcher = new HdfsFetcher(new VoldemortConfig(properties));
-        newUrl = fetcher.modifyURLbyConfig(url);
-        assertEquals("webhdfs://localhost:50070/user/testpath", newUrl);
-
-        //Test replacing is correct based on properties in config.
-        properties.setProperty("readonly.modify", "true");
-        properties.setProperty("readonly.modify.protocol", "testprotocol");
-        properties.setProperty("readonly.modify.port", "12345");
-        fetcher = new HdfsFetcher(new VoldemortConfig(properties));
-        newUrl = fetcher.modifyURLbyConfig(url);
-        assertEquals("testprotocol://localhost:12345/user/testpath", newUrl) ;
-
-        //Local path, should not modifed anything.
-        properties.setProperty("readonly.modify", "true");
-        fetcher = new HdfsFetcher(new VoldemortConfig(properties));
-        url = "/testpath/file";
-        newUrl = fetcher.modifyURLbyConfig(url);
-        assertEquals(url, newUrl);
-  }
 }

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherTest.java
@@ -18,7 +18,6 @@ package voldemort.store.readonly.fetcher;
 
 import java.io.File;
 
-import java.util.Properties;
 import junit.framework.TestCase;
 
 import org.apache.commons.codec.binary.Hex;
@@ -169,5 +168,4 @@ public class HdfsFetcherTest extends TestCase {
         checkSumFile.delete();
 
     }
-
 }

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/utils/VoldemortUtilsTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/utils/VoldemortUtilsTest.java
@@ -1,0 +1,59 @@
+package voldemort.store.readonly.mr.utils;
+
+import java.util.Properties;
+import junit.framework.TestCase;
+import voldemort.server.VoldemortConfig;
+import voldemort.store.readonly.fetcher.HdfsFetcher;
+
+
+/**
+ * Tests for VoldemortUtils.
+ */
+public class VoldemortUtilsTest extends TestCase {
+    public void testModifyURLByConfig() {
+        String url = "swebhdfs://localhost:50470/user/testpath";
+        Properties properties = new Properties();
+        properties.setProperty("node.id", "1");
+        properties.setProperty("voldemort.home", "/test");
+        VoldemortConfig config = new VoldemortConfig(properties);
+
+        //Default configuration. Should not modify url.
+        HdfsFetcher fetcher = new HdfsFetcher(config);
+        String newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getMysqlPort());
+        assertEquals(url, newUrl);
+
+        //Enable modify feature. URL should be replace to webhdfs with 50070 port number.
+        properties.setProperty("readonly.modify.protocol", "webhdfs");
+        properties.setProperty("readonly.modify.port", "50070");
+        config = new VoldemortConfig(properties);
+        newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
+        assertEquals("webhdfs://localhost:50070/user/testpath", newUrl);
+
+        //No modified protocol assigned. Should not modify URL.
+        properties.remove("readonly.modify.protocol");
+        config = new VoldemortConfig(properties);
+        newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
+        assertEquals(url, newUrl);
+
+        //No Modified port assigned. Should not modify URL.
+        properties.remove("readonly.modify.port");
+        properties.setProperty("readonly.modify.protocol", "testprotocol");
+        config = new VoldemortConfig(properties);
+        newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
+        assertEquals(url, newUrl);
+
+        //Local path. Should throw IAE because it's not a valid URL.
+        url = "/testpath/file";
+        properties.setProperty("readonly.modify.protocol", "webhdfs");
+        properties.setProperty("readonly.modify.port", "50070");
+        config = new VoldemortConfig(properties);
+        try {
+            VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
+        } catch (IllegalArgumentException iae) {
+            return;
+        } catch (Exception e) {
+            fail("Should met IAE. URL is not valid.");
+        }
+        fail("Should met IAE. URL is not valid.");
+    }
+}

--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -178,6 +178,9 @@ public class VoldemortConfig implements Serializable {
     private int readOnlyMaxValueBufferAllocationSize;
     private long readOnlyLoginIntervalMs;
     private long defaultStorageSpaceQuotaInKB;
+    private boolean SSLEnabled;
+    private String hdfsFetchProtocol;
+    private String hdfsFetchPort;
 
     public static final String PUSH_HA_ENABLED = "push.ha.enabled";
     private boolean highAvailabilityPushEnabled;
@@ -401,6 +404,10 @@ public class VoldemortConfig implements Serializable {
         // property "readonly.compression.codec" to "GZIP"
         this.readOnlyCompressionCodec = props.getString("readonly.compression.codec",
                                                         VoldemortConfig.DEFAULT_RO_COMPRESSION_CODEC);
+
+        this.SSLEnabled = props.getBoolean("readonly.hdfs.ssl", false);
+        this.hdfsFetchProtocol = props.getString("readonly.hdfs.protocol", "webhdfs");
+        this.hdfsFetchPort = props.getString("readonly.hdfs.port", "50070");
 
         this.highAvailabilityPushClusterId = props.getString(PUSH_HA_CLUSTER_ID, null);
         this.highAvailabilityPushLockPath = props.getString(PUSH_HA_LOCK_PATH, null);
@@ -3012,6 +3019,52 @@ public class VoldemortConfig implements Serializable {
      */
     public void setReadOnlySearchStrategy(String readOnlySearchStrategy) {
         this.readOnlySearchStrategy = readOnlySearchStrategy;
+    }
+
+    public boolean isSSLEnabled() {
+        return SSLEnabled;
+    }
+
+    /**
+     * Determin whether enable SSL when fetching file from HDFS.
+     *
+     * <ul>
+     * <li>Property : "readonly.hdfs.ssl"</li>
+     * <li>Default : false</li>
+     * </ul>
+     */
+    public void setSSLEnabled(boolean SSLEnabled) {
+        this.SSLEnabled = SSLEnabled;
+    }
+    public String getHdfsFetchProtocol() {
+        return hdfsFetchProtocol;
+    }
+    /**
+     * Set protocol used to fetch file from HDFS.
+     *
+     * <ul>
+     * <li>Property : "readonly.hdfs.protocol"</li>
+     * <li>Default : webhdfs</li>
+     * </ul>
+     */
+    public void setHdfsFetchProtocol(String hdfsFetchProtocol) {
+        this.hdfsFetchProtocol = hdfsFetchProtocol;
+    }
+
+    public String getHdfsFetchPort() {
+        return hdfsFetchPort;
+    }
+
+    /**
+     * Set port used to fetch file from HDFS.
+     *
+     * <ul>
+     * <li>Property : "readonly.hdfs.port"</li>
+     * <li>Default : 50070</li>
+     * </ul>
+     */
+    public void setHdfsFetchPort(String hdfsFetchPort) {
+        this.hdfsFetchPort = hdfsFetchPort;
     }
 
     public boolean isHighAvailabilityPushEnabled() {

--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -178,9 +178,9 @@ public class VoldemortConfig implements Serializable {
     private int readOnlyMaxValueBufferAllocationSize;
     private long readOnlyLoginIntervalMs;
     private long defaultStorageSpaceQuotaInKB;
-    private boolean SSLEnabled;
-    private String hdfsFetchProtocol;
-    private String hdfsFetchPort;
+    private boolean modifyUrlEnable;
+    private String modifiedProtocol;
+    private int modifiedPort;
 
     public static final String PUSH_HA_ENABLED = "push.ha.enabled";
     private boolean highAvailabilityPushEnabled;
@@ -405,9 +405,9 @@ public class VoldemortConfig implements Serializable {
         this.readOnlyCompressionCodec = props.getString("readonly.compression.codec",
                                                         VoldemortConfig.DEFAULT_RO_COMPRESSION_CODEC);
 
-        this.SSLEnabled = props.getBoolean("readonly.hdfs.ssl", false);
-        this.hdfsFetchProtocol = props.getString("readonly.hdfs.protocol", "webhdfs");
-        this.hdfsFetchPort = props.getString("readonly.hdfs.port", "50070");
+        this.modifyUrlEnable = props.getBoolean("readonly.modify", false);
+        this.modifiedProtocol = props.getString("readonly.modify.protocol", "webhdfs");
+        this.modifiedPort = props.getInt("readonly.modify.port", 50070);
 
         this.highAvailabilityPushClusterId = props.getString(PUSH_HA_CLUSTER_ID, null);
         this.highAvailabilityPushLockPath = props.getString(PUSH_HA_LOCK_PATH, null);
@@ -3021,50 +3021,52 @@ public class VoldemortConfig implements Serializable {
         this.readOnlySearchStrategy = readOnlySearchStrategy;
     }
 
-    public boolean isSSLEnabled() {
-        return SSLEnabled;
+    public boolean isModifyUrlEnable() {
+        return modifyUrlEnable;
     }
 
     /**
-     * Determin whether enable SSL when fetching file from HDFS.
+     * Determine whether enable URL modify feature when fetching file.
      *
      * <ul>
-     * <li>Property : "readonly.hdfs.ssl"</li>
+     * <li>Property : "readonly.modify"</li>
      * <li>Default : false</li>
      * </ul>
      */
-    public void setSSLEnabled(boolean SSLEnabled) {
-        this.SSLEnabled = SSLEnabled;
+    public void setModifyUrlEnable(boolean modifyUrlEnable) {
+        this.modifyUrlEnable = modifyUrlEnable;
     }
-    public String getHdfsFetchProtocol() {
-        return hdfsFetchProtocol;
+
+    public String getModifiedProtocol() {
+        return this.modifiedProtocol;
     }
+
     /**
-     * Set protocol used to fetch file from HDFS.
+     * Set modified protocol used to fetch file.
      *
      * <ul>
-     * <li>Property : "readonly.hdfs.protocol"</li>
-     * <li>Default : webhdfs</li>
+     * <li>Property : "readonly.modify.protocol"</li>
+     * <li>Default : "webhdfs"</li>
      * </ul>
      */
-    public void setHdfsFetchProtocol(String hdfsFetchProtocol) {
-        this.hdfsFetchProtocol = hdfsFetchProtocol;
+    public void setModifiedProtocol(String modifiedProtocol) {
+        this.modifiedProtocol = modifiedProtocol;
     }
 
-    public String getHdfsFetchPort() {
-        return hdfsFetchPort;
+    public int getModifiedPort() {
+        return this.modifiedPort;
     }
 
     /**
-     * Set port used to fetch file from HDFS.
+     * Set modifed port used to fetch file.
      *
      * <ul>
-     * <li>Property : "readonly.hdfs.port"</li>
+     * <li>Property : "readonly.modify.port"</li>
      * <li>Default : 50070</li>
      * </ul>
      */
-    public void setHdfsFetchPort(String hdfsFetchPort) {
-        this.hdfsFetchPort = hdfsFetchPort;
+    public void setModifiedPort(int modifiedPort) {
+        this.modifiedPort = modifiedPort;
     }
 
     public boolean isHighAvailabilityPushEnabled() {

--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -178,7 +178,6 @@ public class VoldemortConfig implements Serializable {
     private int readOnlyMaxValueBufferAllocationSize;
     private long readOnlyLoginIntervalMs;
     private long defaultStorageSpaceQuotaInKB;
-    private boolean modifyUrlEnable;
     private String modifiedProtocol;
     private int modifiedPort;
 
@@ -405,9 +404,8 @@ public class VoldemortConfig implements Serializable {
         this.readOnlyCompressionCodec = props.getString("readonly.compression.codec",
                                                         VoldemortConfig.DEFAULT_RO_COMPRESSION_CODEC);
 
-        this.modifyUrlEnable = props.getBoolean("readonly.modify", false);
-        this.modifiedProtocol = props.getString("readonly.modify.protocol", "webhdfs");
-        this.modifiedPort = props.getInt("readonly.modify.port", 50070);
+        this.modifiedProtocol = props.getString("readonly.modify.protocol", null);
+        this.modifiedPort = props.getInt("readonly.modify.port", -1);
 
         this.highAvailabilityPushClusterId = props.getString(PUSH_HA_CLUSTER_ID, null);
         this.highAvailabilityPushLockPath = props.getString(PUSH_HA_LOCK_PATH, null);
@@ -3021,22 +3019,6 @@ public class VoldemortConfig implements Serializable {
         this.readOnlySearchStrategy = readOnlySearchStrategy;
     }
 
-    public boolean isModifyUrlEnable() {
-        return modifyUrlEnable;
-    }
-
-    /**
-     * Determine whether enable URL modify feature when fetching file.
-     *
-     * <ul>
-     * <li>Property : "readonly.modify"</li>
-     * <li>Default : false</li>
-     * </ul>
-     */
-    public void setModifyUrlEnable(boolean modifyUrlEnable) {
-        this.modifyUrlEnable = modifyUrlEnable;
-    }
-
     public String getModifiedProtocol() {
         return this.modifiedProtocol;
     }
@@ -3046,7 +3028,7 @@ public class VoldemortConfig implements Serializable {
      *
      * <ul>
      * <li>Property : "readonly.modify.protocol"</li>
-     * <li>Default : "webhdfs"</li>
+     * <li>Default : null</li>
      * </ul>
      */
     public void setModifiedProtocol(String modifiedProtocol) {
@@ -3062,7 +3044,7 @@ public class VoldemortConfig implements Serializable {
      *
      * <ul>
      * <li>Property : "readonly.modify.port"</li>
-     * <li>Default : 50070</li>
+     * <li>Default : -1</li>
      * </ul>
      */
     public void setModifiedPort(int modifiedPort) {


### PR DESCRIPTION
In order to enable and disable SSL support in Voldemort node. Add 3 properties in configuration and replace source file url before fetching if needed.