### PR TITLE
Bug fixes and improvements for Build and Push.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/HadoopStoreBuilder.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/HadoopStoreBuilder.java
@@ -514,20 +514,19 @@ public class HadoopStoreBuilder extends AbstractHadoopJob {
             }
 
             // update metadata
-            long diskSizeForNodeInBytes = dataSizeInBytes + indexSizeInBytes;
-            logger.info("Estimated disk size for store " + this.storeDef.getName() + " in "
-                        + directoryName + " in KB: "
-                        + (diskSizeForNodeInBytes / ByteUtils.BYTES_PER_KB));
-            metadata.add(ReadOnlyStorageMetadata.DISK_SIZE_IN_BYTES,
-                         Long.toString(diskSizeForNodeInBytes));
+
+            String checkSum = "NONE";
             if(checkSumType != CheckSumType.NONE) {
                 metadata.add(ReadOnlyStorageMetadata.CHECKSUM_TYPE, CheckSum.toString(checkSumType));
-
-                String checkSum = new String(Hex.encodeHex(checkSumGenerator.getCheckSum()));
-                logger.info("Checksum for node " + directoryName + " - " + checkSum);
-
+                checkSum = new String(Hex.encodeHex(checkSumGenerator.getCheckSum()));
                 metadata.add(ReadOnlyStorageMetadata.CHECKSUM, checkSum);
             }
+
+            long diskSizeForNodeInBytes = dataSizeInBytes + indexSizeInBytes;
+            logger.info(directoryName + ": Checksum = " + checkSum +
+                        ", Size = " + (diskSizeForNodeInBytes / ByteUtils.BYTES_PER_KB) + " KB");
+            metadata.add(ReadOnlyStorageMetadata.DISK_SIZE_IN_BYTES,
+                         Long.toString(diskSizeForNodeInBytes));
         }
 
     }

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -694,7 +694,7 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
                                                             getInputPath(),
                                                             checkSumType,
                                                             props.getBoolean(SAVE_KEYS, true),
-                                                            props.getBoolean(REDUCER_PER_BUCKET, false),
+                                                            props.getBoolean(REDUCER_PER_BUCKET, true),
                                                             props.getInt(BUILD_CHUNK_SIZE, 1024 * 1024 * 1024),
                                                             props.getInt(NUM_CHUNKS, -1),
                                                             this.isAvroJob,

--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -739,7 +739,8 @@ public class VoldemortConfig implements Serializable {
         }
 
         // Define various paths
-        String dataDirectory = combinedConfigs.getString(VOLDEMORT_HOME) + File.separator + "data";
+        String defaultDataDirectory = combinedConfigs.getString(VOLDEMORT_HOME) + File.separator + "data";
+        String dataDirectory = combinedConfigs.getString(DATA_DIRECTORY, defaultDataDirectory);
         dynamicDefaults.put(DATA_DIRECTORY, dataDirectory);
         dynamicDefaults.put(BDB_DATA_DIRECTORY, dataDirectory + File.separator + "bdb");
         dynamicDefaults.put(READONLY_DATA_DIRECTORY, dataDirectory + File.separator + "read-only");

--- a/src/java/voldemort/utils/Props.java
+++ b/src/java/voldemort/utils/Props.java
@@ -27,11 +27,14 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import voldemort.annotations.concurrency.NotThreadsafe;
 
@@ -344,7 +347,15 @@ public class Props implements Map<String, String> {
     public String toString(boolean oneLinePerEntry) {
         StringBuilder builder = new StringBuilder("{");
         boolean firstLine = true;
-        for(Entry<String, String> entry: this.props.entrySet()) {
+        SortedSet<Entry<String, String>> sortedEntries =
+                new TreeSet<Entry<String, String>>(new Comparator<Entry<String, String>>(){
+                    @Override
+                    public int compare(Entry<String, String> o1, Entry<String, String> o2) {
+                        return o1.getKey().compareTo(o2.getKey());
+                    }
+                });
+        sortedEntries.addAll(this.props.entrySet());
+        for(Entry<String, String> entry: sortedEntries) {
             if (oneLinePerEntry) {
                 builder.append("\n\t");
             } else {


### PR DESCRIPTION
- HadoopStoreWriter did not handle multiple chunks correctly which caused reduce tasks to step on each others' toes. Fixed.
- Changed default 'reducer.per.bucket' config to true.
- AbstractStoreBuilderConfigurable.getPartition() was broken when 'build.primary.replicas.only' was enabled. Fixed it and added a lot more comments.
- Added defensive code in HadoopStoreWriter to catch future regressions in the partitioning (shuffling) code.
- Improved logging in Props and HadoopStoreBuilder.