### PR TITLE
fixing the 'unknown.host' test in ClientRequestExecutorPoolTest

### DIFF
--- a/test/unit/voldemort/server/socket/ClientRequestExecutorPoolTest.java
+++ b/test/unit/voldemort/server/socket/ClientRequestExecutorPoolTest.java
@@ -286,7 +286,7 @@ public class ClientRequestExecutorPoolTest {
 
     @Test
     public void testNonExistentHost() throws Exception {
-        SocketDestination nonExistentHost = new SocketDestination("unknown.host",
+        SocketDestination nonExistentHost = new SocketDestination("unknown.invalid",
                                                                   port,
                                                                   RequestFormatType.VOLDEMORT_V1);
         // JDK 1.6 throws UnresolvedAddressException, which is not even an


### PR DESCRIPTION
it turns out that somebody has registered 'unknown.host':

    $ host unknown.host
    unknown.host has address 188.68.51.215
    unknown.host mail is handled by 10 serpens.uberspace.de.

which is kinda of annoying. Have switched to using unknown.invalid as
this is reserved and should never resolve.