### PR TITLE
BouncyCastle jar is required even when not enabled

### DIFF
--- a/src/java/voldemort/server/SetupSSLProvider.java
+++ b/src/java/voldemort/server/SetupSSLProvider.java
@@ -1,0 +1,11 @@
+package voldemort.server;
+
+import java.security.Security;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+public class SetupSSLProvider {
+    public static void useBouncyCastle() {
+        Security.insertProviderAt(new BouncyCastleProvider(), 1);
+    }
+}


### PR DESCRIPTION
For some background read this post
http://stackoverflow.com/questions/34259275/when-is-a-java-class-loaded/

This command failed before and after this patch it passed.
./gradlew clean jar && rm lib/bcprov-jdk15on-1.48.jar && bin/voldemort-server.sh config/single_node_cluster/

BouncyCastle jar is referenced from VoldemortServer and when
VoldemortServer class is loaded, all its references are resolved
which causes it to fail with ClassLoader error.

Added one more level of indirection to avoid the direct reference
and hence BouncyCastle is not required to be available in the class
path when not enabled.