### PR TITLE
HdfsFetcher's AdminClient is now configurable.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -195,9 +195,10 @@ public class HdfsFetcher implements FileFetcher {
                       String storeName,
                       long pushVersion,
                       MetadataStore metadataStore) throws Exception {
+        // FIXME: Stop using an admin client to talk to yourself, silly Voldemort!
         AdminClient adminClient = null;
         try {
-            adminClient = new AdminClient(metadataStore.getCluster());
+            adminClient = AdminClient.createTempAdminClient(voldemortConfig, metadataStore.getCluster(), 1);
 
             Versioned<String> diskQuotaSize = adminClient.quotaMgmtOps.getQuotaForNode(storeName,
                                                                                        QuotaType.STORAGE_SPACE,


### PR DESCRIPTION
This AdminClient is used to retrieve quota information from within
the HdfsFetcher. It is a bit messy and we probably should not be
using an AdminClient at all for this, but for now this is just a
quick fix to ensure that we can actually configure this server-side
AdminClient with parameters from VoldemortConfig.