### PR TITLE
Squash commits. Let Voldemort node can modify URL before fetching file.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -44,6 +44,7 @@ import voldemort.store.readonly.FileFetcher;
 import voldemort.store.readonly.ReadOnlyStorageMetadata;
 import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
 import voldemort.store.readonly.mr.utils.HadoopUtils;
+import voldemort.store.readonly.mr.utils.VoldemortUtils;
 import voldemort.store.readonly.swapper.InvalidBootstrapURLException;
 import voldemort.utils.ByteUtils;
 import voldemort.utils.EventThrottler;
@@ -219,6 +220,8 @@ public class HdfsFetcher implements FileFetcher {
         ObjectName jmxName = null;
         HdfsCopyStats stats = null;
         FileSystem fs = null;
+        sourceFileUrl = VoldemortUtils
+            .modifyURL(sourceFileUrl, voldemortConfig.getModifiedProtocol(), voldemortConfig.getModifiedPort());
         try {
             fs = HadoopUtils.getHadoopFileSystem(voldemortConfig, sourceFileUrl);
             final Path path = new Path(sourceFileUrl);

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/utils/VoldemortUtilsTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/utils/VoldemortUtilsTest.java
@@ -1,0 +1,59 @@
+package voldemort.store.readonly.mr.utils;
+
+import java.util.Properties;
+import junit.framework.TestCase;
+import voldemort.server.VoldemortConfig;
+import voldemort.store.readonly.fetcher.HdfsFetcher;
+
+
+/**
+ * Tests for VoldemortUtils.
+ */
+public class VoldemortUtilsTest extends TestCase {
+    public void testModifyURLByConfig() {
+        String url = "swebhdfs://localhost:50470/user/testpath";
+        Properties properties = new Properties();
+        properties.setProperty("node.id", "1");
+        properties.setProperty("voldemort.home", "/test");
+        VoldemortConfig config = new VoldemortConfig(properties);
+
+        //Default configuration. Should not modify url.
+        HdfsFetcher fetcher = new HdfsFetcher(config);
+        String newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getMysqlPort());
+        assertEquals(url, newUrl);
+
+        //Enable modify feature. URL should be replace to webhdfs with 50070 port number.
+        properties.setProperty("readonly.modify.protocol", "webhdfs");
+        properties.setProperty("readonly.modify.port", "50070");
+        config = new VoldemortConfig(properties);
+        newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
+        assertEquals("webhdfs://localhost:50070/user/testpath", newUrl);
+
+        //No modified protocol assigned. Should not modify URL.
+        properties.remove("readonly.modify.protocol");
+        config = new VoldemortConfig(properties);
+        newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
+        assertEquals(url, newUrl);
+
+        //No Modified port assigned. Should not modify URL.
+        properties.remove("readonly.modify.port");
+        properties.setProperty("readonly.modify.protocol", "testprotocol");
+        config = new VoldemortConfig(properties);
+        newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
+        assertEquals(url, newUrl);
+
+        //Local path. Should throw IAE because it's not a valid URL.
+        url = "/testpath/file";
+        properties.setProperty("readonly.modify.protocol", "webhdfs");
+        properties.setProperty("readonly.modify.port", "50070");
+        config = new VoldemortConfig(properties);
+        try {
+            VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
+        } catch (IllegalArgumentException iae) {
+            return;
+        } catch (Exception e) {
+            fail("Should met IAE. URL is not valid.");
+        }
+        fail("Should met IAE. URL is not valid.");
+    }
+}

--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -178,6 +178,8 @@ public class VoldemortConfig implements Serializable {
     private int readOnlyMaxValueBufferAllocationSize;
     private long readOnlyLoginIntervalMs;
     private long defaultStorageSpaceQuotaInKB;
+    private String modifiedProtocol;
+    private int modifiedPort;
 
     public static final String PUSH_HA_ENABLED = "push.ha.enabled";
     private boolean highAvailabilityPushEnabled;
@@ -401,6 +403,9 @@ public class VoldemortConfig implements Serializable {
         // property "readonly.compression.codec" to "GZIP"
         this.readOnlyCompressionCodec = props.getString("readonly.compression.codec",
                                                         VoldemortConfig.DEFAULT_RO_COMPRESSION_CODEC);
+
+        this.modifiedProtocol = props.getString("readonly.modify.protocol", null);
+        this.modifiedPort = props.getInt("readonly.modify.port", -1);
 
         this.highAvailabilityPushClusterId = props.getString(PUSH_HA_CLUSTER_ID, null);
         this.highAvailabilityPushLockPath = props.getString(PUSH_HA_LOCK_PATH, null);
@@ -3012,6 +3017,38 @@ public class VoldemortConfig implements Serializable {
      */
     public void setReadOnlySearchStrategy(String readOnlySearchStrategy) {
         this.readOnlySearchStrategy = readOnlySearchStrategy;
+    }
+
+    public String getModifiedProtocol() {
+        return this.modifiedProtocol;
+    }
+
+    /**
+     * Set modified protocol used to fetch file.
+     *
+     * <ul>
+     * <li>Property : "readonly.modify.protocol"</li>
+     * <li>Default : null</li>
+     * </ul>
+     */
+    public void setModifiedProtocol(String modifiedProtocol) {
+        this.modifiedProtocol = modifiedProtocol;
+    }
+
+    public int getModifiedPort() {
+        return this.modifiedPort;
+    }
+
+    /**
+     * Set modifed port used to fetch file.
+     *
+     * <ul>
+     * <li>Property : "readonly.modify.port"</li>
+     * <li>Default : -1</li>
+     * </ul>
+     */
+    public void setModifiedPort(int modifiedPort) {
+        this.modifiedPort = modifiedPort;
     }
 
     public boolean isHighAvailabilityPushEnabled() {


### PR DESCRIPTION
on or turn off SSL when fetching file from HDFS.

Fix the issue when url dose not contain protocl(Eg. local file path), parsing url will cause String index out of range exception.

Rollback the format change to original codes.

Make modify URL feature more generic and use java.net.URL instead of parsing URL mannually.

Move modify URL feature to Utils class. And let VoldemortSwapJob to invode this method to replace url.

Let voldemort node modify URL separately before fetching file.