### PR TITLE
Expose data points in FileFetcher and create autometrics sensors for them

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/BasicFetchStrategy.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/BasicFetchStrategy.java
@@ -19,7 +19,6 @@ import voldemort.server.protocol.admin.AsyncOperationStatus;
 import voldemort.server.protocol.admin.AsyncOperationStoppedException;
 import voldemort.store.readonly.checksum.CheckSum;
 import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
-import voldemort.utils.ExceptionUtils;
 
 
 public class BasicFetchStrategy implements FetchStrategy {
@@ -96,6 +95,8 @@ public class BasicFetchStrategy implements FetchStrategy {
             boolean success = false;
             long totalBytesRead = 0;
             boolean fsOpened = false;
+
+            stats.singleFileFetchStart(attempt != 1);
             try {
                 CheckSum fileCheckSumGenerator = null;
                 // Create a per file checksum generator
@@ -201,6 +202,8 @@ public class BasicFetchStrategy implements FetchStrategy {
                     throw e;
                 }
             } finally {
+                stats.singleFileFetchEnd();
+
                 IOUtils.closeQuietly(output);
                 IOUtils.closeQuietly(input);
                 if(success) {

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -76,6 +76,9 @@ public class HdfsFetcher implements FileFetcher {
     private final EventThrottler throttler;
     private final VoldemortConfig voldemortConfig;
 
+    // Throttle name for all the hdfs data pull
+    private static final String GLOBAL_HDFS_FETCHER_THROTTLE_NAME = "hdfs-fetcher-node-throttler";
+
     /**
      * This is the constructor invoked via reflection from
      * {@link AdminServiceRequestHandler#setFetcherClass(voldemort.server.VoldemortConfig)}
@@ -138,8 +141,8 @@ public class HdfsFetcher implements FileFetcher {
         if(maxBytesPerSecond != null && maxBytesPerSecond > 0) {
             this.maxBytesPerSecond = maxBytesPerSecond;
             this.throttler = new EventThrottler(this.maxBytesPerSecond,
-                                                throttlerIntervalMs,
-                                                "hdfs-fetcher-node-throttler");
+                    throttlerIntervalMs,
+                    GLOBAL_HDFS_FETCHER_THROTTLE_NAME);
             throttlerInfo = "throttler with global rate = " + maxBytesPerSecond + " bytes / sec";
         } else {
             this.maxBytesPerSecond = null;
@@ -449,6 +452,15 @@ public class HdfsFetcher implements FileFetcher {
         } else {
             logger.debug("store: " + storeName + " is a Non Quota type store.");
         }
+    }
+
+    /**
+     * Get the data fetch rate for all the HDFS data pull.
+     *
+     * @return HDFS data fetch rate (byte per second)
+     */
+    public static double getDataFetchRate() {
+        return EventThrottler.getSharedThrottleRate(GLOBAL_HDFS_FETCHER_THROTTLE_NAME);
     }
 
     public Long getReportingIntervalBytes() {

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcherAggStats.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcherAggStats.java
@@ -1,0 +1,190 @@
+package voldemort.store.readonly.fetcher;
+
+import org.apache.log4j.Logger;
+import voldemort.annotations.jmx.JmxGetter;
+import voldemort.utils.JmxUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+ * This class is used to capture the aggregated metrics for all the file pulls from Hdfs,
+ * and expose them through JMX Bean.
+ */
+public class HdfsFetcherAggStats {
+    // A singleton for all the data pull tasks
+    private static final HdfsFetcherAggStats stats;
+
+    private static Logger logger = Logger.getLogger(HdfsFetcherAggStats.class);
+
+    // Total bytes fetched by all the data pull tasks
+    private long totalBytesFetched;
+    // Total Hdfs fetch retry number
+    private long totalFetchRetries;
+    // Total checksum failures
+    private long totalCheckSumFailures;
+    // Total file read failures
+    private long totalFileReadFailures;
+    // Total authentication failures
+    private long totalAuthenticationFailures;
+    // Total file not found failures
+    private long totalFileNotFoundFailures;
+    // Total quota exceed failures
+    private long totalQuotaExceedFailures;
+    // Total unauthorized store failures
+    private long totalUnauthorizedStoreFailures;
+
+    // Parallel active fetch number
+    // This metric is only used to capture the active fetches number right now
+    private int parallelFetches;
+    // Total Hdfs fetch number
+    private long totalFetches;
+
+    // TODO: Max number of parallel fetches (if there are more than one running at the same time)
+    // Need to use Tehuti lib
+
+    // Total number for incomplete fetches
+    private long totalIncompleteFetches;
+
+    // TODO: File fetcher average and max connection times (NameNode and DataNode)
+    // Not sure how to extract those metrics
+
+    // Maintain the mapping between store name and its corresponding HdfsCopyStats,
+    // so that we can get the aggregated transfer rates for all the stores
+    private Map<String, HdfsCopyStats> copyStatsMap = new HashMap<String, HdfsCopyStats>();
+
+    // Register the global aggregated stats object in Bean Server
+    static {
+        stats = new HdfsFetcherAggStats();
+        JmxUtils.registerMbean("hdfs-fetcher-agg-stats", stats);
+    }
+
+    private HdfsFetcherAggStats() {}
+
+    public static HdfsFetcherAggStats getStats() {
+        return stats;
+    }
+
+    public synchronized void recordBytesTransferred(long bytesTransferred) {
+        totalBytesFetched += bytesTransferred;
+    }
+
+    public synchronized void storeFetch() {
+        ++totalFetches;
+    }
+    public synchronized void singleFileFetchStart(boolean isRetry) {
+        ++parallelFetches;
+        if (isRetry) {
+            ++totalFetchRetries;
+        }
+    }
+
+    public synchronized void singleFileFetchEnd() {
+        --parallelFetches;
+    }
+
+    public synchronized void checkSumFailed() {
+        ++totalCheckSumFailures;
+    }
+
+    public synchronized void authenticateFailed() {
+        ++totalAuthenticationFailures;
+    }
+
+    public synchronized void fileNotFound() {
+        ++totalFileNotFoundFailures;
+    }
+
+    public synchronized void fileReadFailed() {
+        ++totalFileReadFailures;
+    }
+
+    public synchronized void quotaCheckFailed() {
+        ++totalQuotaExceedFailures;
+    }
+
+    public synchronized void unauthorizedStorePush() {
+        ++totalUnauthorizedStoreFailures;
+    }
+
+    public synchronized void incompleteFetch() {
+        ++totalIncompleteFetches;
+    }
+
+    public synchronized void addStoreCopyStats(String storeName, HdfsCopyStats copyStats) {
+        copyStatsMap.put(storeName, copyStats);
+    }
+
+    public synchronized void removeStoreCopyStats(String storeName) {
+        copyStatsMap.remove(storeName);
+    }
+
+    public synchronized HdfsCopyStats getStoreCopyStatus(String storeName) {
+        return copyStatsMap.get(storeName);
+    }
+
+    @JmxGetter(name = "totalBytesFetched", description = "The total bytes transferred from HDFS so far.")
+    public synchronized long getTotalBytesFetched() {
+        return totalBytesFetched;
+    }
+
+    @JmxGetter(name = "totalFetchRetries", description = "The total fetch retry number so far.")
+    public synchronized long getTotalFetchRetries() {
+        return totalFetchRetries;
+    }
+
+    @JmxGetter(name = "totalCheckSumFailures", description = "The total data file checksum failures happened so far.")
+    public synchronized long getTotalCheckSumFailures() {
+        return totalCheckSumFailures;
+    }
+
+    @JmxGetter(name = "totalAuthenticationFailures", description = "The total authentication failures happened so far.")
+    public synchronized long getTotalAuthenticationFailures() {
+        return totalAuthenticationFailures;
+    }
+
+    @JmxGetter(name = "totalFileNotFoundFailures", description = "The total file-not-found failures happened so far.")
+    public synchronized long getTotalFileNotFoundFailures() {
+        return totalFileNotFoundFailures;
+    }
+
+    @JmxGetter(name = "totalFileReadFailures", description = "The total HDFS file read failures happened so far.")
+    public synchronized long getTotalFileReadFailures() {
+        return totalFileReadFailures;
+    }
+
+    @JmxGetter(name = "totalQuotaExceedFailures", description = "The total quota exceed failures happened so far.")
+    public synchronized long getTotalQuotaExceedFailures() {
+        return totalQuotaExceedFailures;
+    }
+
+    @JmxGetter(name = "totalUnauthorizedStoreFailures", description = "The total unauthorized store push failures happened so far.")
+    public synchronized long getTotalUnauthorizedStoreFailures() {
+        return  totalUnauthorizedStoreFailures;
+    }
+
+    @JmxGetter(name = "parallelFetches", description = "The total number of active fetches right now.")
+    public synchronized int getParallelFetches() {
+        return parallelFetches;
+    }
+
+    @JmxGetter(name = "totalFetches", description = "The total HDFS fetch number so far.")
+    public synchronized long getTotalFetches() {
+        return totalFetches;
+    }
+
+    @JmxGetter(name = "totalIncompleteFetches", description = "The total incomplete fetch number so far.")
+    public synchronized long getTotalIncompleteFetches() {
+        return totalIncompleteFetches;
+    }
+
+    @JmxGetter(name = "totalDataFetchRate", description = "The total data fetch rate right now.")
+    public synchronized double getTotalDataFetchRate() {
+        double fetchRate = 0;
+        for (HdfsCopyStats copyStats : copyStatsMap.values()) {
+            fetchRate += copyStats.getBytesTransferredPerSecond();
+        }
+
+        return fetchRate;
+    }
+}

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcherAggStats.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcherAggStats.java
@@ -180,11 +180,14 @@ public class HdfsFetcherAggStats {
 
     @JmxGetter(name = "totalDataFetchRate", description = "The total data fetch rate right now.")
     public synchronized double getTotalDataFetchRate() {
+        return HdfsFetcher.getDataFetchRate();
+        /*
         double fetchRate = 0;
         for (HdfsCopyStats copyStats : copyStatsMap.values()) {
             fetchRate += copyStats.getBytesTransferredPerSecond();
         }
 
         return fetchRate;
+        */
     }
 }

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetchAggStatsTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetchAggStatsTest.java
@@ -1,0 +1,62 @@
+package voldemort.store.readonly.fetcher;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+
+public class HdfsFetchAggStatsTest {
+    @Test
+    public void testSingleFileFetchStartWithoutRetry() {
+        long parallelFetchesBefore = HdfsFetcherAggStats.getStats().getParallelFetches();
+        long totalFetchRetiesBefore = HdfsFetcherAggStats.getStats().getTotalFetchRetries();
+        HdfsFetcherAggStats.getStats().singleFileFetchStart(false);
+
+        Assert.assertEquals(parallelFetchesBefore + 1, HdfsFetcherAggStats.getStats().getParallelFetches());
+        Assert.assertEquals(totalFetchRetiesBefore, HdfsFetcherAggStats.getStats().getTotalFetchRetries());
+    }
+
+    @Test
+    public void testSingleFileFetchStartWithRetry() {
+        long parallelFetchesBefore = HdfsFetcherAggStats.getStats().getParallelFetches();
+        long totalFetchRetiesBefore = HdfsFetcherAggStats.getStats().getTotalFetchRetries();
+        HdfsFetcherAggStats.getStats().singleFileFetchStart(true);
+
+        Assert.assertEquals(parallelFetchesBefore + 1, HdfsFetcherAggStats.getStats().getParallelFetches());
+        Assert.assertEquals(totalFetchRetiesBefore + 1, HdfsFetcherAggStats.getStats().getTotalFetchRetries());
+    }
+
+    @Test
+    public void testGetTotalDataFetchRateWithoutStorePush() {
+        synchronized (HdfsFetcherAggStats.class) {
+            Assert.assertEquals(0, HdfsFetcherAggStats.getStats().getTotalDataFetchRate(), 0);
+        }
+    }
+
+    @Test
+    public void testGetTotalDataFetchRateWithTwoStorePushes() {
+        // Mock two HdfsCopyStats objects
+        String testStore1 = "test1";
+        HdfsCopyStats stats1 = Mockito.mock(HdfsCopyStats.class);
+        BDDMockito.given(stats1.getBytesTransferredPerSecond()).willReturn(100.2);
+
+        String testStore2 = "test2";
+        HdfsCopyStats stats2 = Mockito.mock(HdfsCopyStats.class);
+        BDDMockito.given(stats2.getBytesTransferredPerSecond()).willReturn(50.3);
+
+        // Add them into aggregated stats object
+        HdfsFetcherAggStats.getStats().addStoreCopyStats(testStore1, stats1);
+        HdfsFetcherAggStats.getStats().addStoreCopyStats(testStore2, stats2);
+
+        double totalDataFetchRate = HdfsFetcherAggStats.getStats().getTotalDataFetchRate();
+
+        // Remove them to avoid side effect
+        HdfsFetcherAggStats.getStats().removeStoreCopyStats(testStore1);
+        HdfsFetcherAggStats.getStats().removeStoreCopyStats(testStore2);
+
+        Assert.assertEquals(150.5, totalDataFetchRate, 0);
+        // After removal, the data transfer rate should be 0
+        Assert.assertEquals(0, HdfsFetcherAggStats.getStats().getTotalDataFetchRate(), 0);
+
+    }
+}

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherAdvancedTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherAdvancedTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008-2009 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -80,6 +80,8 @@ public class HdfsFetcherAdvancedTest {
     FSDataInputStream input;
     byte[] buffer;
 
+    private final String storeName = "test";
+
     @Parameters
     public static Collection<Object[]> configs() {
         return Arrays.asList(new Object[][] { { false, true }, { true, false } });
@@ -112,7 +114,7 @@ public class HdfsFetcherAdvancedTest {
 
     /**
      * Create a temporary directory that is a child of the given directory
-     * 
+     *
      * @param parent The parent directory
      * @return The temporary directory
      */
@@ -216,11 +218,12 @@ public class HdfsFetcherAdvancedTest {
         File destination = new File(testDestDir.getAbsolutePath() + "1");
 
         stats = new HdfsCopyStats(sourceString,
-                                  destination,
-                                  enableStatsFile,
-                                  5,
-                                  false,
-                                  hdfsPathInfo);
+                destination,
+                enableStatsFile,
+                5,
+                false,
+                hdfsPathInfo,
+                storeName);
         copyLocation = new File(destination, finalIndexFileName);
 
         Utils.mkdirs(destination);
@@ -280,7 +283,7 @@ public class HdfsFetcherAdvancedTest {
 
     /*
      * Tests that HdfsFetcher can correctly fetch a file in happy path
-     * 
+     *
      * Checks for both checksum and correctness in case of decompression.
      */
     @Test
@@ -505,7 +508,7 @@ public class HdfsFetcherAdvancedTest {
     /*
      * Tests that HdfsFetcher can correctly fetch a file when there is an
      * IOException, specifically an EofException during the fetch
-     * 
+     *
      * For a compressed input, exception is acceptable.
      */
     @Test
@@ -569,7 +572,7 @@ public class HdfsFetcherAdvancedTest {
     /*
      * Tests that HdfsFetcher can correctly handle when there is an
      * RuntimeException
-     * 
+     *
      * Expected- the exception should be consumed without spilling it over
      */
 
@@ -594,12 +597,12 @@ public class HdfsFetcherAdvancedTest {
     /*
      * Tests that corrupted compressed stream triggers exception when servers
      * starts to decompress.
-     * 
+     *
      * 1. We produce random bytes in index and data files
-     * 
+     *
      * 2. We rename them to end with ".gz" to simulate corrupted compressed
      * streams
-     * 
+     *
      * 3. We run the fetcher. Fetcher would see the ".gz" extension and starts
      * decompressing and does not find right GZIP headers . Thus produces
      * exception.

--- a/src/java/voldemort/server/VoldemortServer.java
+++ b/src/java/voldemort/server/VoldemortServer.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008-2013 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -65,10 +65,10 @@ import com.google.common.collect.Lists;
 
 /**
  * This is the main server, it bootstraps all the services.
- * 
+ *
  * It can be embedded or run directly via it's main method.
- * 
- * 
+ *
+ *
  */
 public class VoldemortServer extends AbstractService {
 
@@ -104,7 +104,7 @@ public class VoldemortServer extends AbstractService {
     /**
      * Constructor is used exclusively by tests. I.e., this is not a code path
      * that is exercised in production.
-     * 
+     *
      * @param config
      * @param cluster
      */
@@ -120,7 +120,7 @@ public class VoldemortServer extends AbstractService {
         // update cluster details in metaDataStore
         ConfigurationStorageEngine metadataInnerEngine = new ConfigurationStorageEngine("metadata-config-store",
                                                                                         voldemortConfig.getMetadataDirectory());
-        
+
         List<Versioned<String>> clusterXmlValue = metadataInnerEngine.get(MetadataStore.CLUSTER_KEY,
                                                                           null);
 
@@ -161,7 +161,7 @@ public class VoldemortServer extends AbstractService {
     /**
      * Compare the configured hostname with all the ip addresses and hostnames
      * for the server node, and log a warning if there is a mismatch.
-     * 
+     *
      */
     // TODO: VoldemortServer should throw exception if cluster xml, node id, and
     // server's state are not all mutually consistent.
@@ -347,7 +347,7 @@ public class VoldemortServer extends AbstractService {
             jmxService = new JmxService(this, this.metadata.getCluster(), storeRepository, services);
             services.add(jmxService);
         }
-        
+
         return ImmutableList.copyOf(services);
     }
 
@@ -410,7 +410,7 @@ public class VoldemortServer extends AbstractService {
     /**
      * Attempt to shutdown the server. As much shutdown as possible will be
      * completed, even if intermediate errors are encountered.
-     * 
+     *
      * @throws VoldemortException
      */
     @Override


### PR DESCRIPTION
This change is mostly to expose more aggregated metrics for HDFS data pushes:
1. totalBytesFetched : the total bytes transferred from HDFS so far;
2. totalFetchRetries : the total fetch retry number so far;
3. totalCheckSumFailures : the total data file checksum failures
happened so far;
4. totalAuthenticationFailures : the total authentication failures
happened so far;
5. totalFileNotFoundFailures : the total file-not-found failures
happened so far;
6. totalFileReadFailures : the total HDFS file read failures happened so
far;
7. totalQuotaExceedFailures : the total quota exceed failures happened
so far;
8. totalUnauthorizedStoreFailures : the total unauthorized store push
failures happened so far;
9. parallelFetches : the total number of active fetches right now;
10. totalFetches : the total HDFS fetch number so far;
11. totalIncompleteFetches : the total incomplete fetch number so far;
12. totalDataFetchRate : the total data fetch rate right now;