### PR TITLE
The AdminClient's verifyOrAddStore is vulnerable to connectivity issues.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -936,6 +936,7 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
         try {
             adminClientPerCluster.get(clusterURL).storeMgmtOps.verifyOrAddStore(newStoreDef, "BnP config/data", enableStoreCreation);
         } catch (UnreachableStoreException e) {
+            log.info("verifyOrAddStore() failed on some nodes for clusterURL: " + clusterURL + " (this is harmless).", e);
             // When we can't reach some node, we just skip it and won't create the store on it.
             // Next time BnP is run while the node is up, it will get the store created.
         } // Other exceptions need to bubble up!

--- a/src/java/voldemort/tools/ReadOnlyReplicationHelperCLI.java
+++ b/src/java/voldemort/tools/ReadOnlyReplicationHelperCLI.java
@@ -183,23 +183,23 @@ public class ReadOnlyReplicationHelperCLI {
             String storageFormat = null;
             if(storeDef.getReplicationFactor() <= 1) {
                 logger.error("Store " + storeName +
-			     " cannot be restored, as it has replication factor = "
-                             + storeDef.getReplicationFactor());
+                        " cannot be restored, as it has replication factor = "
+                        + storeDef.getReplicationFactor());
                 continue;
-	    }
-	    if(!storeDef.getType().equals(ReadOnlyStorageConfiguration.TYPE_NAME)) {
+            }
+            if(!storeDef.getType().equals(ReadOnlyStorageConfiguration.TYPE_NAME)) {
                 logger.error("Store " + storeName +
-			     " cannot be restored, as it has type = " +
-                             storeDef.getType() +
-			     " instead of " +
-			     ReadOnlyStorageConfiguration.TYPE_NAME);
+                        " cannot be restored, as it has type = " +
+                        storeDef.getType() +
+                        " instead of " +
+                        ReadOnlyStorageConfiguration.TYPE_NAME);
                 continue;
-	    }
+            }
 
             logger.info("Processing store " + storeName);
 
             RoutingStrategy strategy = new RoutingStrategyFactory().updateRoutingStrategy(storeDef,
-                                                                                          cluster);
+                    cluster);
 
             // Go over the entire partitions and find if the destination node
             // belong in the replication partition list
@@ -230,8 +230,8 @@ public class ReadOnlyReplicationHelperCLI {
                 Node sourceNode = cluster.getNodeForPartitionId(naryPartitionIds.get(0));
                 Integer sourceNodeId = sourceNode.getId();
                 Long version = adminClient.readonlyOps.getROCurrentVersion(sourceNodeId,
-                                                                           Arrays.asList(storeName))
-                                                      .get(storeName);
+                        Arrays.asList(storeName))
+                        .get(storeName);
 
                 // Now get all the file names from this node.
                 List<String> fileNames = null;
@@ -241,7 +241,7 @@ public class ReadOnlyReplicationHelperCLI {
                     fileNames = getROStorageFileListLocally(srcPartitionIds, strategy);
                 } else {
                     fileNames = adminClient.readonlyOps.getROStorageFileList(sourceNode.getId(),
-                                                                             storeName);
+                            storeName);
                 }
 
                 List<String> sourceFileNames = parseAndCompare(fileNames, masterPartitionId);
@@ -261,19 +261,19 @@ public class ReadOnlyReplicationHelperCLI {
                         // Now concat the parts together to create the file name
                         // on the destination node
                         String destFileName = partitionId.concat(SPLIT_LITERAL)
-                                                         .concat(replicaId)
-                                                         .concat(SPLIT_LITERAL)
-                                                         .concat(chunkId);
+                                .concat(replicaId)
+                                .concat(SPLIT_LITERAL)
+                                .concat(chunkId);
                         String sourceRelPath = storeName + "/version-" + version + "/"
-                                               + sourceFileName;
+                                + sourceFileName;
                         String destRelPath = storeName + "/version-" + version + "/" + destFileName;
 
                         infoList.add(sourceNode.getHost() + "," + sourceNode.getId() + ","
-                                     + sourceRelPath + "," + destRelPath);
+                                + sourceRelPath + "," + destRelPath);
                     }
                 } else {
                     logger.warn("Cannot find file for partition " + masterPartitionId
-                                + " on source node " + sourceNode.getId());
+                            + " on source node " + sourceNode.getId());
                 }
             }
         }

--- a/src/java/voldemort/utils/ExceptionUtils.java
+++ b/src/java/voldemort/utils/ExceptionUtils.java
@@ -9,17 +9,25 @@ import java.io.StringWriter;
 public class ExceptionUtils {
     /**
      * Inspects a given {@link Throwable} as well as its nested causes, in order to look
-     * for a specific exception class.
+     * for a specific set of exception classes. The function also detects if the throwable
+     * to inspect is a subclass of one of the classes you look for, but not the other way
+     * around (i.e.: if you're looking for the subclass but the throwableToInspect is the
+     * parent class, then this function returns false).
      *
-     * @return true if a the throwableToInspect corresponds to or is caused by the throwableClassToLookFor
+     * @return true if a the throwableToInspect corresponds to or is caused by any of the throwableClassesToLookFor
      */
-    public static boolean recursiveClassEquals(Throwable throwableToInspect, Class throwableClassToLookFor) {
-        if (throwableToInspect.getClass().equals(throwableClassToLookFor)) {
-            return true;
-        } else {
-            Throwable cause = throwableToInspect.getCause();
-            return cause != null && recursiveClassEquals(cause, throwableClassToLookFor);
+    public static boolean recursiveClassEquals(Throwable throwableToInspect, Class... throwableClassesToLookFor) {
+        for (Class clazz: throwableClassesToLookFor) {
+            Class classToInspect = throwableToInspect.getClass();
+            while (classToInspect != null) {
+                if (classToInspect.equals(clazz)) {
+                    return true;
+                }
+                classToInspect = classToInspect.getSuperclass();
+            }
         }
+        Throwable cause = throwableToInspect.getCause();
+        return cause != null && recursiveClassEquals(cause, throwableClassesToLookFor);
     }
 
     /**

--- a/test/unit/voldemort/utils/ExceptionUtilsTest.java
+++ b/test/unit/voldemort/utils/ExceptionUtilsTest.java
@@ -1,0 +1,43 @@
+package voldemort.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import voldemort.VoldemortException;
+
+import java.io.IOException;
+import java.net.ConnectException;
+
+public class ExceptionUtilsTest {
+    @Test
+    public void testRecursiveClassEquals() {
+        Assert.assertTrue(
+                "recursiveClassEquals should recognize the top-level exception.",
+                ExceptionUtils.recursiveClassEquals(
+                        new VoldemortException("blah", new IOException("bleh")),
+                        VoldemortException.class));
+
+        Assert.assertFalse(
+                "recursiveClassEquals should NOT recognize the exception.",
+                ExceptionUtils.recursiveClassEquals(
+                        new VoldemortException("blah", new IOException("bleh")),
+                        NullPointerException.class));
+
+        Assert.assertTrue(
+                "recursiveClassEquals should recognize a nested exception.",
+                ExceptionUtils.recursiveClassEquals(
+                        new VoldemortException("blah", new IOException("bleh")),
+                        IOException.class));
+
+        Assert.assertTrue(
+                "recursiveClassEquals should recognize a nested exception which is the child of the class we're looking for.",
+                ExceptionUtils.recursiveClassEquals(
+                        new VoldemortException("blah", new ConnectException("bleh")),
+                        IOException.class));
+
+        Assert.assertFalse(
+                "recursiveClassEquals should NOT recognize a nested exception which is the parent of the class we're looking for.",
+                ExceptionUtils.recursiveClassEquals(
+                        new VoldemortException("blah", new IOException("bleh")),
+                        ConnectException.class));
+    }
+}


### PR DESCRIPTION
This commit makes the following changes:
- verifyOrAddStore() is now more resilient to various kinds of exceptions.
- ExceptionUtils.recursiveClassEquals() can now look for many exception types.
- VoldemortBuildAndPushJob now logs verifyOrAddStore's exceptions.