### PR TITLE
Metadata check to include quota check

### DIFF
--- a/src/java/voldemort/VoldemortAdminTool.java
+++ b/src/java/voldemort/VoldemortAdminTool.java
@@ -85,6 +85,7 @@ import voldemort.store.compress.CompressionStrategy;
 import voldemort.store.compress.CompressionStrategyFactory;
 import voldemort.store.metadata.MetadataStore;
 import voldemort.store.metadata.MetadataStore.VoldemortState;
+import voldemort.store.quota.QuotaType;
 import voldemort.store.quota.QuotaUtils;
 import voldemort.store.readonly.ReadOnlyStorageConfiguration;
 import voldemort.store.system.SystemStoreConstants;
@@ -945,7 +946,7 @@ public class VoldemortAdminTool {
             Utils.croak("Store " + storeName + " not in cluster.");
         }
 
-        adminClient.quotaMgmtOps.setQuota(storeName, quotaType, quotaValue);
+        adminClient.quotaMgmtOps.setQuota(storeName, QuotaType.valueOf(quotaType), Long.parseLong(quotaValue));
     }
 
     private static void executeUnsetQuota(AdminClient adminClient,

--- a/src/java/voldemort/store/quota/QuotaUtils.java
+++ b/src/java/voldemort/store/quota/QuotaUtils.java
@@ -16,10 +16,24 @@
 
 package voldemort.store.quota;
 
+import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import voldemort.VoldemortApplicationException;
+import voldemort.server.StoreRepository;
+import voldemort.store.configuration.FileBackedCachingStorageEngine;
+import voldemort.store.system.SystemStoreConstants;
+import voldemort.utils.ByteArray;
+import voldemort.versioning.VectorClock;
+import voldemort.versioning.VectorClockUtils;
+import voldemort.versioning.Versioned;
+
+
 public class QuotaUtils {
+
+  private static final String QUOTA_STORE = SystemStoreConstants.SystemStoreName.voldsys$_store_quotas.toString();
 
     public static String makeQuotaKey(String storeName, QuotaType quotaType) {
         return String.format("%s.%s", storeName, quotaType.toString());
@@ -32,4 +46,47 @@ public class QuotaUtils {
         }
         return quotaTypes;
     }
+
+  private static FileBackedCachingStorageEngine getQuotaStore(StoreRepository repoistory) {
+    FileBackedCachingStorageEngine quotaStore =
+        (FileBackedCachingStorageEngine) repoistory.getStorageEngine(QUOTA_STORE);
+
+    if (quotaStore == null) {
+      throw new VoldemortApplicationException("Could not find the quota store for Store " + QUOTA_STORE);
+    }
+
+    return quotaStore;
+  }
+
+  private static ByteArray convertToByteArray(String value) {
+    try {
+      return new ByteArray(value.getBytes("UTF8"));
+    } catch (UnsupportedEncodingException ex) {
+      throw new VoldemortApplicationException("Error converting key to byte array " + value, ex);
+    }
+  }
+
+  public static Long getQuota(String storeName, QuotaType type, StoreRepository repoistory) {
+    FileBackedCachingStorageEngine quotaStore = getQuotaStore(repoistory);
+    String quotaKey = makeQuotaKey(storeName, QuotaType.STORAGE_SPACE);
+    String diskQuotaSize = quotaStore.cacheGet(quotaKey);
+    Long diskQuotaSizeInKB = (diskQuotaSize == null) ? null : Long.parseLong(diskQuotaSize);
+    return diskQuotaSizeInKB;
+  }
+
+  public static void setQuota(String storeName, QuotaType type, StoreRepository repoistory, Set<Integer> nodeIds,
+      long lquota) {
+    FileBackedCachingStorageEngine quotaStore = getQuotaStore(repoistory);
+    String quotaKey = makeQuotaKey(storeName, QuotaType.STORAGE_SPACE);
+    ByteArray keyArray = convertToByteArray(quotaKey);
+
+    List<Versioned<byte[]>> existingValue = quotaStore.get(keyArray, null);
+    String quotaValue = Long.toString(lquota);
+
+    ByteArray valueArray = convertToByteArray(quotaValue);
+    VectorClock newClock = VectorClockUtils.makeClockWithCurrentTime(nodeIds);
+    Versioned<byte[]> newValue = new Versioned<byte[]>(valueArray.get(), newClock);
+    quotaStore.put(keyArray, newValue, null);
+
+  }
 }

--- a/src/java/voldemort/store/readonly/ReadOnlyFileEntry.java
+++ b/src/java/voldemort/store/readonly/ReadOnlyFileEntry.java
@@ -29,6 +29,7 @@ public class ReadOnlyFileEntry implements Comparable<ReadOnlyFileEntry> {
 
     private final FileType type;
     private final int size;
+
     private final String name;
 
     public ReadOnlyFileEntry(String name, FileType type, int size) {
@@ -54,6 +55,10 @@ public class ReadOnlyFileEntry implements Comparable<ReadOnlyFileEntry> {
 
     public ReadOnlyFileEntry(String name, FileType type) {
         this(name, type, -1);
+    }
+
+    public int getSize() {
+      return size;
     }
 
     @Override

--- a/src/java/voldemort/tools/ReplaceNodeCLI.java
+++ b/src/java/voldemort/tools/ReplaceNodeCLI.java
@@ -64,7 +64,6 @@ public class ReplaceNodeCLI {
         this.newUrl = newUrl;
         this.skipRestore = skipRestore;
         this.parallelism = parallelism;
-
         init();
     }
 
@@ -73,6 +72,10 @@ public class ReplaceNodeCLI {
         this.newAdminClient = new AdminClient(this.newUrl);
 
         this.cluster = adminClient.getAdminClientCluster();
+
+        // Validate node exists in the old cluster
+        this.cluster.getNodeById(nodeId);
+        
         this.newCluster = newAdminClient.getAdminClientCluster();
 
         if(newCluster.getNumberOfNodes() > 1) {
@@ -116,12 +119,12 @@ public class ReplaceNodeCLI {
                                                                                                     key);
                 String xml = xmlVersionedValue.getValue();
                 metadataXMLsInNodes.put(i.intValue(), xml);
-            } catch(UnreachableStoreException e) {
+            } catch(Exception e) {
                 if(i.intValue() == nodeId) {
-                    logger.info("Ignoring unreachable store error on the node being replaced "
+                    logger.info("Ignoring exception on the node being replaced "
                                 + nodeId, e);
                 } else {
-                    throw e;
+                    throw new VoldemortApplicationException("Error retrieving metadata XML from the Node " + i, e);
                 }
             }
         }

--- a/src/java/voldemort/tools/admin/command/AdminCommandQuota.java
+++ b/src/java/voldemort/tools/admin/command/AdminCommandQuota.java
@@ -513,6 +513,7 @@ public class AdminCommandQuota extends AbstractAdminCommand {
             allNodes = options.has(AdminParserUtils.OPT_ALL_NODES);
             if(options.has(AdminParserUtils.OPT_NODE)) {
                 nodeIds = (List<Integer>) options.valuesOf(AdminParserUtils.OPT_NODE);
+                allNodes = false;
             }
             if(options.has(AdminParserUtils.OPT_CONFIRM)) {
                 confirm = true;
@@ -528,7 +529,11 @@ public class AdminCommandQuota extends AbstractAdminCommand {
             System.out.println("  " + Joiner.on(", ").join(storeNames));
             System.out.println("Location:");
             System.out.println("  bootstrap url = " + url);
-            System.out.println("  node = all nodes");
+            if (allNodes || nodeIds == null) {
+                System.out.println("  node = all nodes");
+            } else {
+                System.out.println("  node = " + Joiner.on(", ").join(nodeIds));
+            }
 
             // execute command
             if(!AdminToolUtils.askConfirm(confirm, "set quota")) {
@@ -566,8 +571,8 @@ public class AdminCommandQuota extends AbstractAdminCommand {
                         Map.Entry entry = (Map.Entry) iter.next();
                         if(nodeIds == null) {
                             adminClient.quotaMgmtOps.setQuota(storeName,
-                                                              (String) entry.getKey(),
-                                                              (String) entry.getValue());
+                                                              QuotaType.valueOf((String) entry.getKey()),
+                                                              Long.parseLong((String) entry.getValue()));
                         } else {
                             for(Integer nodeId: nodeIds) {
                                 adminClient.quotaMgmtOps.setQuotaForNode(storeName,

--- a/test/unit/voldemort/server/quota/QuotaLimitingStoreTest.java
+++ b/test/unit/voldemort/server/quota/QuotaLimitingStoreTest.java
@@ -129,13 +129,12 @@ public class QuotaLimitingStoreTest {
     }
 
     private void setQuota(int throughPut) {
-        String throughPutStr = Integer.toString(throughPut);
         adminClient.quotaMgmtOps.setQuota("test",
-                                          QuotaType.GET_THROUGHPUT.toString(),
-                                          throughPutStr);
+                                          QuotaType.GET_THROUGHPUT,
+                                          throughPut);
         adminClient.quotaMgmtOps.setQuota("test",
-                                          QuotaType.PUT_THROUGHPUT.toString(),
-                                          throughPutStr);
+                                          QuotaType.PUT_THROUGHPUT,
+                                          throughPut);
     }
 
     private void unSetQuota() {


### PR DESCRIPTION
1) Reliably set Quota on all nodes.
2) Meta check will check for quota on all nodes.
3) Meta check will ignore 0 length RO files
4) Meta check will skip nodes with 0 partitions when verifying
store can be fetched.
5) ReplaceNodeCLI node validation and ignore all errors from failing
node.
6) Set Quota to report the correct node it is going to run against.
7) When a store is created, set the default quota directly instead
of using an admin client to write to the same node.

All operability improvement for working with quota.