### PR TITLE
Fix for a regression introduced in a706147

### DIFF
--- a/src/java/voldemort/store/readonly/JsonStoreBuilder.java
+++ b/src/java/voldemort/store/readonly/JsonStoreBuilder.java
@@ -255,7 +255,7 @@ public class JsonStoreBuilder {
 
     public void buildVersion0() throws IOException {
         logger.info("Building store " + storeDefinition.getName() + " for "
-                    + cluster.getNumberOfNodes() + " with " + numChunks
+                    + cluster.getNumberOfNodes() + " nodes with " + numChunks
                     + " chunks per node and type " + ReadOnlyStorageFormat.READONLY_V0);
 
         // initialize nodes

--- a/src/java/voldemort/store/readonly/StoreVersionManager.java
+++ b/src/java/voldemort/store/readonly/StoreVersionManager.java
@@ -78,7 +78,7 @@ public class StoreVersionManager {
         // Make sure versions missing from the file-system are cleaned up from the internal state
         for (Long version: versionToEnabledMap.keySet()) {
             File[] existingVersionDirs = ReadOnlyUtils.getVersionDirs(rootDir, version, version);
-            if (existingVersionDirs.length == 0) {
+            if (existingVersionDirs == null || existingVersionDirs.length == 0) {
                 removeVersion(version);
             }
         }

--- a/src/java/voldemort/store/readonly/chunk/ChunkedFileSet.java
+++ b/src/java/voldemort/store/readonly/chunk/ChunkedFileSet.java
@@ -563,11 +563,11 @@ public class ChunkedFileSet {
      * 
      * @param key Byte array of keys
      * @return Chunk id
+     * @throws IllegalStateException if unable to find the chunk id for the given key
      */
-    public int getChunkForKey(byte[] key) {
+    public int getChunkForKey(byte[] key) throws IllegalStateException {
         if(numChunks == 0) {
-            // The ChunkedFileSet is closed
-            return -1;
+            throw new IllegalStateException("The ChunkedFileSet is closed.");
         }
 
         switch(storageFormat) {
@@ -576,13 +576,13 @@ public class ChunkedFileSet {
             }
             case READONLY_V1: {
                 if(nodePartitionIds == null) {
-                    return -1;
+                    throw new IllegalStateException("nodePartitionIds is null.");
                 }
                 List<Integer> routingPartitionList = routingStrategy.getPartitionList(key);
                 routingPartitionList.retainAll(nodePartitionIds);
 
                 if(routingPartitionList.size() != 1) {
-                    return -1;
+                    throw new IllegalStateException("The key does not belong on this node.");
                 }
 
                 return chunkIdToChunkStart.get(routingPartitionList.get(0))
@@ -595,25 +595,31 @@ public class ChunkedFileSet {
                 Pair<Integer, Integer> bucket = null;
                 for(int replicaType = 0; replicaType < routingPartitionList.size(); replicaType++) {
                     if(nodePartitionIds == null) {
-                        return -1;
+                        throw new IllegalStateException("nodePartitionIds is null.");
                     }
                     if(nodePartitionIds.contains(routingPartitionList.get(replicaType))) {
                         if(bucket == null) {
                             bucket = Pair.create(routingPartitionList.get(0), replicaType);
                         } else {
-                            return -1;
+                            throw new IllegalStateException("Found more than one replica for a given partition on the current node!");
                         }
                     }
                 }
 
-                if(bucket == null)
-                    return -1;
+                if(bucket == null) {
+                    throw new IllegalStateException("The key does not belong on this node.");
+                }
 
-                return chunkIdToChunkStart.get(bucket)
-                       + ReadOnlyUtils.chunk(ByteUtils.md5(key), chunkIdToNumChunks.get(bucket));
+                Integer chunkStart = chunkIdToChunkStart.get(bucket);
+
+                if (chunkStart == null) {
+                    throw new IllegalStateException("chunkStart is null.");
+                }
+
+                return chunkStart + ReadOnlyUtils.chunk(ByteUtils.md5(key), chunkIdToNumChunks.get(bucket));
             }
             default: {
-                return -1;
+                throw new IllegalStateException("Unsupported storageFormat: " + storageFormat);
             }
         }
 

--- a/test/unit/voldemort/store/readonly/ReadOnlyStorageEngineTestInstance.java
+++ b/test/unit/voldemort/store/readonly/ReadOnlyStorageEngineTestInstance.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +89,8 @@ public class ReadOnlyStorageEngineTestInstance {
                                                            int repFactor,
                                                            SerializerDefinition keySerDef,
                                                            SerializerDefinition valueSerDef,
-                                                           ReadOnlyStorageFormat type)
+                                                           ReadOnlyStorageFormat type,
+                                                           int[][] partitionMap)
             throws Exception {
         // create some test data
         Map<String, String> data = createTestData(testSize);
@@ -99,12 +99,17 @@ public class ReadOnlyStorageEngineTestInstance {
         // set up definitions for cluster and store
         List<Node> nodes = new ArrayList<Node>();
         for(int i = 0; i < numNodes; i++) {
+            List<Integer> partitions = new ArrayList<Integer>(partitionMap[i].length);
+            for(int p: partitionMap[i]) {
+                partitions.add(p);
+            }
+
             nodes.add(new Node(i,
                                "localhost",
                                8080 + i,
                                6666 + i,
                                7000 + i,
-                               Arrays.asList(4 * i, 4 * i + 1, 4 * i + 2, 4 * i + 3)));
+                               partitions));
         }
         Cluster cluster = new Cluster("test", nodes);
         StoreDefinition storeDef = new StoreDefinitionBuilder().setName("test")


### PR DESCRIPTION
Under certain partition assignment configurations, servers would skip the
initialization of certain partitions, which would then result in NPEs getting
thrown during get requests. This issue is now fixed.

In addition to that, the following changes are also included in this commit:
- More comprehensive tests in ReadOnlyStorageEngineTest to catch the edge case.
- Better error reporting in ChunkedFileSet.getChunkForKey(byte[] key).

Currently re-running all unit tests. Will report back when that's finished.