### PR TITLE
Fix exception error in ClientRequestExecutorPoolTest

### DIFF
--- a/test/unit/voldemort/server/socket/ClientRequestExecutorPoolTest.java
+++ b/test/unit/voldemort/server/socket/ClientRequestExecutorPoolTest.java
@@ -289,14 +289,7 @@ public class ClientRequestExecutorPoolTest {
         SocketDestination nonExistentHost = new SocketDestination("unknown.invalid",
                                                                   port,
                                                                   RequestFormatType.VOLDEMORT_V1);
-        // JDK 1.6 throws UnresolvedAddressException, which is not even an
-        // instance of IOException or ConnectException . JDK 1.8 fixes this
-        // issue and uses the ConnectException .
-        try {
-            testConnectionFailure(pool, nonExistentHost, ConnectException.class);
-        } catch(Exception e) {
-            testConnectionFailure(pool, nonExistentHost, UnresolvedAddressException.class);
-        }
+        testConnectionFailure(pool, nonExistentHost, UnresolvedAddressException.class);
     }
 
     @Test


### PR DESCRIPTION
The test failed because the original code in order to establish socket connection throws out 'UnresolvedAddressException' instead of 'ConnectException'. So I updated test cases.