### PR TITLE
Better exception handling in HdfsFetcher#fetchFromSource().

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -368,12 +368,13 @@ public class HdfsFetcher implements FileFetcher {
             if(fs != null) {
                 try {
                     fs.close();
-                } catch(IOException e) {
-                    String errorMessage = "Got IOException while trying to close the filesystem instance (harmless).";
+                } catch(Exception e) {
+                    String errorMessage = "Caught " + e.getClass().getSimpleName() +
+                                          " while trying to close the filesystem instance (harmless).";
                     if(stats != null) {
                         stats.reportError(errorMessage, e);
                     }
-                    logger.info(errorMessage, e);
+                    logger.debug(errorMessage, e);
                 }
             }
         }


### PR DESCRIPTION
Previously, a FileSystem#close() operation was guarded by try/catch looking for IOExceptions only. It turns out this close() function can sometimes throw NPEs as well. This commit expands the catch clause to any exception type, and updates the logged message accordingly.