### PR TITLE
Check server state when bring nodes back

### DIFF
--- a/src/java/voldemort/server/VoldemortServer.java
+++ b/src/java/voldemort/server/VoldemortServer.java
@@ -382,7 +382,13 @@ public class VoldemortServer extends AbstractService {
         JNAUtils.tryMlockall();
         logger.info("Starting " + basicServices.size() + " services.");
         long start = System.currentTimeMillis();
-        boolean goOnline = true;
+
+        boolean goOnline;
+        if (getMetadataStore().getServerStateUnlocked() == MetadataStore.VoldemortState.OFFLINE_SERVER)
+            goOnline = false;
+        else
+            goOnline = true;
+
         for(VoldemortService service: basicServices) {
             try {
                 service.start();
@@ -391,6 +397,7 @@ public class VoldemortServer extends AbstractService {
                 goOnline = false;
             }
         }
+
         if (goOnline) {
             startOnlineServices();
         } else {

--- a/test/common/voldemort/ServerTestUtils.java
+++ b/test/common/voldemort/ServerTestUtils.java
@@ -1061,11 +1061,13 @@ public class ServerTestUtils {
      * @param socketStoreFactory
      * @param config
      * @param cluster
+     * @param testConnection
      * @return
      */
     public static VoldemortServer startVoldemortServer(SocketStoreFactory socketStoreFactory,
                                                        VoldemortConfig config,
-                                                       Cluster cluster) throws BindException {
+                                                       Cluster cluster,
+                                                       boolean testConnection) throws BindException {
 
         // TODO: Some tests that use this method fail intermittently with the
         // following output:
@@ -1094,7 +1096,8 @@ public class ServerTestUtils {
                     server = new VoldemortServer(config);
                 }
                 server.start();
-                ServerTestUtils.waitForServerStart(socketStoreFactory, server.getIdentityNode());
+                if (testConnection)
+                    ServerTestUtils.waitForServerStart(socketStoreFactory, server.getIdentityNode());
                 // wait till server starts or throw exception
                 success = true;
                 return server;
@@ -1121,12 +1124,28 @@ public class ServerTestUtils {
     }
 
     public static VoldemortServer startVoldemortServer(SocketStoreFactory socketStoreFactory,
+                                                       VoldemortConfig config,
+                                                       Cluster cluster) throws BindException {
+        return startVoldemortServer(socketStoreFactory, config, cluster, true);
+    }
+
+
+    public static VoldemortServer startVoldemortServer(SocketStoreFactory socketStoreFactory,
                                                        VoldemortConfig config) throws BindException {
         return startVoldemortServer(socketStoreFactory, config, null);
     }
 
+    /**
+     * Test if socket connection is available on the node
+     *
+     *
+     * @param socketStoreFactory
+     * @param node
+     */
     public static void waitForServerStart(SocketStoreFactory socketStoreFactory, Node node) {
         boolean success = false;
+        UnreachableStoreException exception = null;
+
         int retries = 10;
         Store<ByteArray, ?, ?> store = null;
         while(retries-- > 0 && !success) {
@@ -1137,21 +1156,21 @@ public class ServerTestUtils {
                 store.get(new ByteArray(MetadataStore.CLUSTER_KEY.getBytes()), null);
                 success = true;
             } catch(UnreachableStoreException e) {
-                store.close();
-                store = null;
                 System.out.println("UnreachableSocketStore sleeping will try again " + retries
                                    + " times.");
+                exception = e;
                 try {
                     Thread.sleep(1000);
                 } catch(InterruptedException e1) {
                     // ignore
                 }
+            }finally{
+                store.close();
+                store = null;
             }
         }
-
-        store.close();
         if(!success)
-            throw new RuntimeException("Failed to connect with server:" + node);
+            throw exception;
     }
 
     /***
@@ -1218,14 +1237,14 @@ public class ServerTestUtils {
         for(int nodeId: cluster.getNodeIds()) {
 
             voldemortServers[count] = ServerTestUtils.startVoldemortServer(socketStoreFactory,
-                                                                           ServerTestUtils.createServerConfig(useNio,
-                                                                                                              nodeId,
-                                                                                                              TestUtils.createTempDir()
-                                                                                                                       .getAbsolutePath(),
-                                                                                                              clusterFile,
-                                                                                                              storeFile,
-                                                                                                              properties),
-                                                                           cluster);
+                    ServerTestUtils.createServerConfig(useNio,
+                            nodeId,
+                            TestUtils.createTempDir()
+                                    .getAbsolutePath(),
+                            clusterFile,
+                            storeFile,
+                            properties),
+                    cluster);
             count++;
         }
         return cluster;


### PR DESCRIPTION
Fixed the issue when starting up Voldemort in offilne state, it actually
goes online and keeps listening client requests.