### PR TITLE
Expose data points in FileFetcher and create autometrics sensors for them

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/BasicFetchStrategy.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/BasicFetchStrategy.java
@@ -102,6 +102,7 @@ public class BasicFetchStrategy implements FetchStrategy {
             boolean fsOpened = false;
             bufferCheckSumGenerator = null;
 
+            stats.singleFileFetchStart(attempt != 1);
             try {
                 // Create a per file checksum generator
                 if (checkSumType != null) {
@@ -206,6 +207,8 @@ public class BasicFetchStrategy implements FetchStrategy {
                     throw e;
                 }
             } finally {
+                stats.singleFileFetchEnd();
+
                 IOUtils.closeQuietly(output);
                 IOUtils.closeQuietly(input);
                 if(success) {

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -215,7 +215,12 @@ public class HdfsFetcher implements FileFetcher {
         FileSystem fs = null;
         sourceFileUrl = VoldemortUtils
             .modifyURL(sourceFileUrl, voldemortConfig.getModifiedProtocol(), voldemortConfig.getModifiedPort());
+        // Flag to indicate whether the fetch is complete or not
+        boolean isCompleteFetch = false;
         try {
+            // Record as one store fetch
+            HdfsCopyStats.storeFetch();
+
             fs = HadoopUtils.getHadoopFileSystem(voldemortConfig, sourceFileUrl);
             final Path rootPath = new Path(sourceFileUrl);
             File destination = new File(destinationFile);
@@ -228,11 +233,11 @@ public class HdfsFetcher implements FileFetcher {
             boolean isFile = fs.isFile(rootPath);
 
             stats = new HdfsCopyStats(sourceFileUrl,
-                                      destination,
-                                      false, // stats file initially disabled, to fetch just the first metadata file
-                                      maxVersionsStatsFile,
-                                      isFile,
-                                      null);
+                    destination,
+                    false, // stats file initially disabled, to fetch just the first metadata file
+                    maxVersionsStatsFile,
+                    isFile,
+                    null);
             jmxName = JmxUtils.registerMbean("hdfs-copy-" + copyCount.getAndIncrement(), stats);
             logger.info("Starting fetch for : " + sourceFileUrl);
 
@@ -314,10 +319,12 @@ public class HdfsFetcher implements FileFetcher {
                     if(directoryToFetch.validateCheckSum(fileCheckSumMap)) {
                         logger.info("Completed fetch: " + sourceFileUrl);
                     } else {
+                        stats.checkSumFailed();
                         logger.error("Checksum did not match for " + directoryToFetch.toString() + " !");
                         return null;
                     }
                 }
+                isCompleteFetch = true;
                 return destination;
             } else if (allowFetchingOfSingleFile) {
                 /** This code path is only used by {@link #main(String[])} */
@@ -327,6 +334,7 @@ public class HdfsFetcher implements FileFetcher {
                 File copyLocation = new File(destination, fileName);
                 fetchStrategy.fetch(file, copyLocation, CheckSumType.NONE);
                 logger.info("Completed fetch : " + sourceFileUrl);
+                isCompleteFetch = true;
                 return destination;
             } else {
                 logger.error("Source " + rootPath.toString() + " should be a directory");
@@ -336,6 +344,10 @@ public class HdfsFetcher implements FileFetcher {
             if(stats != null) {
                 stats.reportError("File fetcher failed for destination " + destinationFile, e);
             }
+            // Since AuthenticationException may happen before stats object initialization (HadoopUtils.getHadoopFileSystem),
+            // we use the static method to capture all the exceptions here.
+            HdfsCopyStats.reportExceptionForStats(e);
+
             if(e instanceof VoldemortException) {
                 throw e;
             } else {
@@ -347,6 +359,9 @@ public class HdfsFetcher implements FileFetcher {
 
             if(stats != null) {
                 stats.complete();
+            }
+            if (!isCompleteFetch) {
+                HdfsCopyStats.incompleteFetch();
             }
 
             if(fs != null) {

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcherAggStats.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcherAggStats.java
@@ -1,0 +1,184 @@
+package voldemort.store.readonly.fetcher;
+
+import io.tehuti.Metric;
+import io.tehuti.metrics.MetricConfig;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Rate;
+import voldemort.annotations.jmx.JmxGetter;
+import voldemort.store.stats.StoreStats;
+import voldemort.utils.JmxUtils;
+
+import java.util.concurrent.TimeUnit;
+
+/*
+ * This class is used to capture the aggregated metrics for all the file pulls from Hdfs,
+ * and expose them through JMX Bean.
+ */
+public class HdfsFetcherAggStats {
+    // A singleton for all the data pull tasks
+    private static final HdfsFetcherAggStats stats;
+
+    // Total bytes fetched by all the data pull tasks
+    private long totalBytesFetched;
+    // Total Hdfs fetch retry number
+    private long totalFetchRetries;
+    // Total checksum failures
+    private long totalCheckSumFailures;
+    // Total file read failures
+    private long totalFileReadFailures;
+    // Total authentication failures
+    private long totalAuthenticationFailures;
+    // Total file not found failures
+    private long totalFileNotFoundFailures;
+    // Total quota exceed failures
+    private long totalQuotaExceedFailures;
+    // Total unauthorized store failures
+    private long totalUnauthorizedStoreFailures;
+
+    // Parallel active fetch number
+    // This metric is only used to capture the active fetches number right now
+    private int parallelFetches;
+    // Total Hdfs fetch number
+    private long totalFetches;
+
+    // TODO: Max number of parallel fetches (if there are more than one running at the same time)
+    // Need to use Tehuti lib
+
+    // Total number for incomplete fetches
+    private long totalIncompleteFetches;
+
+    // TODO: File fetcher average and max connection times (NameNode and DataNode)
+    // Not sure how to extract those metrics
+
+    // Metrics repository for data transfer rate
+    private static final MetricsRepository metricsRepository;
+    private static final Sensor dataTransferRateSensor;
+    private static final Metric dataTransferMetric;
+
+    // Register the global aggregated stats object in Bean Server
+    static {
+        stats = new HdfsFetcherAggStats();
+        JmxUtils.registerMbean("hdfs-fetcher-agg-stats", stats);
+
+        // Metric repository
+        metricsRepository = new MetricsRepository();
+        MetricConfig dataTransferRateConfig = new MetricConfig().timeWindow(StoreStats.timeWindow, TimeUnit.MILLISECONDS);
+        dataTransferRateSensor = metricsRepository.sensor("hdfs-fetcher-agg-data-transfer");
+        Rate dataTransferStat = new Rate(TimeUnit.SECONDS);
+        dataTransferMetric = dataTransferRateSensor.add("data-transfer.rate", dataTransferStat, dataTransferRateConfig);
+    }
+
+    private HdfsFetcherAggStats() {}
+
+    public static HdfsFetcherAggStats getStats() {
+        return stats;
+    }
+
+    public synchronized void recordBytesTransferred(long bytesTransferred) {
+        totalBytesFetched += bytesTransferred;
+        dataTransferRateSensor.record(bytesTransferred);
+    }
+
+    public synchronized void storeFetch() {
+        ++totalFetches;
+    }
+    public synchronized void singleFileFetchStart(boolean isRetry) {
+        ++parallelFetches;
+        if (isRetry) {
+            ++totalFetchRetries;
+        }
+    }
+
+    public synchronized void singleFileFetchEnd() {
+        --parallelFetches;
+    }
+
+    public synchronized void checkSumFailed() {
+        ++totalCheckSumFailures;
+    }
+
+    public synchronized void authenticateFailed() {
+        ++totalAuthenticationFailures;
+    }
+
+    public synchronized void fileNotFound() {
+        ++totalFileNotFoundFailures;
+    }
+
+    public synchronized void fileReadFailed() {
+        ++totalFileReadFailures;
+    }
+
+    public synchronized void quotaCheckFailed() {
+        ++totalQuotaExceedFailures;
+    }
+
+    public synchronized void unauthorizedStorePush() {
+        ++totalUnauthorizedStoreFailures;
+    }
+
+    public synchronized void incompleteFetch() {
+        ++totalIncompleteFetches;
+    }
+
+    @JmxGetter(name = "totalBytesFetched", description = "The total bytes transferred from HDFS so far.")
+    public synchronized long getTotalBytesFetched() {
+        return totalBytesFetched;
+    }
+
+    @JmxGetter(name = "totalFetchRetries", description = "The total fetch retry number so far.")
+    public synchronized long getTotalFetchRetries() {
+        return totalFetchRetries;
+    }
+
+    @JmxGetter(name = "totalCheckSumFailures", description = "The total data file checksum failures happened so far.")
+    public synchronized long getTotalCheckSumFailures() {
+        return totalCheckSumFailures;
+    }
+
+    @JmxGetter(name = "totalAuthenticationFailures", description = "The total authentication failures happened so far.")
+    public synchronized long getTotalAuthenticationFailures() {
+        return totalAuthenticationFailures;
+    }
+
+    @JmxGetter(name = "totalFileNotFoundFailures", description = "The total file-not-found failures happened so far.")
+    public synchronized long getTotalFileNotFoundFailures() {
+        return totalFileNotFoundFailures;
+    }
+
+    @JmxGetter(name = "totalFileReadFailures", description = "The total HDFS file read failures happened so far.")
+    public synchronized long getTotalFileReadFailures() {
+        return totalFileReadFailures;
+    }
+
+    @JmxGetter(name = "totalQuotaExceedFailures", description = "The total quota exceed failures happened so far.")
+    public synchronized long getTotalQuotaExceedFailures() {
+        return totalQuotaExceedFailures;
+    }
+
+    @JmxGetter(name = "totalUnauthorizedStoreFailures", description = "The total unauthorized store push failures happened so far.")
+    public synchronized long getTotalUnauthorizedStoreFailures() {
+        return  totalUnauthorizedStoreFailures;
+    }
+
+    @JmxGetter(name = "parallelFetches", description = "The total number of active fetches right now.")
+    public synchronized int getParallelFetches() {
+        return parallelFetches;
+    }
+
+    @JmxGetter(name = "totalFetches", description = "The total HDFS fetch number so far.")
+    public synchronized long getTotalFetches() {
+        return totalFetches;
+    }
+
+    @JmxGetter(name = "totalIncompleteFetches", description = "The total incomplete fetch number so far.")
+    public synchronized long getTotalIncompleteFetches() {
+        return totalIncompleteFetches;
+    }
+
+    @JmxGetter(name = "totalDataFetchRate", description = "The total data fetch rate right now.")
+    public synchronized double getTotalDataFetchRate() {
+        return dataTransferMetric.value();
+    }
+}

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsCopyStatsTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsCopyStatsTest.java
@@ -2,21 +2,35 @@ package voldemort.store.readonly.fetcher;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import voldemort.store.quota.QuotaExceededException;
+import voldemort.store.readonly.UnauthorizedStoreException;
+
+import java.lang.reflect.Type;
+import java.lang.Exception;
 
 @RunWith(Parameterized.class)
 public class HdfsCopyStatsTest {
@@ -56,11 +70,11 @@ public class HdfsCopyStatsTest {
             // linux timestamp has second granularity, so sleep for a second
             Thread.sleep(1000);
             HdfsCopyStats stats = new HdfsCopyStats(testSourceDir.getAbsolutePath(),
-                                                    destination,
-                                                    enableStatsFile,
-                                                    maxStatsFile,
-                                                    isFileCopy,
-                                                    HdfsPathInfo.getTestObject(1000));
+                    destination,
+                    enableStatsFile,
+                    maxStatsFile,
+                    isFileCopy,
+                    HdfsPathInfo.getTestObject(1000));
 
             if(stats.getStatsFile() != null) {
                 expectedStatsFile.add(stats.getStatsFile().getName());
@@ -123,5 +137,79 @@ public class HdfsCopyStatsTest {
             HdfsFetcherAdvancedTest.deleteDir(testSourceDir);
         if(statsDir != null)
             HdfsFetcherAdvancedTest.deleteDir(statsDir);
+    }
+
+    @Test
+    public void testRecordBytesTransferred() {
+        HdfsCopyStats stats = new HdfsCopyStats(null,
+                null,
+                false,
+                3,
+                false,
+                null);
+        long totalAggBytesFetchedBefore = HdfsFetcherAggStats.getStats().getTotalBytesFetched();
+        stats.recordBytesTransferred(100);
+        stats.complete();
+
+        assertEquals(100, stats.getBytesTransferredSinceLastReport(), 0);
+        assertEquals(100, stats.getBytesTransferredSinceLastReport(), 0);
+        assertEquals(100, stats.getTotalBytesTransferred(), 0);
+        assertEquals(totalAggBytesFetchedBefore + 100, HdfsFetcherAggStats.getStats().getTotalBytesFetched(), 0);
+    }
+
+    private Map<String, Long> buildMethodResultMap(long authenticateFailedRes,
+                                      long fileNotFoundRes,
+                                      long fileReadFailedRes,
+                                      long quotaCheckFailedRes,
+                                      long unauthorizedStorePushRes) {
+        Map<String, Long> resMap = new HashMap<String, Long>();
+        resMap.put("getTotalAuthenticationFailures", new Long(authenticateFailedRes));
+        resMap.put("getTotalFileNotFoundFailures", new Long(fileNotFoundRes));
+        resMap.put("getTotalFileReadFailures", new Long(fileReadFailedRes));
+        resMap.put("getTotalQuotaExceedFailures", new Long(quotaCheckFailedRes));
+        resMap.put("getTotalUnauthorizedStoreFailures", new Long(unauthorizedStorePushRes));
+
+        return resMap;
+    }
+
+    private Map<String, Long> invokeInternalMethod(HdfsFetcherAggStats stats, Set<String> methodNames)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Map<String, Long> res = new HashMap<String, Long>();
+        for (String methodName : methodNames) {
+            Long methodRes = (Long)stats.getClass().getMethod(methodName).invoke(stats);
+            res.put(methodName, methodRes);
+        }
+
+        return res;
+    }
+
+    @Test
+    public void testReportExceptionForStats()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Map<Exception, Map> config = new HashMap<Exception, Map>();
+        config.put(new Exception(new AuthenticationException("test")), buildMethodResultMap(1, 0, 0, 0, 0));
+        config.put(new FileNotFoundException(), buildMethodResultMap(0, 1, 0, 0, 0));
+        config.put(new IOException(), buildMethodResultMap(0, 0, 1, 0, 0));
+        config.put(new QuotaExceededException("test"), buildMethodResultMap(0, 0, 0, 1, 0));
+        config.put(new UnauthorizedStoreException("test"), buildMethodResultMap(0, 0, 0, 0, 1));
+
+        HdfsFetcherAggStats aggStats = HdfsFetcherAggStats.getStats();
+
+        for (Map.Entry<Exception, Map> entry : config.entrySet()) {
+            Exception e = entry.getKey();
+            Map<String, Long> methodResMap = entry.getValue();
+            Set<String> methodSet = methodResMap.keySet();
+            // Get result before invocation
+            Map<String, Long> beforeRes = invokeInternalMethod(aggStats, methodSet);
+            HdfsCopyStats.reportExceptionForStats(e);
+            // Get result after invocation
+            Map<String, Long> afterRes = invokeInternalMethod(aggStats, methodSet);
+            // Compare the difference
+            for (String methodName : methodSet) {
+                String msg = "Method expects " + methodResMap.get(methodName) + " with exception: " + e.getClass().getName();
+                assertEquals(msg, methodResMap.get(methodName).longValue(),
+                        afterRes.get(methodName).longValue() - beforeRes.get(methodName).longValue());
+            }
+        }
     }
 }

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetchAggStatsTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetchAggStatsTest.java
@@ -1,0 +1,28 @@
+package voldemort.store.readonly.fetcher;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+
+public class HdfsFetchAggStatsTest {
+    @Test
+    public void testSingleFileFetchStartWithoutRetry() {
+        long parallelFetchesBefore = HdfsFetcherAggStats.getStats().getParallelFetches();
+        long totalFetchRetiesBefore = HdfsFetcherAggStats.getStats().getTotalFetchRetries();
+        HdfsFetcherAggStats.getStats().singleFileFetchStart(false);
+
+        Assert.assertEquals(parallelFetchesBefore + 1, HdfsFetcherAggStats.getStats().getParallelFetches());
+        Assert.assertEquals(totalFetchRetiesBefore, HdfsFetcherAggStats.getStats().getTotalFetchRetries());
+    }
+
+    @Test
+    public void testSingleFileFetchStartWithRetry() {
+        long parallelFetchesBefore = HdfsFetcherAggStats.getStats().getParallelFetches();
+        long totalFetchRetiesBefore = HdfsFetcherAggStats.getStats().getTotalFetchRetries();
+        HdfsFetcherAggStats.getStats().singleFileFetchStart(true);
+
+        Assert.assertEquals(parallelFetchesBefore + 1, HdfsFetcherAggStats.getStats().getParallelFetches());
+        Assert.assertEquals(totalFetchRetiesBefore + 1, HdfsFetcherAggStats.getStats().getTotalFetchRetries());
+    }
+}

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherAdvancedTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherAdvancedTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008-2009 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -112,7 +112,7 @@ public class HdfsFetcherAdvancedTest {
 
     /**
      * Create a temporary directory that is a child of the given directory
-     * 
+     *
      * @param parent The parent directory
      * @return The temporary directory
      */
@@ -216,11 +216,11 @@ public class HdfsFetcherAdvancedTest {
         File destination = new File(testDestDir.getAbsolutePath() + "1");
 
         stats = new HdfsCopyStats(sourceString,
-                                  destination,
-                                  enableStatsFile,
-                                  5,
-                                  false,
-                                  hdfsPathInfo);
+                destination,
+                enableStatsFile,
+                5,
+                false,
+                hdfsPathInfo);
         copyLocation = new File(destination, finalIndexFileName);
 
         Utils.mkdirs(destination);
@@ -280,7 +280,7 @@ public class HdfsFetcherAdvancedTest {
 
     /*
      * Tests that HdfsFetcher can correctly fetch a file in happy path
-     * 
+     *
      * Checks for both checksum and correctness in case of decompression.
      */
     @Test
@@ -505,7 +505,7 @@ public class HdfsFetcherAdvancedTest {
     /*
      * Tests that HdfsFetcher can correctly fetch a file when there is an
      * IOException, specifically an EofException during the fetch
-     * 
+     *
      * For a compressed input, exception is acceptable.
      */
     @Test
@@ -569,7 +569,7 @@ public class HdfsFetcherAdvancedTest {
     /*
      * Tests that HdfsFetcher can correctly handle when there is an
      * RuntimeException
-     * 
+     *
      * Expected- the exception should be consumed without spilling it over
      */
 
@@ -594,12 +594,12 @@ public class HdfsFetcherAdvancedTest {
     /*
      * Tests that corrupted compressed stream triggers exception when servers
      * starts to decompress.
-     * 
+     *
      * 1. We produce random bytes in index and data files
-     * 
+     *
      * 2. We rename them to end with ".gz" to simulate corrupted compressed
      * streams
-     * 
+     *
      * 3. We run the fetcher. Fetcher would see the ".gz" extension and starts
      * decompressing and does not find right GZIP headers . Thus produces
      * exception.

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/fetcher/HdfsFetcherTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008-2009 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -33,8 +33,8 @@ import voldemort.store.readonly.checksum.CheckSum.CheckSumType;
 
 /**
  * Tests for the HDFS-based fetcher
- * 
- * 
+ *
+ *
  */
 public class HdfsFetcherTest extends TestCase {
 
@@ -167,5 +167,206 @@ public class HdfsFetcherTest extends TestCase {
         assertNotNull(fetchedFile);
         checkSumFile.delete();
 
+    }
+
+    public void testAggStatsWithValidFile() throws Exception {
+        HdfsFetcherAggStats stats = HdfsFetcherAggStats.getStats();
+        long totalBytesFetchedBefore = stats.getTotalBytesFetched();
+        long totalFetchesBefore = stats.getTotalFetches();
+        double totalDataFetchRateBefore = stats.getTotalDataFetchRate();
+
+        // Generate 0_0.[index | data] and their corresponding metadata
+        File testSourceDirectory = TestUtils.createTempDir();
+        File testDestinationDirectory = TestUtils.createTempDir();
+
+        // Missing metadata file
+        File indexFile = new File(testSourceDirectory, "0_0.index");
+        FileUtils.writeByteArrayToFile(indexFile, TestUtils.randomBytes(100));
+
+        File dataFile = new File(testSourceDirectory, "0_0.data");
+        FileUtils.writeByteArrayToFile(dataFile, TestUtils.randomBytes(400));
+
+        File metadataFile = new File(testSourceDirectory, ".metadata");
+        ReadOnlyStorageMetadata metadata = new ReadOnlyStorageMetadata();
+        metadata.add(ReadOnlyStorageMetadata.FORMAT, ReadOnlyStorageFormat.READONLY_V2.getCode());
+        metadata.add(ReadOnlyStorageMetadata.CHECKSUM,
+                new String(Hex.encodeHex(CheckSumTests.calculateCheckSum(testSourceDirectory.listFiles(),
+                        CheckSumType.MD5))));
+        FileUtils.writeStringToFile(metadataFile, metadata.toJsonString());
+
+        HdfsFetcher fetcher = new HdfsFetcher();
+        File fetchedFile = fetcher.fetch(testSourceDirectory.getAbsolutePath(),
+                testDestinationDirectory.getAbsolutePath() + "1");
+        assertNotNull(fetchedFile);
+        assertEquals(fetchedFile.getAbsolutePath(), testDestinationDirectory.getAbsolutePath()
+                + "1");
+
+        // The total bytes fetched includes meta data file as well.
+        assertEquals(totalBytesFetchedBefore + 500 + metadata.toJsonString().length(), stats.getTotalBytesFetched());
+        assertEquals(totalFetchesBefore + 1, stats.getTotalFetches());
+        assertTrue(stats.getTotalDataFetchRate() > totalDataFetchRateBefore);
+    }
+
+    public void testAggStatsWithInvalidMetaFile() throws Exception {
+        HdfsFetcherAggStats stats = HdfsFetcherAggStats.getStats();
+        long totalBytesFetchedBefore = stats.getTotalBytesFetched();
+        long totalFileReadFailuresBefore = stats.getTotalFileReadFailures();
+        long totalFetchesBefore = stats.getTotalFetches();
+        long totalIncompleteFetchesBefore = stats.getTotalIncompleteFetches();
+
+        File testSourceDirectory = TestUtils.createTempDir();
+        File testDestinationDirectory = TestUtils.createTempDir();
+
+        // Missing metadata file
+        File indexFile = new File(testSourceDirectory, "0_0.index");
+        FileUtils.writeByteArrayToFile(indexFile, TestUtils.randomBytes(100));
+
+        File dataFile = new File(testSourceDirectory, "0_0.data");
+        FileUtils.writeByteArrayToFile(dataFile, TestUtils.randomBytes(400));
+
+        HdfsFetcher fetcher = new HdfsFetcher();
+
+        // Write bad metadata file
+        File metadataFile = new File(testSourceDirectory, ".metadata");
+        FileUtils.writeByteArrayToFile(metadataFile, TestUtils.randomBytes(100));
+        try {
+            File fetchedFile = fetcher.fetch(testSourceDirectory.getAbsolutePath(),
+                    testDestinationDirectory.getAbsolutePath() + "1");
+            fail("Should have thrown an exception since metadata file is corrupt");
+        } catch(VoldemortException e) {}
+        metadataFile.delete();
+
+        // The total bytes fetched includes meta data file as well.
+        assertEquals(totalBytesFetchedBefore + 100, stats.getTotalBytesFetched());
+        assertEquals(totalFileReadFailuresBefore + 1, stats.getTotalFileReadFailures());
+        assertEquals(totalFetchesBefore + 1, stats.getTotalFetches());
+        assertEquals(totalIncompleteFetchesBefore + 1, stats.getTotalIncompleteFetches());
+    }
+
+    public void testAggStatsWithQuotaExceedException() throws Exception {
+        HdfsFetcherAggStats stats = HdfsFetcherAggStats.getStats();
+        long totalBytesFetchedBefore = stats.getTotalBytesFetched();
+        long totalQuotaExceedFailuresBefore = stats.getTotalQuotaExceedFailures();
+        long totalFetchesBefore = stats.getTotalFetches();
+        long totalIncompleteFetchesBefore = stats.getTotalIncompleteFetches();
+
+        // Generate 0_0.[index | data] and their corresponding metadata
+        File testSourceDirectory = TestUtils.createTempDir();
+        File testDestinationDirectory = TestUtils.createTempDir();
+
+        // Missing metadata file
+        File indexFile = new File(testSourceDirectory, "0_0.index");
+        FileUtils.writeByteArrayToFile(indexFile, TestUtils.randomBytes(1000));
+
+        File dataFile = new File(testSourceDirectory, "0_0.data");
+        FileUtils.writeByteArrayToFile(dataFile, TestUtils.randomBytes(4000));
+
+        File metadataFile = new File(testSourceDirectory, ".metadata");
+        ReadOnlyStorageMetadata metadata = new ReadOnlyStorageMetadata();
+        metadata.add(ReadOnlyStorageMetadata.FORMAT, ReadOnlyStorageFormat.READONLY_V2.getCode());
+        metadata.add(ReadOnlyStorageMetadata.CHECKSUM,
+                new String(Hex.encodeHex(CheckSumTests.calculateCheckSum(testSourceDirectory.listFiles(),
+                        CheckSumType.MD5))));
+        metadata.add(ReadOnlyStorageMetadata.DISK_SIZE_IN_BYTES, "5000");
+        FileUtils.writeStringToFile(metadataFile, metadata.toJsonString());
+
+        HdfsFetcher fetcher = new HdfsFetcher();
+        File fetchedFile = null;
+        try {
+            fetchedFile = fetcher.fetch(testSourceDirectory.getAbsolutePath(),
+                    testDestinationDirectory.getAbsolutePath() + "1", 1);
+        } catch (Exception e)
+        {}
+        assertNull(fetchedFile);
+
+        // The total bytes fetched includes meta data file as well.
+        assertEquals(totalBytesFetchedBefore + metadata.toJsonString().length(), stats.getTotalBytesFetched());
+        assertEquals(totalQuotaExceedFailuresBefore + 1, stats.getTotalQuotaExceedFailures());
+        assertEquals(totalFetchesBefore + 1, stats.getTotalFetches());
+        assertEquals(totalIncompleteFetchesBefore + 1, stats.getTotalIncompleteFetches());
+    }
+
+    public void testAggStatsWithUnauthorizedStoreException() throws Exception {
+        HdfsFetcherAggStats stats = HdfsFetcherAggStats.getStats();
+        long totalBytesFetchedBefore = stats.getTotalBytesFetched();
+        long totalUnauthorizedStoreFailuresBefore = stats.getTotalUnauthorizedStoreFailures();
+        long totalFetchesBefore = stats.getTotalFetches();
+        long totalIncompleteFetchesBefore = stats.getTotalIncompleteFetches();
+
+        // Generate 0_0.[index | data] and their corresponding metadata
+        File testSourceDirectory = TestUtils.createTempDir();
+        File testDestinationDirectory = TestUtils.createTempDir();
+
+        // Missing metadata file
+        File indexFile = new File(testSourceDirectory, "0_0.index");
+        FileUtils.writeByteArrayToFile(indexFile, TestUtils.randomBytes(100));
+
+        File dataFile = new File(testSourceDirectory, "0_0.data");
+        FileUtils.writeByteArrayToFile(dataFile, TestUtils.randomBytes(400));
+
+        File metadataFile = new File(testSourceDirectory, ".metadata");
+        ReadOnlyStorageMetadata metadata = new ReadOnlyStorageMetadata();
+        metadata.add(ReadOnlyStorageMetadata.FORMAT, ReadOnlyStorageFormat.READONLY_V2.getCode());
+        metadata.add(ReadOnlyStorageMetadata.CHECKSUM,
+                new String(Hex.encodeHex(CheckSumTests.calculateCheckSum(testSourceDirectory.listFiles(),
+                        CheckSumType.MD5))));
+        metadata.add(ReadOnlyStorageMetadata.DISK_SIZE_IN_BYTES, "5000");
+        FileUtils.writeStringToFile(metadataFile, metadata.toJsonString());
+
+        HdfsFetcher fetcher = new HdfsFetcher();
+        File fetchedFile = null;
+        try {
+            fetchedFile = fetcher.fetch(testSourceDirectory.getAbsolutePath(),
+                    testDestinationDirectory.getAbsolutePath() + "1", 0);
+        } catch (Exception e)
+        {}
+        assertNull(fetchedFile);
+
+        // The total bytes fetched includes meta data file as well.
+        assertEquals(totalBytesFetchedBefore + metadata.toJsonString().length(), stats.getTotalBytesFetched());
+        assertEquals(totalUnauthorizedStoreFailuresBefore + 1, stats.getTotalUnauthorizedStoreFailures());
+        assertEquals(totalFetchesBefore + 1, stats.getTotalFetches());
+        assertEquals(totalIncompleteFetchesBefore + 1, stats.getTotalIncompleteFetches());
+    }
+
+    public void testAggStatsWithCheckSumFailure() throws Exception {
+        HdfsFetcherAggStats stats = HdfsFetcherAggStats.getStats();
+        long totalBytesFetchedBefore = stats.getTotalBytesFetched();
+        long totalCheckSumFailuresBefore = stats.getTotalCheckSumFailures();
+        long totalFetchesBefore = stats.getTotalFetches();
+        long totalIncompleteFetchesBefore = stats.getTotalIncompleteFetches();
+
+        // Generate 0_0.[index | data] and their corresponding metadata
+        File testSourceDirectory = TestUtils.createTempDir();
+        File testDestinationDirectory = TestUtils.createTempDir();
+
+        // Missing metadata file
+        File indexFile = new File(testSourceDirectory, "0_0.index");
+        FileUtils.writeByteArrayToFile(indexFile, TestUtils.randomBytes(100));
+
+        File dataFile = new File(testSourceDirectory, "0_0.data");
+        FileUtils.writeByteArrayToFile(dataFile, TestUtils.randomBytes(400));
+
+        File metadataFile = new File(testSourceDirectory, ".metadata");
+        ReadOnlyStorageMetadata metadata = new ReadOnlyStorageMetadata();
+        metadata.add(ReadOnlyStorageMetadata.FORMAT, ReadOnlyStorageFormat.READONLY_V2.getCode());
+        metadata.add(ReadOnlyStorageMetadata.CHECKSUM_TYPE, CheckSum.toString(CheckSumType.MD5));
+        metadata.add(ReadOnlyStorageMetadata.CHECKSUM, "1234");
+        FileUtils.writeStringToFile(metadataFile, metadata.toJsonString());
+
+        HdfsFetcher fetcher = new HdfsFetcher();
+        File fetchedFile = null;
+        try {
+            fetchedFile = fetcher.fetch(testSourceDirectory.getAbsolutePath(),
+                    testDestinationDirectory.getAbsolutePath() + "1");
+        } catch (Exception e)
+        {}
+        assertNull(fetchedFile);
+
+        // The total bytes fetched includes meta data file as well.
+        assertEquals(totalBytesFetchedBefore + 500 + metadata.toJsonString().length(), stats.getTotalBytesFetched());
+        assertEquals(totalCheckSumFailuresBefore + 1, stats.getTotalCheckSumFailures());
+        assertEquals(totalFetchesBefore + 1, stats.getTotalFetches());
+        assertEquals(totalIncompleteFetchesBefore + 1, stats.getTotalIncompleteFetches());
     }
 }

--- a/src/java/voldemort/server/VoldemortServer.java
+++ b/src/java/voldemort/server/VoldemortServer.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008-2013 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -65,10 +65,10 @@ import com.google.common.collect.Lists;
 
 /**
  * This is the main server, it bootstraps all the services.
- * 
+ *
  * It can be embedded or run directly via it's main method.
- * 
- * 
+ *
+ *
  */
 public class VoldemortServer extends AbstractService {
 
@@ -104,7 +104,7 @@ public class VoldemortServer extends AbstractService {
     /**
      * Constructor is used exclusively by tests. I.e., this is not a code path
      * that is exercised in production.
-     * 
+     *
      * @param config
      * @param cluster
      */
@@ -120,7 +120,7 @@ public class VoldemortServer extends AbstractService {
         // update cluster details in metaDataStore
         ConfigurationStorageEngine metadataInnerEngine = new ConfigurationStorageEngine("metadata-config-store",
                                                                                         voldemortConfig.getMetadataDirectory());
-        
+
         List<Versioned<String>> clusterXmlValue = metadataInnerEngine.get(MetadataStore.CLUSTER_KEY,
                                                                           null);
 
@@ -161,7 +161,7 @@ public class VoldemortServer extends AbstractService {
     /**
      * Compare the configured hostname with all the ip addresses and hostnames
      * for the server node, and log a warning if there is a mismatch.
-     * 
+     *
      */
     // TODO: VoldemortServer should throw exception if cluster xml, node id, and
     // server's state are not all mutually consistent.
@@ -347,7 +347,7 @@ public class VoldemortServer extends AbstractService {
             jmxService = new JmxService(this, this.metadata.getCluster(), storeRepository, services);
             services.add(jmxService);
         }
-        
+
         return ImmutableList.copyOf(services);
     }
 
@@ -410,7 +410,7 @@ public class VoldemortServer extends AbstractService {
     /**
      * Attempt to shutdown the server. As much shutdown as possible will be
      * completed, even if intermediate errors are encountered.
-     * 
+     *
      * @throws VoldemortException
      */
     @Override

--- a/src/java/voldemort/store/stats/StoreStats.java
+++ b/src/java/voldemort/store/stats/StoreStats.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2012 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -28,8 +28,8 @@ import voldemort.utils.JmxUtils;
 
 /**
  * Some convenient statistics to track about the store
- * 
- * 
+ *
+ *
  */
 public class StoreStats {
 
@@ -41,7 +41,7 @@ public class StoreStats {
 
     // RequestCounter config
     private static final boolean useHistogram = true;
-    private static final long timeWindow = 60000;
+    public static final long timeWindow = 60000;
 
     public StoreStats(String storeName) {
         this(storeName, null);
@@ -142,7 +142,7 @@ public class StoreStats {
 
     /**
      * Method to service public recording APIs
-     * 
+     *
      * @param op Operation being tracked
      * @param timeNS Duration of operation
      * @param numEmptyResponses Number of empty responses being sent back,

--- a/src/java/voldemort/utils/EventThrottler.java
+++ b/src/java/voldemort/utils/EventThrottler.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2013 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -28,14 +28,14 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * A class to throttle Events to a certain rate
- * 
+ *
  * This class takes a maximum rate in events/sec and a minimum interval over
  * which to check the rate. The rate is measured over two rolling windows: one
  * full window, and one in-flight window. Each window is bounded to the provided
  * interval in ms, therefore, the total interval measured over is up to twice
  * the provided interval parameter. If the current event rate exceeds the maximum,
  * the call to {@link #maybeThrottle(int)} will block long enough to equalize it.
- * 
+ *
  * This is a generalized IoThrottler as it existed before, which can be used to
  * throttle Bytes read or written, number of entries scanned, etc.
  */
@@ -129,7 +129,7 @@ public class EventThrottler {
 
     /**
      * Sleeps if necessary to slow down the caller.
-     * 
+     *
      * @param eventsSeen Number of events seen since last invocation. Basis for
      *        determining whether its necessary to sleep.
      */


### PR DESCRIPTION
This change is mostly to expose more aggregated metrics for HDFS data pushes pushes:
1. totalBytesFetched : the total bytes transferred from HDFS so far;
2. totalFetchRetries : the total fetch retry number so far;
3. totalCheckSumFailures : the total data file checksum failures
happened so far;
4. totalAuthenticationFailures : the total authentication failures
happened so far;
5. totalFileNotFoundFailures : the total file-not-found failures
happened so far;
6. totalFileReadFailures : the total HDFS file read failures happened so
far;
7. totalQuotaExceedFailures : the total quota exceed failures happened
so far;
8. totalUnauthorizedStoreFailures : the total unauthorized store push
failures happened so far;
9. parallelFetches : the total number of active fetches right now;
10. totalFetches : the total HDFS fetch number so far;
11. totalIncompleteFetches : the total incomplete fetch number so far;
12. totalDataFetchRate : the total data fetch rate right now;