### PR TITLE
Hdfs FileSystem handles are leaked in Fetch

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -26,14 +26,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.management.ObjectName;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Logger;
 
 import voldemort.VoldemortException;
-import voldemort.client.protocol.admin.AdminClient;
 import voldemort.cluster.Cluster;
 import voldemort.routing.RoutingStrategy;
 import voldemort.routing.RoutingStrategyFactory;
@@ -43,20 +41,18 @@ import voldemort.server.protocol.admin.AsyncOperationStatus;
 import voldemort.store.StoreDefinition;
 import voldemort.store.metadata.MetadataStore;
 import voldemort.store.quota.QuotaExceededException;
-import voldemort.store.quota.QuotaType;
 import voldemort.store.readonly.FileFetcher;
 import voldemort.store.readonly.ReadOnlyStorageMetadata;
 import voldemort.store.readonly.ReadOnlyUtils;
+import voldemort.store.readonly.UnauthorizedStoreException;
 import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
 import voldemort.store.readonly.mr.utils.HadoopUtils;
 import voldemort.store.readonly.mr.utils.VoldemortUtils;
-import voldemort.store.readonly.UnauthorizedStoreException;
 import voldemort.utils.ByteUtils;
 import voldemort.utils.EventThrottler;
 import voldemort.utils.JmxUtils;
 import voldemort.utils.Time;
 import voldemort.utils.Utils;
-import voldemort.versioning.Versioned;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;


### PR DESCRIPTION
Issue : After the HadoopFileSystem object is created, the validity of
the fileSystem is verified by doing a sample operation. If the operation
fails the Hadoop FileSystem object is leaked. This object should be
cleaned up by the Garbage collection, but all the FileSystem objects
are cached, so this is leaked. When voldemort server is used with
secure webhdfs (swebhdfs) file system it leaks enough memory to kill
the servers eventually.

Previously in voldemort webhdfs file system handles were leaked.
Apparently webhdfs file system handles are very cheap. But in SwebHdfs
they have the security certificate embedded in them. This causes them to
be very big.

Heap Dump analysis
WebHdfsFileSystem - 3768 Objects - 80 MB
SWebHdfsFileSystem - 1748 Objects - 3 GB

Solution :
1)  Disable the caching, as we re-login for every filesystem
creation and the caching is not intended for the FileSystem handles
anyway. Re-visit this when kerberos caching is enabled as default.
2) Clean up the file handles on the error cases. Traced down all the
handles and cleaned them up on the error path.