### PR TITLE
Disabling Fetch Fails BnP HA

### DIFF
--- a/src/java/voldemort/client/protocol/admin/AdminClient.java
+++ b/src/java/voldemort/client/protocol/admin/AdminClient.java
@@ -121,6 +121,7 @@ import voldemort.versioning.Versioned;
 import voldemort.xml.ClusterMapper;
 import voldemort.xml.StoreDefinitionsMapper;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -1832,6 +1833,23 @@ public class AdminClient implements Closeable {
         }
 
         /**
+         * Ideally this function should be in the SerializerDefinition class,
+         * but that class already has different way of comparing Serializers.
+         * Not sure what will be the impact of refactoring that code.
+         * 
+         * @param oldDef
+         * @param newDef
+         * @return
+         */
+        private boolean seriailizerMetadataEquals(SerializerDefinition oldDef,
+                                                 SerializerDefinition newDef) {
+            if(!oldDef.getName().equals(newDef.getName())) {
+                return false;
+            }
+            return Objects.equal(oldDef.getCompression(), newDef.getCompression());
+        }
+
+        /**
          * This function ensures that a StoreDefinition exists on all online Voldemort Servers.
          *
          * These are the steps this function goes through:
@@ -1894,10 +1912,10 @@ public class AdminClient implements Closeable {
                             SerializerDefinition newValueSerializerDef = newStoreDef.getValueSerializer();
                             SerializerDefinition remoteKeySerializerDef = remoteStoreDef.getKeySerializer();
                             SerializerDefinition remoteValueSerializerDef = remoteStoreDef.getValueSerializer();
-                            String newKeySerDeName = newKeySerializerDef.getName();
                             String newValSerDeName = newValueSerializerDef.getName();
-                            if(remoteKeySerializerDef.getName().equals(newKeySerDeName)
-                                    && remoteValueSerializerDef.getName().equals(newValSerDeName)) {
+
+                            if(seriailizerMetadataEquals(remoteKeySerializerDef,newKeySerializerDef)
+                               && seriailizerMetadataEquals(remoteValueSerializerDef,newValueSerializerDef)) {
 
                                 Object remoteKeyDef, remoteValDef, localKeyDef, localValDef;
                                 if (newValSerDeName.equals(DefaultSerializerFactory.AVRO_GENERIC_VERSIONED_TYPE_NAME) ||

--- a/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
+++ b/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
@@ -1052,7 +1052,7 @@ public class AdminServiceRequestHandler implements RequestHandler {
                                                                                                             .setStatus("started");
         try {
             if(!metadataStore.getReadOnlyFetchEnabledUnlocked()) {
-                throw new VoldemortException("Read-only fetcher is disabled in "
+                throw new ReadOnlyFetchDisabledException("Read-only fetcher is disabled in "
                                              + metadataStore.getServerStateUnlocked()
                                              + " state on node " + metadataStore.getNodeId());
             }

--- a/src/java/voldemort/server/protocol/admin/ReadOnlyFetchDisabledException.java
+++ b/src/java/voldemort/server/protocol/admin/ReadOnlyFetchDisabledException.java
@@ -1,0 +1,17 @@
+package voldemort.server.protocol.admin;
+
+import voldemort.VoldemortApplicationException;
+
+/**
+ * This exception is thrown when fetch is disabled explicitly on the voldemort
+ * server you can see the state of the fetcher on a server by running the
+ * command
+ * 
+ * bin/vadmin.sh meta get readonly.fetch.enabled --url <AdminUrl>
+ */
+public class ReadOnlyFetchDisabledException extends VoldemortApplicationException {
+
+    public ReadOnlyFetchDisabledException(String s) {
+        super(s);
+    }
+}

--- a/src/java/voldemort/store/ErrorCodeMapper.java
+++ b/src/java/voldemort/store/ErrorCodeMapper.java
@@ -23,6 +23,7 @@ import voldemort.VoldemortApplicationException;
 import voldemort.VoldemortException;
 import voldemort.VoldemortUnsupportedOperationalException;
 import voldemort.server.protocol.admin.AsyncOperationStoppedException;
+import voldemort.server.protocol.admin.ReadOnlyFetchDisabledException;
 import voldemort.server.rebalance.AlreadyRebalancingException;
 import voldemort.server.rebalance.VoldemortRebalancingException;
 import voldemort.store.quota.QuotaExceededException;
@@ -66,6 +67,7 @@ public class ErrorCodeMapper {
         codeToException.put((short) 18, SlopStreamingDisabledException.class);
         codeToException.put((short) 19, InvalidBootstrapURLException.class);
         codeToException.put((short) 20, AsyncOperationStoppedException.class);
+        codeToException.put((short) 21, ReadOnlyFetchDisabledException.class);
 
         exceptionToCode = new HashMap<Class<? extends VoldemortException>, Short>();
         for(Map.Entry<Short, Class<? extends VoldemortException>> entry: codeToException.entrySet())
@@ -75,7 +77,8 @@ public class ErrorCodeMapper {
     public VoldemortException getError(short code, String message) {
         Class<? extends VoldemortException> klass = codeToException.get(code);
         if(klass == null)
-            return new UnknownFailure(Integer.toString(code));
+            return new UnknownFailure(message + ". Unrecognized error code: "
+                                      + Integer.toString(code));
         else
             return ReflectUtils.callConstructor(klass, new Object[] { message });
     }


### PR DESCRIPTION
When a node is in offline mode, it responds with fetch disabled
error. Currently the error is not treated as a soft error and this
fails the HA BnP.

With this code change, FetchDisabled is considered as a soft error
and the fetch will continue as normal.