### PR TITLE
Use empty stores for Replace Node CLI test

### DIFF
--- a/test/common/voldemort/config/empty-stores.xml
+++ b/test/common/voldemort/config/empty-stores.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<stores>
+</stores>

--- a/test/unit/voldemort/client/ReplaceNodeTest.java
+++ b/test/unit/voldemort/client/ReplaceNodeTest.java
@@ -35,6 +35,7 @@ public class ReplaceNodeTest {
 
 
     private static final String ORIGINAL_STORES_XML = "test/common/voldemort/config/stores-rw-replication.xml";
+    private static final String EMPTY_STORES_XML = "test/common/voldemort/config/empty-stores.xml";
     
     private static final String STORE322_NAME = "test322";
     private static final String STORE211_NAME = "test211";
@@ -101,12 +102,12 @@ public class ReplaceNodeTest {
         otherServers = new VoldemortServer[replacementServerCount];
         ServerTestUtils.startVoldemortCluster(replacementServerCount,
                                               otherServers,
-                                                                replacementPartitionMap,
-                                                                replacementSocketStoreFactory,
-                                                                USE_NIO,
-                                                                null,
-                                				ORIGINAL_STORES_XML,
-                                                                serverProperties);
+                                              replacementPartitionMap,
+                                              replacementSocketStoreFactory,
+                                              USE_NIO,
+                                              null,
+                                              EMPTY_STORES_XML,
+                                              serverProperties);
     }
 
     @After


### PR DESCRIPTION
This should have caught a bug, which is already fixed
in the last commit.

There are still couple of bugs in the Offline Mode.

AdminClient storeOps uses socketPort, which will be down in the
offline mode. AdminPort supports full client operations and hence
it should have used the AdminPort.

AdminClient on the voldemort server uses cluster for bootstrapping
which uses the client port again. This is problematic when the node
is node 0. It should use the Admin Port for bootstrapping.

Those bugs are in backlog will fix them later.