### PR TITLE
Stop swallowing exception's original message and clarify top-level message

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -368,12 +368,13 @@ public class HdfsFetcher implements FileFetcher {
             if(fs != null) {
                 try {
                     fs.close();
-                } catch(IOException e) {
-                    String errorMessage = "Got IOException while trying to close the filesystem instance (harmless).";
+                } catch(Exception e) {
+                    String errorMessage = "Caught " + e.getClass().getSimpleName() +
+                                          " while trying to close the filesystem instance (harmless).";
                     if(stats != null) {
                         stats.reportError(errorMessage, e);
                     }
-                    logger.info(errorMessage, e);
+                    logger.debug(errorMessage, e);
                 }
             }
         }

--- a/test/unit/voldemort/server/socket/ClientRequestExecutorPoolTest.java
+++ b/test/unit/voldemort/server/socket/ClientRequestExecutorPoolTest.java
@@ -289,14 +289,7 @@ public class ClientRequestExecutorPoolTest {
         SocketDestination nonExistentHost = new SocketDestination("unknown.invalid",
                                                                   port,
                                                                   RequestFormatType.VOLDEMORT_V1);
-        // JDK 1.6 throws UnresolvedAddressException, which is not even an
-        // instance of IOException or ConnectException . JDK 1.8 fixes this
-        // issue and uses the ConnectException .
-        try {
-            testConnectionFailure(pool, nonExistentHost, ConnectException.class);
-        } catch(Exception e) {
-            testConnectionFailure(pool, nonExistentHost, UnresolvedAddressException.class);
-        }
+        testConnectionFailure(pool, nonExistentHost, UnresolvedAddressException.class);
     }
 
     @Test


### PR DESCRIPTION
AdminStoreSwapper#invokeFetch() used to take charge of collecting exceptions among sub-threads. It swallowed original exceptions and made customers confused when debugging. Now it maintains all sub-thread exception in an list and throw the first exception in the list.

Also modify the InvalidBootstrapurLException message to make it more clear. It is now:
 "Not able to find store (" + storeName +") in this cluster according to the push URL. BnP job is not able to create new stores now." + "Please create new stores through Nuage if you think this is the correct cluster you want to push."