### PR TITLE
Changed HDFS directory size measurement in HdfsFetcher.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsCopyStats.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsCopyStats.java
@@ -83,7 +83,7 @@ public class HdfsCopyStats {
         return this.statsFile;
     }
 
-    private static final int STATS_VERSION = 3;
+    private static final int STATS_VERSION = 4;
     private void initializeStatsFile(File destination,
                                      boolean enableStatsFile,
                                      int maxVersionsStatsFile,
@@ -230,16 +230,23 @@ public class HdfsCopyStats {
 
     public void complete() {
         long nowMS = System.currentTimeMillis() ;
-        reportStats(" Completed at " + nowMS + " MS. Total bytes transferred " + totalBytesTransferred
-                    + " . Expected total bytes transferred " + pathInfo.getTotalSize()
-                    + " . Total bytes written " + totalBytesWritten
-                    + " . Time taken(MS) " + (nowMS - startTimeMS));
+        String expectedTotalBytesTransferred = "unavailable";
+        if (pathInfo != null) {
+            expectedTotalBytesTransferred = String.valueOf(pathInfo.getTotalSize());
+        }
+        reportStats(" Completed at " + nowMS + " MS. Total bytes transferred: " + totalBytesTransferred
+                    + " . Expected total bytes transferred: " + expectedTotalBytesTransferred
+                    + " . Total bytes written: " + totalBytesWritten
+                    + " . Time taken(MS): " + (nowMS - startTimeMS));
         if(statsFileWriter != null) {
             IOUtils.closeQuietly(statsFileWriter);
         }
     }
 
     public double getPercentCopied() {
+        if (pathInfo == null) {
+            return -1.0;
+        }
         if(pathInfo.getTotalSize() == 0) {
             return 0.0;
         } else {

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/utils/HadoopUtils.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/utils/HadoopUtils.java
@@ -361,7 +361,7 @@ public class HadoopUtils {
             throws Exception {
         final Configuration config = getConfiguration(voldemortConfig, sourceFileUrl);
         final Path path = new Path(sourceFileUrl);
-        final int maxAttempts = voldemortConfig.getReadOnlyFetchRetryCount() + 1;
+        final int maxAttempts = voldemortConfig.getReadOnlyFetchRetryCount();
         final String keytabPath = voldemortConfig.getReadOnlyKeytabPath();
         FileSystem fs = null;
 
@@ -422,7 +422,7 @@ public class HadoopUtils {
                         logger.error("Could not get a valid Filesystem object on attempt # " + attempt +
                                              " / " + maxAttempts + ". Trying again in " + randomDelay + " ms.");
                         try {
-                            Thread.sleep(retryDelayMs);
+                            Thread.sleep(randomDelay);
                         } catch(InterruptedException ie) {
                             logger.error("Fetcher interrupted while waiting to retry", ie);
                             Thread.currentThread().interrupt();


### PR DESCRIPTION
This fixes two issues in 'build.primary.replicas.only':
1. The progress report in the AsyncTask was wrong, which
   also resulted in erroneous logs in the BnP job.
2. The previous implementation was DDOSing the NameNode
   with a furious amount of ListStatus operation, most
   of which it did not even need to get the result of.

Also cleaned up HdfsFetcherAdvancedTest a little bit.