### PR TITLE
Resolved concurrency push conflict, refactor quirky AdmintClient used in HdfsFetcher, add hyperlink in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ get "k1"
 
 You can find more commands by running```help```
 
+Want to dig into the detailed implementation or even contribute to Voldemort? [A quick git guide for people who want to make contributions to Voldemort](https://github.com/voldemort/voldemort/wiki/A-quick-git-guide-for-people-who-want-to-make-contributions-to-Voldemort).
+
 
 ## Comparison to relational databases ##
 

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -189,6 +189,8 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
         String clusterUrlText = props.getString(PUSH_CLUSTER);
         for(String url: Utils.COMMA_SEP.split(clusterUrlText.trim())) {
             if(url.trim().length() > 0) {
+                if (clusterURLs.contains(url))
+                    throw new VoldemortException("the URL: " + url + " is duplicated. Please check it out.");
                 this.clusterURLs.add(url);
                 AdminClient adminClient = new AdminClient(new ClientConfig().setBootstrapUrls(url)
                                                                             .setConnectionTimeout(15,

--- a/src/java/voldemort/server/protocol/admin/AsyncOperationService.java
+++ b/src/java/voldemort/server/protocol/admin/AsyncOperationService.java
@@ -76,24 +76,34 @@ public class AsyncOperationService extends AbstractService {
     }
 
     /**
-     * Is a request complete? If so, forget the operations
+     * Check if the an operation is done or not. 
      * 
      * @param requestId Id of the request
+     * @param remove Whether remove the request out of the list if it is done.
      * @return True if request is complete, false otherwise
      */
-    public synchronized boolean isComplete(int requestId) {
-        if(!operations.containsKey(requestId))
+    public synchronized boolean isComplete(int requestId, boolean remove) {
+        if (!operations.containsKey(requestId))
             throw new VoldemortException("No operation with id " + requestId + " found");
 
-        if(operations.get(requestId).getStatus().isComplete()) {
-            if(logger.isDebugEnabled()) {
+        if (operations.get(requestId).getStatus().isComplete()) {
+            if (logger.isDebugEnabled())
                 logger.debug("Operation complete " + requestId);
-            }
-            operations.remove(requestId);
+
+            if (remove)
+                operations.remove(requestId);
 
             return true;
         }
+
         return false;
+    }
+    /**
+     * A default caller. remove operations ID out of the list when it is done.
+     * @param requestId Id of the request
+     */
+    public synchronized boolean isComplete(int requestId) {
+        return isComplete(requestId, true);
     }
 
     // Wrap getOperationStatus to avoid throwing exception over JMX

--- a/src/java/voldemort/server/protocol/admin/ReadOnlyStoreFetchOperation.java
+++ b/src/java/voldemort/server/protocol/admin/ReadOnlyStoreFetchOperation.java
@@ -29,6 +29,7 @@ public class ReadOnlyStoreFetchOperation extends AsyncOperation {
     private final long pushVersion;
     private final ReadOnlyStorageEngine store;
     private final long startTime = System.currentTimeMillis();
+    private final Long diskQuotaSizeInKB;
 
     private State currentState;
 
@@ -38,7 +39,8 @@ public class ReadOnlyStoreFetchOperation extends AsyncOperation {
                                        FileFetcher fileFetcher,
                                        String storeName,
                                        String fetchUrl,
-                                       long pushVersion) {
+                                       long pushVersion,
+                                       Long diskQuotaSizeInKB) {
         super(id, "Fetch store '" + storeName + "' v" + pushVersion);
         this.metadataStore = metadataStore;
         this.store = store;
@@ -47,6 +49,7 @@ public class ReadOnlyStoreFetchOperation extends AsyncOperation {
         this.fetchUrl = fetchUrl;
         this.pushVersion = pushVersion;
         this.currentState = State.WAITING;
+        this.diskQuotaSizeInKB = diskQuotaSizeInKB;
 
         updateStatus("Waiting in Queue");
     }
@@ -97,7 +100,8 @@ public class ReadOnlyStoreFetchOperation extends AsyncOperation {
                                              status,
                                              storeName,
                                              pushVersion,
-                                             metadataStore);
+                                             metadataStore,
+                                             diskQuotaSizeInKB);
                 if(fetchDir == null) {
                     String errorMessage = "File fetcher failed for " + fetchUrl + " and store '"
                                           + storeName

--- a/src/java/voldemort/store/readonly/FileFetcher.java
+++ b/src/java/voldemort/store/readonly/FileFetcher.java
@@ -53,5 +53,6 @@ public interface FileFetcher {
                       AsyncOperationStatus status,
                       String storeName,
                       long pushVersion,
-                      MetadataStore metadataStore) throws IOException, Exception;
+                      MetadataStore metadataStore,
+                      Long diskQuotaSizeInKB) throws IOException, Exception;
 }

--- a/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
+++ b/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
@@ -59,6 +59,7 @@ import com.google.common.collect.Lists;
 public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte[], byte[]> {
 
     private static Logger logger = Logger.getLogger(ReadOnlyStorageEngine.class);
+    public static int NO_FETCH_IN_PROGRESS = -1;
 
     // Immutable state
     private final int numBackups, nodeId, deleteBackupMs, maxValueBufferAllocationSize;
@@ -72,6 +73,7 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
     private volatile ChunkedFileSet fileSet;
     private volatile boolean isOpen;
     private long lastSwapped;
+    private int lastFetchReqestId;
 
     /**
      * Create an instance of the store
@@ -137,6 +139,8 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
         this.isOpen = false;
         storeVersionManager = new StoreVersionManager(storeDir);
         open(null);
+
+        lastFetchReqestId = NO_FETCH_IN_PROGRESS;
     }
 
     @Override
@@ -662,4 +666,8 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
                     "Store '" + getName() + "' version " + getCurrentVersionId() + " is disabled on this node.");
         }
     }
+
+    public int getFetchingRequest() { return lastFetchReqestId; }
+
+    public void setFetchingRequest(int requestId) { lastFetchReqestId = requestId; }
 }

--- a/test/unit/voldemort/store/readonly/swapper/MockFetcher.java
+++ b/test/unit/voldemort/store/readonly/swapper/MockFetcher.java
@@ -1,0 +1,53 @@
+package voldemort.store.readonly.swapper;
+
+import voldemort.VoldemortException;
+import voldemort.server.VoldemortConfig;
+import voldemort.server.protocol.admin.AsyncOperationStatus;
+import voldemort.store.metadata.MetadataStore;
+import voldemort.store.readonly.FileFetcher;
+import voldemort.utils.Utils;
+
+import java.io.File;
+import java.io.IOException;
+
+/** mock fileFetcher class
+ * This class is only for testing purpose.
+ * The Fetcher is gonna running for "sleepTime" seconds long.
+ */
+public class MockFetcher implements FileFetcher {
+
+    static private int sleepTime = 0;
+
+    //This constructor method is necessary since the instance is created by a reflection way
+    //which requires VoldemortConfig as an argument.
+    public MockFetcher(VoldemortConfig config){
+    }
+
+    static public void setSleepTime(int time) { sleepTime = time; }
+
+    @Override
+    public File fetch(String source, String dest) throws IOException {
+        return new File("mock Fetcher");
+    }
+
+    @Override
+    public File fetch(String source, String dest, long diskQuotaSizeInKB) throws IOException {
+        return this.fetch(source, dest);
+    }
+
+    @Override
+    public File fetch(String source, String dest, AsyncOperationStatus status, String storeName, long pushVersion, MetadataStore metadataStore, Long diskQuotaSizeInKB) throws IOException, InterruptedException {
+        Thread.currentThread().sleep(sleepTime * 1000);
+        if (!Utils.isReadableDir(source))
+            throw new VoldemortException("Fetch url " + source + " is not readable");
+
+        File destFile = new File(dest);
+
+        if (destFile.exists())
+            throw new VoldemortException("Version directory " + destFile.getAbsolutePath()
+                    + " already exists");
+
+        Utils.move(new File(source), destFile);
+        return destFile;
+    }
+}


### PR DESCRIPTION
1. It was very likely to cause content conflict when multiply jobs try to push to
the same store simultaneously. We add a hashmap in AdminRequestHandler
to check whether a store is currently fetching or not. And if so, we
block the rest of fetching request and throw an exception.

2. The HdfsFetcher used to create an admintClient instance and asked
itself "diskQuotaSizeInKB". This was a quirky used adminClient. We
removed it and passed quota size directly from AdminRequestHandler.

3. Add a hyperlink in README.md to "A quick git guild for people who
want to make contributions to Voldemort".