### PR TITLE
AdminClient does not obey the Client Timeout

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -27,8 +27,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.management.ObjectName;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -36,9 +34,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Logger;
 
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.routing.RoutingStrategy;
 import voldemort.routing.RoutingStrategyFactory;
@@ -62,6 +58,9 @@ import voldemort.utils.JmxUtils;
 import voldemort.utils.Time;
 import voldemort.utils.Utils;
 import voldemort.versioning.Versioned;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * A {@link FileFetcher} implementation that fetches the store files from HDFS
@@ -199,9 +198,7 @@ public class HdfsFetcher implements FileFetcher {
                       MetadataStore metadataStore) throws Exception {
         AdminClient adminClient = null;
         try {
-            adminClient = new AdminClient(metadataStore.getCluster(),
-                                          new AdminClientConfig(),
-                                          new ClientConfig());
+            adminClient = new AdminClient(metadataStore.getCluster());
 
             Versioned<String> diskQuotaSize = adminClient.quotaMgmtOps.getQuotaForNode(storeName,
                                                                                        QuotaType.STORAGE_SPACE,

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.avro.Schema;
 import org.apache.avro.mapred.AvroInputFormat;
@@ -48,7 +49,6 @@ import org.apache.log4j.Logger;
 import voldemort.VoldemortException;
 import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.client.protocol.pb.VAdminProto;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
@@ -190,7 +190,9 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
         for(String url: Utils.COMMA_SEP.split(clusterUrlText.trim())) {
             if(url.trim().length() > 0) {
                 this.clusterURLs.add(url);
-                AdminClient adminClient = new AdminClient(url, new AdminClientConfig(), new ClientConfig());
+                AdminClient adminClient = new AdminClient(new ClientConfig().setBootstrapUrls(url)
+                                                                            .setConnectionTimeout(15,
+                                                                                                  TimeUnit.SECONDS));
                 this.adminClientPerCluster.put(url, adminClient);
                 this.closeables.add(adminClient);
             }

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortRollbackJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortRollbackJob.java
@@ -27,9 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.log4j.Logger;
 
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.store.readonly.mr.utils.VoldemortUtils;
@@ -76,9 +74,7 @@ public class VoldemortRollbackJob extends AbstractJob {
             ExecutorService service = null;
             try {
                 service = Executors.newCachedThreadPool();
-                adminClient = new AdminClient(clusterUrl,
-                                              new AdminClientConfig(),
-                                              new ClientConfig());
+                adminClient = new AdminClient(clusterUrl);
                 Cluster cluster = adminClient.getAdminClientCluster();
                 AdminStoreSwapper swapper = new AdminStoreSwapper(
                         cluster,

--- a/src/java/voldemort/VoldemortAdminTool.java
+++ b/src/java/voldemort/VoldemortAdminTool.java
@@ -64,9 +64,7 @@ import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.map.ObjectMapper;
 
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.client.protocol.admin.QueryKeyResult;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
@@ -382,9 +380,7 @@ public class VoldemortAdminTool {
             int parallelism = CmdUtils.valueOf(options, "restore", 5);
             Integer zoneId = CmdUtils.valueOf(options, "zone", -1);
 
-            AdminClient adminClient = new AdminClient(url,
-                                                      new AdminClientConfig(),
-                                                      new ClientConfig());
+            AdminClient adminClient = new AdminClient(url);
 
             List<String> storeNames = null;
             if(options.has("store") && options.has("stores")) {

--- a/src/java/voldemort/VoldemortAvroClientShell.java
+++ b/src/java/voldemort/VoldemortAvroClientShell.java
@@ -16,7 +16,6 @@ import voldemort.client.SocketStoreClientFactory;
 import voldemort.client.StoreClientFactory;
 import voldemort.client.protocol.RequestFormatType;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.store.StoreDefinition;
 import voldemort.utils.Pair;
 import voldemort.utils.Utils;
@@ -104,7 +103,7 @@ public class VoldemortAvroClientShell {
 
         AdminClient adminClient = null;
         try {
-            adminClient = new AdminClient(url, new AdminClientConfig(), new ClientConfig());
+            adminClient = new AdminClient(url);
             List<StoreDefinition> storeDefs = adminClient.metadataMgmtOps.getRemoteStoreDefList()
                                                                          .getValue();
 

--- a/src/java/voldemort/VoldemortClientShell.java
+++ b/src/java/voldemort/VoldemortClientShell.java
@@ -49,9 +49,8 @@ import voldemort.client.SocketStoreClientFactory;
 import voldemort.client.StoreClient;
 import voldemort.client.protocol.RequestFormatType;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
-import voldemort.cluster.Node;
 import voldemort.cluster.Cluster;
+import voldemort.cluster.Node;
 import voldemort.cluster.failuredetector.FailureDetector;
 import voldemort.routing.RoutingStrategy;
 import voldemort.routing.RoutingStrategyFactory;
@@ -115,19 +114,18 @@ public class VoldemortClientShell {
         this.commandOutput = commandOutput;
         this.errorStream = errorStream;
 
-        String bootstrapUrl = clientConfig.getBootstrapUrls()[0];
-
         try {
             factory = new SocketStoreClientFactory(clientConfig);
             client = factory.getStoreClient(storeName);
-            adminClient = new AdminClient(bootstrapUrl, new AdminClientConfig(), clientConfig);
+            adminClient = new AdminClient(clientConfig);
 
             storeDef = StoreUtils.getStoreDef(factory.getStoreDefs(), storeName);
 
 	    Cluster cluster = adminClient.getAdminClientCluster();
 	    routingStrategy = new RoutingStrategyFactory().updateRoutingStrategy(storeDef, cluster);
 
-            commandOutput.println("Established connection to " + storeName + " via " + bootstrapUrl);
+            commandOutput.println("Established connection to " + storeName + " via "
+                                  + Arrays.toString(clientConfig.getBootstrapUrls()));
             commandOutput.print(PROMPT);
         } catch(Exception e) {
             safeClose();

--- a/src/java/voldemort/client/protocol/admin/BaseStreamingClient.java
+++ b/src/java/voldemort/client/protocol/admin/BaseStreamingClient.java
@@ -35,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.log4j.Logger;
 
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.RequestFormatType;
 import voldemort.client.protocol.pb.ProtoUtils;
 import voldemort.client.protocol.pb.VAdminProto;
@@ -102,7 +101,7 @@ public class BaseStreamingClient {
     protected EventThrottler throttler;
 
     protected AdminClient adminClient;
-    private AdminClientConfig adminClientConfig;
+    private final AdminClientConfig adminClientConfig = new AdminClientConfig();
 
     String bootstrapURL;
 
@@ -137,8 +136,7 @@ public class BaseStreamingClient {
         THROTTLE_QPS = config.getThrottleQPS();
         this.overWriteIfLatestTs = config.isOverWriteIfLatestTs();
 
-        adminClientConfig = new AdminClientConfig();
-        adminClient = new AdminClient(bootstrapURL, adminClientConfig, new ClientConfig());
+        adminClient = new AdminClient(bootstrapURL);
         faultyNodes = new ArrayList<Integer>();
         storeNames = new ArrayList<String>();
         nodesToStream = new ArrayList<Node>();

--- a/src/java/voldemort/client/rebalance/RebalanceController.java
+++ b/src/java/voldemort/client/rebalance/RebalanceController.java
@@ -27,9 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.log4j.Logger;
 
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.client.rebalance.task.RebalanceTask;
 import voldemort.client.rebalance.task.StealerBasedRebalanceTask;
 import voldemort.cluster.Cluster;
@@ -66,9 +64,7 @@ public class RebalanceController {
     public RebalanceController(String bootstrapUrl,
                                int maxParallelRebalancing,
                                long proxyPauseSec) {
-        this.adminClient = new AdminClient(bootstrapUrl,
-                                           new AdminClientConfig(),
-                                           new ClientConfig());
+        this.adminClient = new AdminClient(bootstrapUrl);
         Pair<Cluster, List<StoreDefinition>> pair = getCurrentClusterState();
         this.currentCluster = pair.getFirst();
         this.currentStoreDefs = pair.getSecond();

--- a/src/java/voldemort/cluster/Cluster.java
+++ b/src/java/voldemort/cluster/Cluster.java
@@ -334,6 +334,22 @@ public class Cluster implements Serializable {
          */
     }
 
+    public List<String> getBootStrapUrls() {
+        return getBootStrapUrls(5);
+    }
+
+    public List<String> getBootStrapUrls(int maxSize) {
+        List<String> bootStrapUrls = new ArrayList<String>();
+        for(Node node: getNodes()) {
+            if(bootStrapUrls.size() >= maxSize) {
+                break;
+            }
+            String bootStrapUrl = node.getSocketUrl().toString();
+            bootStrapUrls.add(bootStrapUrl);
+        }
+        return bootStrapUrls;
+    }
+
     @Override
     public boolean equals(Object second) {
         if(this == second)

--- a/src/java/voldemort/cluster/failuredetector/AdminConnectionVerifier.java
+++ b/src/java/voldemort/cluster/failuredetector/AdminConnectionVerifier.java
@@ -45,7 +45,8 @@ public class AdminConnectionVerifier implements ConnectionVerifier {
         if (adminClient == null) {
             adminClient = new AdminClient(this.cluster,
                                           new AdminClientConfig(),
-                                          new ClientConfig().setSelectors(1));
+                                          new ClientConfig().setSelectors(1)
+                                                            .setBootstrapUrls(this.cluster.getBootStrapUrls()));
         }
         return adminClient;
     }

--- a/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
+++ b/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
@@ -34,10 +34,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.VoldemortFilter;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.client.protocol.admin.filter.DefaultVoldemortFilter;
 import voldemort.client.protocol.pb.ProtoUtils;
 import voldemort.client.protocol.pb.VAdminProto;
@@ -1683,9 +1681,7 @@ public class AdminServiceRequestHandler implements RequestHandler {
             StoreDefinitionsMapper mapper = new StoreDefinitionsMapper();
             StoreDefinition def = mapper.readStore(new StringReader(request.getStoreDefinition()));
 
-            adminClient = new AdminClient(metadataStore.getCluster(),
-                                          new AdminClientConfig(),
-                                          new ClientConfig());
+            adminClient = new AdminClient(metadataStore.getCluster());
 
             synchronized(lock) {
                 // only allow a single store to be created at a time. We'll see

--- a/src/java/voldemort/server/scheduler/slop/StreamingSlopPusherJob.java
+++ b/src/java/voldemort/server/scheduler/slop/StreamingSlopPusherJob.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.log4j.Logger;
 
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
 import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
@@ -128,8 +127,7 @@ public class StreamingSlopPusherJob extends SlopPusherJob implements Runnable {
 
         if(adminClient == null) {
             adminClient = new AdminClient(cluster,
-                                          new AdminClientConfig().setMaxConnectionsPerNode(1),
-                                          new ClientConfig());
+                                          new AdminClientConfig().setMaxConnectionsPerNode(1));
         }
 
         if(voldemortConfig.getSlopZonesDownToTerminate() > 0) {

--- a/src/java/voldemort/store/readonly/swapper/AdminStoreSwapper.java
+++ b/src/java/voldemort/store/readonly/swapper/AdminStoreSwapper.java
@@ -1,25 +1,5 @@
 package voldemort.store.readonly.swapper;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
-import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
-import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
-import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
-import voldemort.cluster.Cluster;
-import voldemort.cluster.Node;
-import voldemort.store.quota.QuotaExceededException;
-import voldemort.store.readonly.ReadOnlyUtils;
-import voldemort.utils.CmdUtils;
-import voldemort.utils.Time;
-import voldemort.utils.logging.PrefixedLogger;
-import voldemort.xml.ClusterMapper;
-
 import java.io.File;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -34,6 +14,27 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+
+import voldemort.VoldemortException;
+import voldemort.client.protocol.admin.AdminClient;
+import voldemort.cluster.Cluster;
+import voldemort.cluster.Node;
+import voldemort.store.quota.QuotaExceededException;
+import voldemort.store.readonly.ReadOnlyUtils;
+import voldemort.utils.CmdUtils;
+import voldemort.utils.Time;
+import voldemort.utils.logging.PrefixedLogger;
+import voldemort.xml.ClusterMapper;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 
 public class AdminStoreSwapper {
 
@@ -387,7 +388,7 @@ public class AdminStoreSwapper {
         String clusterStr = FileUtils.readFileToString(new File(clusterXml));
         Cluster cluster = new ClusterMapper().readCluster(new StringReader(clusterStr));
         ExecutorService executor = Executors.newFixedThreadPool(cluster.getNumberOfNodes());
-        AdminClient adminClient = new AdminClient(cluster, new AdminClientConfig(), new ClientConfig());
+        AdminClient adminClient = new AdminClient(cluster);
         AdminStoreSwapper swapper = new AdminStoreSwapper(cluster, executor, adminClient, timeoutMs);
 
         try {

--- a/src/java/voldemort/tools/DeleteKeysCLI.java
+++ b/src/java/voldemort/tools/DeleteKeysCLI.java
@@ -48,7 +48,6 @@ import voldemort.client.SocketStoreClientFactory;
 import voldemort.client.StoreClient;
 import voldemort.client.protocol.RequestFormatType;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Node;
 import voldemort.cluster.Zone;
 import voldemort.serialization.DefaultSerializerFactory;
@@ -201,7 +200,7 @@ public class DeleteKeysCLI {
             if(adminUrl == null || adminUrl.length() == 0) {
                 throw new Exception("When deleting from a specific node admin URL is expected");
             }
-            adminClient = new AdminClient(adminUrl, new AdminClientConfig(), clientConfig);
+            adminClient = new AdminClient(adminUrl);
         } else {
             adminClient = null;
         }

--- a/src/java/voldemort/tools/KeySamplerCLI.java
+++ b/src/java/voldemort/tools/KeySamplerCLI.java
@@ -41,9 +41,7 @@ import joptsimple.OptionSet;
 import org.apache.log4j.Logger;
 
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.store.StoreDefinition;
@@ -93,7 +91,7 @@ public class KeySamplerCLI {
         if(logger.isInfoEnabled()) {
             logger.info("Connecting to bootstrap server: " + url);
         }
-        this.adminClient = new AdminClient(url, new AdminClientConfig(), new ClientConfig());
+        this.adminClient = new AdminClient(url);
         this.cluster = adminClient.getAdminClientCluster();
         this.storeDefinitions = adminClient.metadataMgmtOps.getRemoteStoreDefList().getValue();
         this.storeNameSet = new HashSet<String>();

--- a/src/java/voldemort/tools/KeyVersionFetcherCLI.java
+++ b/src/java/voldemort/tools/KeyVersionFetcherCLI.java
@@ -45,15 +45,13 @@ import joptsimple.OptionSet;
 import org.apache.commons.codec.DecoderException;
 import org.apache.log4j.Logger;
 
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.routing.BaseStoreRoutingPlan;
 import voldemort.store.StoreDefinition;
+import voldemort.utils.ByteArray;
 import voldemort.utils.ByteUtils;
 import voldemort.utils.Utils;
-import voldemort.utils.ByteArray;
 import voldemort.versioning.Version;
 import voldemort.versioning.Versioned;
 
@@ -107,9 +105,7 @@ public class KeyVersionFetcherCLI {
         clientProps.put("socket_timeout_ms", "10000");
         clientProps.put("failuredetector_threshold", "10");
 
-        this.adminClient = new AdminClient(url,
-                                           new AdminClientConfig(),
-                                           new ClientConfig(clientProps));
+        this.adminClient = new AdminClient(url);
         this.cluster = adminClient.getAdminClientCluster();
         this.storeDefinitions = adminClient.metadataMgmtOps.getRemoteStoreDefList(cluster.getNodeIds()
                                                                                          .iterator()

--- a/src/java/voldemort/tools/ReadOnlyReplicationHelperCLI.java
+++ b/src/java/voldemort/tools/ReadOnlyReplicationHelperCLI.java
@@ -29,16 +29,13 @@ import joptsimple.OptionSet;
 
 import org.apache.log4j.Logger;
 
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.routing.RoutingStrategy;
 import voldemort.routing.RoutingStrategyFactory;
 import voldemort.store.StoreDefinition;
 import voldemort.store.readonly.ReadOnlyStorageConfiguration;
-import voldemort.store.readonly.ReadOnlyStorageFormat;
 import voldemort.utils.CmdUtils;
 import voldemort.utils.Utils;
 
@@ -299,7 +296,7 @@ public class ReadOnlyReplicationHelperCLI {
         }
         Boolean local = options.has(OPT_LOCAL);
 
-        AdminClient adminClient = new AdminClient(url, new AdminClientConfig(), new ClientConfig());
+        AdminClient adminClient = new AdminClient(url);
 
         outputStream.println("src_host_name,src_node_id,src_rel_path,dest_rel_path");
 

--- a/src/java/voldemort/tools/ReplaceNodeCLI.java
+++ b/src/java/voldemort/tools/ReplaceNodeCLI.java
@@ -18,9 +18,7 @@ import joptsimple.OptionSet;
 import org.apache.log4j.Logger;
 
 import voldemort.VoldemortApplicationException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.cluster.Zone;
@@ -71,10 +69,8 @@ public class ReplaceNodeCLI {
     }
 
     private void init() {
-        this.adminClient = new AdminClient(this.url, new AdminClientConfig(), new ClientConfig());
-        this.newAdminClient = new AdminClient(this.newUrl,
-                                              new AdminClientConfig(),
-                                              new ClientConfig());
+        this.adminClient = new AdminClient(this.url);
+        this.newAdminClient = new AdminClient(this.newUrl);
 
         this.cluster = adminClient.getAdminClientCluster();
         this.newCluster = newAdminClient.getAdminClientCluster();

--- a/src/java/voldemort/tools/ZoneShrinkageCLI.java
+++ b/src/java/voldemort/tools/ZoneShrinkageCLI.java
@@ -30,9 +30,7 @@ import joptsimple.OptionSet;
 
 import org.apache.log4j.Logger;
 
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.store.StoreDefinition;
@@ -106,9 +104,7 @@ public class ZoneShrinkageCLI {
     }
 
     public ZoneShrinkageCLI(String url, Integer droppingZoneId) {
-        AdminClientConfig acc = new AdminClientConfig();
-        ClientConfig cc = new ClientConfig();
-        adminClient = new AdminClient(url, acc, cc);
+        adminClient = new AdminClient(url);
         this.droppingZoneId = droppingZoneId;
         this.bootstrapUrl = url;
     }

--- a/src/java/voldemort/tools/admin/AdminToolUtils.java
+++ b/src/java/voldemort/tools/admin/AdminToolUtils.java
@@ -20,12 +20,16 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Node;
 import voldemort.store.StoreDefinition;
 import voldemort.store.UnreachableStoreException;
@@ -155,7 +159,7 @@ public class AdminToolUtils {
      * @return Newly constructed AdminClient
      */
     public static AdminClient getAdminClient(String url) {
-        return new AdminClient(url, new AdminClientConfig(), new ClientConfig());
+        return new AdminClient(url);
     }
 
     /**

--- a/src/java/voldemort/utils/ClusterForkLiftTool.java
+++ b/src/java/voldemort/utils/ClusterForkLiftTool.java
@@ -21,9 +21,7 @@ import org.apache.log4j.Logger;
 
 import voldemort.VoldemortApplicationException;
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.client.protocol.admin.BaseStreamingClient;
 import voldemort.client.protocol.admin.QueryKeyResult;
 import voldemort.client.protocol.admin.StreamingClientConfig;
@@ -170,9 +168,7 @@ public class ClusterForkLiftTool implements Runnable {
             throw new IllegalArgumentException("One or more stores expected");
         }
         // set up AdminClient on source cluster
-        this.srcAdminClient = new AdminClient(srcBootstrapUrl,
-                                              new AdminClientConfig(),
-                                              new ClientConfig());
+        this.srcAdminClient = new AdminClient(srcBootstrapUrl);
 
         // set up streaming client to the destination cluster
         Props props = new Props();

--- a/src/java/voldemort/utils/ConsistencyCheck.java
+++ b/src/java/voldemort/utils/ConsistencyCheck.java
@@ -17,8 +17,8 @@ package voldemort.utils;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
-import java.io.Writer;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,9 +36,7 @@ import joptsimple.OptionSet;
 import org.apache.log4j.Logger;
 
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.routing.RoutingStrategyFactory;
@@ -96,9 +94,7 @@ public class ConsistencyCheck {
             if(logger.isInfoEnabled()) {
                 logger.info("Connecting to bootstrap server: " + url);
             }
-            AdminClient adminClient = new AdminClient(url,
-                    new AdminClientConfig(),
-                    new ClientConfig());
+            AdminClient adminClient = new AdminClient(url);
             adminClients.add(adminClient);
             /* get Cluster */
             Cluster cluster = adminClient.getAdminClientCluster();

--- a/src/java/voldemort/utils/ConsistencyFix.java
+++ b/src/java/voldemort/utils/ConsistencyFix.java
@@ -39,9 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.log4j.Logger;
 
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.client.protocol.admin.QueryKeyResult;
 import voldemort.cluster.Cluster;
 import voldemort.routing.StoreRoutingPlan;
@@ -74,7 +72,7 @@ public class ConsistencyFix {
                    boolean parseOnly) {
         this.storeName = storeName;
         logger.info("Connecting to bootstrap server: " + url);
-        this.adminClient = new AdminClient(url, new AdminClientConfig(), new ClientConfig());
+        this.adminClient = new AdminClient(url);
         Cluster cluster = adminClient.getAdminClientCluster();
         logger.info("Cluster determined to be: " + cluster.getName());
 

--- a/test/common/voldemort/ServerTestUtils.java
+++ b/test/common/voldemort/ServerTestUtils.java
@@ -41,12 +41,10 @@ import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;
 
-import voldemort.client.ClientConfig;
 import voldemort.client.RoutingTier;
 import voldemort.client.protocol.RequestFormatFactory;
 import voldemort.client.protocol.RequestFormatType;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.cluster.Zone;
@@ -1016,14 +1014,11 @@ public class ServerTestUtils {
     }
 
     public static AdminClient getAdminClient(Cluster cluster) {
-
-        AdminClientConfig config = new AdminClientConfig();
-        return new AdminClient(cluster, config, new ClientConfig());
+        return new AdminClient(cluster);
     }
 
     public static AdminClient getAdminClient(String bootstrapURL) {
-        AdminClientConfig config = new AdminClientConfig();
-        return new AdminClient(bootstrapURL, config, new ClientConfig());
+        return new AdminClient(bootstrapURL);
     }
 
     public static RequestHandlerFactory getSocketRequestHandlerFactory(StoreRepository repository) {

--- a/test/integration/voldemort/performance/RequestFileFilter.java
+++ b/test/integration/voldemort/performance/RequestFileFilter.java
@@ -28,9 +28,7 @@ import java.util.Set;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.routing.RoutingStrategy;
@@ -157,9 +155,7 @@ public class RequestFileFilter {
         String outputFile = (String) options.valueOf("output");
         boolean stringKeys = options.has("string-keys");
 
-        AdminClient adminClient = new AdminClient(bootstrapURL,
-                                                  new AdminClientConfig(),
-                                                  new ClientConfig());
+        AdminClient adminClient = new AdminClient(bootstrapURL);
         List<StoreDefinition> storeDefinitionList = adminClient.metadataMgmtOps.getRemoteStoreDefList(nodeId)
                                                                                .getValue();
 

--- a/test/unit/voldemort/client/AdminServiceBasicTest.java
+++ b/test/unit/voldemort/client/AdminServiceBasicTest.java
@@ -172,9 +172,7 @@ public class AdminServiceBasicTest {
 
         Properties adminProperties = new Properties();
         adminProperties.setProperty("max_connections", "20");
-        adminClient = new AdminClient(cluster,
-                                      new AdminClientConfig(adminProperties),
-                                      new ClientConfig());
+        adminClient = new AdminClient(cluster, new AdminClientConfig(adminProperties));
 
         Node node = cluster.getNodeById(0);
         String bootstrapUrl = "tcp://" + node.getHost() + ":" + node.getSocketPort();

--- a/test/unit/voldemort/client/AtomicSetMetadataPairTest.java
+++ b/test/unit/voldemort/client/AtomicSetMetadataPairTest.java
@@ -36,7 +36,6 @@ import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
 import voldemort.VoldemortAdminTool;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.server.VoldemortServer;
@@ -143,9 +142,7 @@ public class AtomicSetMetadataPairTest {
     public void testClusterAndStoresAreSetAtomically() {
         try {
 
-            AdminClient adminClient = new AdminClient(bootStrapUrls[0],
-                                                      new AdminClientConfig(),
-                                                      new ClientConfig());
+            AdminClient adminClient = new AdminClient(bootStrapUrls[0]);
 
             StoreDefinitionsMapper storeDefsMapper = new StoreDefinitionsMapper();
             List<StoreDefinition> storeDefs = storeDefsMapper.readStoreList(new File(newStoresXmlfile));

--- a/test/unit/voldemort/client/EndToEndRebootstrapTest.java
+++ b/test/unit/voldemort/client/EndToEndRebootstrapTest.java
@@ -35,7 +35,6 @@ import voldemort.ServerTestUtils;
 import voldemort.VoldemortAdminTool;
 import voldemort.VoldemortException;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.common.service.SchedulerService;
@@ -184,10 +183,9 @@ public class EndToEndRebootstrapTest {
             // Get bootstraptime at start
             String bootstrapTime = getPropertyFromClientInfo("bootstrapTime");
             // Update cluster.xml metadata
-            AdminClient adminClient = new AdminClient(bootStrapUrls[0],
-                                                      new AdminClientConfig(),
-                                                      new ClientConfig(),
-                                                      CLIENT_ZONE_ID);
+            ClientConfig clientConfig = new ClientConfig().setBootstrapUrls(bootStrapUrls)
+                                                          .setClientZoneId(CLIENT_ZONE_ID);
+            AdminClient adminClient = new AdminClient(clientConfig);
             for(Node node: cluster.getNodes()) {
                 VoldemortAdminTool.executeSetMetadata(node.getId(),
                                                       adminClient,
@@ -228,10 +226,10 @@ public class EndToEndRebootstrapTest {
             // Get bootstraptime at start
             String bootstrapTime = getPropertyFromClientInfo("bootstrapTime");
             // Update cluster.xml metadata
-            AdminClient adminClient = new AdminClient(bootStrapUrls[0],
-                                                      new AdminClientConfig(),
-                                                      new ClientConfig(),
-                                                      CLIENT_ZONE_ID);
+            ClientConfig clientConfig = new ClientConfig().setBootstrapUrls(bootStrapUrls)
+                                                          .setClientZoneId(CLIENT_ZONE_ID);
+
+            AdminClient adminClient = new AdminClient(clientConfig);
             StoreDefinitionsMapper storeDefsMapper = new StoreDefinitionsMapper();
             List<StoreDefinition> storeDefs = storeDefsMapper.readStoreList(new File(storesXmlfile));
             for (Node node: cluster.getNodes()) {

--- a/test/unit/voldemort/client/OfflineStateTest.java
+++ b/test/unit/voldemort/client/OfflineStateTest.java
@@ -126,9 +126,7 @@ public class OfflineStateTest {
 
         Properties adminProperties = new Properties();
         adminProperties.setProperty("max_connections", "20");
-        adminClient = new AdminClient(cluster,
-                                      new AdminClientConfig(adminProperties),
-                                      new ClientConfig());
+        adminClient = new AdminClient(cluster, new AdminClientConfig(adminProperties));
 
         Node node = cluster.getNodeById(0);
         String bootstrapUrl = "tcp://" + node.getHost() + ":" + node.getSocketPort();

--- a/test/unit/voldemort/client/QuotaResetterTest.java
+++ b/test/unit/voldemort/client/QuotaResetterTest.java
@@ -91,9 +91,7 @@ public class QuotaResetterTest {
 
         Properties adminProperties = new Properties();
         adminProperties.setProperty("max_connections", "20");
-        adminClient = new AdminClient(cluster,
-                                      new AdminClientConfig(adminProperties),
-                                      new ClientConfig());
+        adminClient = new AdminClient(cluster, new AdminClientConfig(adminProperties));
     }
 
     @After

--- a/test/unit/voldemort/client/ReplaceNodeTest.java
+++ b/test/unit/voldemort/client/ReplaceNodeTest.java
@@ -18,7 +18,6 @@ import org.junit.Test;
 
 import voldemort.ServerTestUtils;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.server.VoldemortConfig;
@@ -218,9 +217,7 @@ public class ReplaceNodeTest {
 
     private void verifyNewNodePartOfCluster(Node replacementNode) {
         // Verify if new node is part of the new cluster.
-        Cluster cluster = new AdminClient(originalBootstrapUrl,
-                                          new AdminClientConfig(),
-                                          new ClientConfig()).getAdminClientCluster();
+        Cluster cluster = new AdminClient(originalBootstrapUrl).getAdminClientCluster();
 
         boolean isNewNodePresent = false;
         for(Node curNode: cluster.getNodes()) {

--- a/test/unit/voldemort/client/rebalance/ZoneShrinkageClientTest.java
+++ b/test/unit/voldemort/client/rebalance/ZoneShrinkageClientTest.java
@@ -68,8 +68,7 @@ public class ZoneShrinkageClientTest {
         Properties adminProperties = new Properties();
         adminProperties.setProperty("max_connections", "2");
         adminClient = new AdminClient(servers[0].getMetadataStore().getCluster(),
-                                      new AdminClientConfig(adminProperties),
-                                      new ClientConfig());
+                                      new AdminClientConfig(adminProperties));
     }
 
     @Test

--- a/test/unit/voldemort/client/rebalance/ZoneShrinkageEndToEndTest.java
+++ b/test/unit/voldemort/client/rebalance/ZoneShrinkageEndToEndTest.java
@@ -37,10 +37,8 @@ import voldemort.ClusterTestUtils;
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
 import voldemort.VoldemortAdminTool;
-import voldemort.client.ClientConfig;
 import voldemort.client.ClientTrafficGenerator;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.routing.ConsistentRoutingStrategy;
@@ -336,10 +334,7 @@ public class ZoneShrinkageEndToEndTest {
         logger.info("        UPDATING BOTH XML      ");
         logger.info("-------------------------------");
 
-        // get admin client
-        AdminClientConfig adminClientConfig = new AdminClientConfig();
-        ClientConfig clientConfigForAdminClient = new ClientConfig();
-        adminClient = new AdminClient(bootstrapURL, adminClientConfig, clientConfigForAdminClient);
+        adminClient = new AdminClient(bootstrapURL);
 
         // set stores metadata (simulating admin tools)
         String validatedStoresXML = storeDefinitionsMapper.writeStoreList(storeDefinitionsMapper.readStoreList(new StringReader(finalStoresXML)));

--- a/test/unit/voldemort/scheduled/SlopPurgeTest.java
+++ b/test/unit/voldemort/scheduled/SlopPurgeTest.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
 import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
@@ -72,8 +71,7 @@ public class SlopPurgeTest {
         Properties adminProperties = new Properties();
         adminProperties.setProperty("max_connections", "2");
         adminClient = new AdminClient(servers[0].getMetadataStore().getCluster(),
-                                      new AdminClientConfig(adminProperties),
-                                      new ClientConfig());
+                                      new AdminClientConfig(adminProperties));
     }
 
     private int numSlopsInServer(List<Versioned<Slop>> slops) {

--- a/test/unit/voldemort/scheduled/SlopPusherDeadSlopTest.java
+++ b/test/unit/voldemort/scheduled/SlopPusherDeadSlopTest.java
@@ -22,7 +22,6 @@ import org.junit.runners.Parameterized.Parameters;
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
 import voldemort.VoldemortTestConstants;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
 import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
@@ -83,8 +82,7 @@ public class SlopPusherDeadSlopTest {
             Properties adminProperties = new Properties();
             adminProperties.setProperty("max_connections", "2");
             adminClient = new AdminClient(servers[0].getMetadataStore().getCluster(),
-                                          new AdminClientConfig(adminProperties),
-                                          new ClientConfig());
+                                          new AdminClientConfig(adminProperties));
         } catch(Exception e) {
             logger.error("Error in setup", e);
             throw e;

--- a/test/unit/voldemort/server/gossip/GossiperTest.java
+++ b/test/unit/voldemort/server/gossip/GossiperTest.java
@@ -39,9 +39,7 @@ import org.junit.runners.Parameterized.Parameters;
 import voldemort.Attempt;
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.server.VoldemortServer;
@@ -156,7 +154,7 @@ public class GossiperTest {
     }
 
     private AdminClient getAdminClient(Cluster newCluster) {
-        return new AdminClient(newCluster, new AdminClientConfig(), new ClientConfig());
+        return new AdminClient(newCluster);
     }
 
     private Cluster attemptStartAdditionalServer() throws IOException {

--- a/test/unit/voldemort/server/quota/ExceededQuotaSlopTest.java
+++ b/test/unit/voldemort/server/quota/ExceededQuotaSlopTest.java
@@ -89,8 +89,7 @@ public class ExceededQuotaSlopTest {
         Properties adminProperties = new Properties();
         adminProperties.setProperty("max_connections", "2");
         adminClient = new AdminClient(cluster,
-                                      new AdminClientConfig(adminProperties),
-                                      new ClientConfig());
+                                      new AdminClientConfig().setMaxConnectionsPerNode(2));
 
         Map<Pair<Integer, QuotaType>, Integer> throughPutMap = new HashMap<Pair<Integer, QuotaType>, Integer>();
         // Set Node0 Quota

--- a/test/unit/voldemort/server/quota/QuotaLimitingStoreTest.java
+++ b/test/unit/voldemort/server/quota/QuotaLimitingStoreTest.java
@@ -21,7 +21,6 @@ import voldemort.client.ClientConfig;
 import voldemort.client.SocketStoreClientFactory;
 import voldemort.client.StoreClient;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.server.VoldemortServer;
 import voldemort.store.configuration.FileBackedCachingStorageEngine;
 import voldemort.store.memory.InMemoryStorageEngine;
@@ -59,9 +58,7 @@ public class QuotaLimitingStoreTest {
         server = ServerTestUtils.startStandAloneVoldemortServer(props,
                                                                 "test/common/voldemort/config/single-store.xml");
 
-        adminClient = new AdminClient(server.getMetadataStore().getCluster(),
-                                      new AdminClientConfig(),
-                                      new ClientConfig());
+        adminClient = new AdminClient(server.getMetadataStore().getCluster());
         String bootStrapUrl = "tcp://" + server.getIdentityNode().getHost() + ":"
                               + server.getIdentityNode().getSocketPort();
         factory = new SocketStoreClientFactory(new ClientConfig().setBootstrapUrls(bootStrapUrl));

--- a/test/unit/voldemort/server/storage/RepairJobTest.java
+++ b/test/unit/voldemort/server/storage/RepairJobTest.java
@@ -36,10 +36,8 @@ import voldemort.MockTime;
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
 import voldemort.VoldemortTestConstants;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.RequestFormatType;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.common.service.SchedulerService;
@@ -194,7 +192,7 @@ public class RepairJobTest {
         populateData(testEntries);
 
         // create admin client and run repair on all nodes
-        AdminClient admin = new AdminClient(cluster, new AdminClientConfig(), new ClientConfig());
+        AdminClient admin = new AdminClient(cluster);
         for(int i = 0; i < 9; i++) {
             admin.storeMntOps.repairJob(i);
         }

--- a/test/unit/voldemort/server/storage/VersionedPutPruneJobTest.java
+++ b/test/unit/voldemort/server/storage/VersionedPutPruneJobTest.java
@@ -36,7 +36,6 @@ import voldemort.client.SocketStoreClientFactory;
 import voldemort.client.StoreClient;
 import voldemort.client.protocol.RequestFormatType;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.routing.BaseStoreRoutingPlan;
@@ -159,7 +158,7 @@ public class VersionedPutPruneJobTest {
         }
 
         // run the prune job
-        AdminClient admin = new AdminClient(cluster, new AdminClientConfig(), new ClientConfig());
+        AdminClient admin = new AdminClient(cluster);
         for(int nodeid = 0; nodeid < servers.length; nodeid++) {
             admin.storeMntOps.pruneJob(nodeid, "test");
         }

--- a/test/unit/voldemort/tools/ReadOnlyReplicationHelperTest.java
+++ b/test/unit/voldemort/tools/ReadOnlyReplicationHelperTest.java
@@ -27,7 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import voldemort.ServerTestUtils;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
 import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
@@ -70,9 +69,7 @@ public class ReadOnlyReplicationHelperTest {
 
         Properties adminProperties = new Properties();
         adminProperties.setProperty("max_connections", "20");
-        adminClient = new AdminClient(cluster,
-                                      new AdminClientConfig(adminProperties),
-                                      new ClientConfig());
+        adminClient = new AdminClient(cluster, new AdminClientConfig(adminProperties));
     }
 
     @After

--- a/test/unit/voldemort/tools/ZoneShrinkageCLITest.java
+++ b/test/unit/voldemort/tools/ZoneShrinkageCLITest.java
@@ -15,8 +15,16 @@
  */
 package voldemort.tools;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Properties;
+
 import org.junit.After;
 import org.junit.Test;
+
 import voldemort.ClusterTestUtils;
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
@@ -25,7 +33,6 @@ import voldemort.client.SocketStoreClientFactory;
 import voldemort.client.StoreClient;
 import voldemort.client.StoreClientFactory;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.server.VoldemortConfig;
@@ -33,13 +40,6 @@ import voldemort.server.VoldemortServer;
 import voldemort.store.StoreDefinition;
 import voldemort.store.socket.SocketStoreFactory;
 import voldemort.store.socket.TestSocketStoreFactory;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Properties;
-
-import static org.junit.Assert.assertEquals;
 
 public class ZoneShrinkageCLITest {
 
@@ -81,7 +81,7 @@ public class ZoneShrinkageCLITest {
         String[] argv = ("--url " + bsURL +" --drop-zoneid 0 --real-run").split(" ");
         ZoneShrinkageCLI.main(argv);
 
-        AdminClient adminClient = new AdminClient(bsURL, new AdminClientConfig(), new ClientConfig());
+        AdminClient adminClient = new AdminClient(bsURL);
         assertEquals(2, adminClient.getAdminClientCluster().getZoneIds().size());
 
 
@@ -103,7 +103,7 @@ public class ZoneShrinkageCLITest {
         String[] argv = ("--url " + bsURL +" --drop-zoneid 1 --real-run").split(" ");
         ZoneShrinkageCLI.main(argv);
 
-        AdminClient adminClient = new AdminClient(bsURL, new AdminClientConfig(), new ClientConfig());
+        AdminClient adminClient = new AdminClient(bsURL);
         assertEquals(1, adminClient.getAdminClientCluster().getZoneIds().size());
     }
 

--- a/test/unit/voldemort/tools/admin/AvroAddStoreTest.java
+++ b/test/unit/voldemort/tools/admin/AvroAddStoreTest.java
@@ -35,9 +35,7 @@ import voldemort.ClusterTestUtils;
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
 import voldemort.VoldemortException;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.server.VoldemortConfig;
@@ -143,7 +141,7 @@ public class AvroAddStoreTest {
             vservers.put(node.getId(), vs);
             socketStoreFactories.put(node.getId(), ssf);
         }
-        adminClient = new AdminClient(cluster, new AdminClientConfig(), new ClientConfig());
+        adminClient = new AdminClient(cluster);
     }
 
     @Test

--- a/test/unit/voldemort/tools/admin/MetaOperationsTest.java
+++ b/test/unit/voldemort/tools/admin/MetaOperationsTest.java
@@ -34,10 +34,8 @@ import org.junit.Test;
 
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
-import voldemort.client.ClientConfig;
 import voldemort.client.RoutingTier;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.server.VoldemortConfig;
@@ -95,7 +93,7 @@ public class MetaOperationsTest {
             vservers.put(node.getId(), vs);
             socketStoreFactories.put(node.getId(), ssf);
         }
-        adminClient = new AdminClient(cluster, new AdminClientConfig(), new ClientConfig());
+        adminClient = new AdminClient(cluster);
     }
 
     @Test

--- a/test/unit/voldemort/tools/admin/QuotaOperationsTest.java
+++ b/test/unit/voldemort/tools/admin/QuotaOperationsTest.java
@@ -29,9 +29,7 @@ import org.junit.Test;
 
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.server.VoldemortConfig;
@@ -82,7 +80,7 @@ public class QuotaOperationsTest {
             vservers.put(node.getId(), vs);
             socketStoreFactories.put(node.getId(), ssf);
         }
-        adminClient = new AdminClient(cluster, new AdminClientConfig(), new ClientConfig());
+        adminClient = new AdminClient(cluster);
         storeName = stores.iterator().next().getName();
         quotaType = QuotaUtils.validQuotaTypes().iterator().next();
     }

--- a/test/unit/voldemort/tools/admin/StoreOperationsTest.java
+++ b/test/unit/voldemort/tools/admin/StoreOperationsTest.java
@@ -32,9 +32,7 @@ import org.junit.Test;
 
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.server.VoldemortConfig;
@@ -85,7 +83,7 @@ public class StoreOperationsTest {
             vservers.put(node.getId(), vs);
             socketStoreFactories.put(node.getId(), ssf);
         }
-        adminClient = new AdminClient(cluster, new AdminClientConfig(), new ClientConfig());
+        adminClient = new AdminClient(cluster);
     }
 
     @Test

--- a/test/unit/voldemort/utils/ClusterForkLiftToolTest.java
+++ b/test/unit/voldemort/utils/ClusterForkLiftToolTest.java
@@ -23,7 +23,6 @@ import voldemort.client.SocketStoreClientFactory;
 import voldemort.client.StoreClient;
 import voldemort.client.StoreClientFactory;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.routing.StoreRoutingPlan;
@@ -125,10 +124,7 @@ public class ClusterForkLiftToolTest {
                 keyCount++;
             }
 
-            srcAdminClient = new AdminClient(srcCluster,
-                                             new AdminClientConfig(),
-                                             new ClientConfig());
-
+            srcAdminClient = new AdminClient(srcCluster);
             List<StoreDefinition> storeDefs = new StoreDefinitionsMapper().readStoreList(new File(SRC_STORES_XML));
 
             primaryResolvingStoreDef = StoreUtils.getStoreDef(storeDefs,
@@ -412,9 +408,7 @@ public class ClusterForkLiftToolTest {
                                                                    ClusterForkLiftTool.ForkLiftTaskMode.no_resolution);
         forkLiftTool.run();
 
-        AdminClient dstAdminClient = new AdminClient(dstBootStrapUrl,
-                                                     new AdminClientConfig(),
-                                                     new ClientConfig());
+        AdminClient dstAdminClient = new AdminClient(dstBootStrapUrl);
 
         for(Node node: dstAdminClient.getAdminClientCluster().getNodes()) {
 

--- a/test/unit/voldemort/utils/ConsistencyCheckTest.java
+++ b/test/unit/voldemort/utils/ConsistencyCheckTest.java
@@ -36,9 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import voldemort.ServerTestUtils;
-import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
-import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.routing.RoutingStrategy;
@@ -443,9 +441,7 @@ public class ConsistencyCheckTest {
 
         Node node = cluster.getNodeById(0);
         String bootstrapUrl = "tcp://" + node.getHost() + ":" + node.getSocketPort();
-        AdminClient adminClient = new AdminClient(bootstrapUrl,
-                                                  new AdminClientConfig(),
-                                                  new ClientConfig());
+        AdminClient adminClient = new AdminClient(bootstrapUrl);
 
         byte[] value = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
         byte[] value2 = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };


### PR DESCRIPTION
Review the changes in AdminClient and Azkaban* files. Others can be ignored. 

1) For BuildAndPush If the Voldemort Cluster is far away from the
Hadoop Cluster, the connection timeout causes the Job to fail.
Increased the connection timeout in Azkaban.* files for this issue.

2) ClientConfig timeout is ignored by the AdminClient bootstrap
methods and it constructs an arbitary ClientConfig. Fixed that.

3) AdminClient passes in empty AdminClientConfig and ClientConfig
at multiple places. Removed that.