### PR TITLE
Removed 'num.chunks' config parameter from BnP.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/benchmark/BuildTestStore.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/benchmark/BuildTestStore.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008-2009 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -41,8 +41,8 @@ import voldemort.xml.StoreDefinitionsMapper;
 
 /**
  * Build a test store from the generated data
- * 
- * 
+ *
+ *
  */
 @SuppressWarnings("deprecation")
 public class BuildTestStore extends Configured implements Tool {
@@ -87,7 +87,6 @@ public class BuildTestStore extends Configured implements Tool {
                 false,
                 false,
                 (long) (1.5 * 1024 * 1024 * 1024),
-                -1,
                 false,
                 null,
                 false);

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/AbstractStoreBuilderConfigurable.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/AbstractStoreBuilderConfigurable.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008-2009 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -37,6 +37,8 @@ import voldemort.xml.StoreDefinitionsMapper;
  */
 abstract public class AbstractStoreBuilderConfigurable {
 
+    public static final String NUM_CHUNKS = "num.chunks";
+
     private int numChunks;
     private Cluster cluster;
     private StoreDefinition storeDef;
@@ -51,9 +53,12 @@ abstract public class AbstractStoreBuilderConfigurable {
             throw new IllegalStateException("Expected to find only a single store, but found multiple!");
         this.storeDef = storeDefs.get(0);
 
-        this.numChunks = conf.getInt(VoldemortBuildAndPushJob.NUM_CHUNKS, -1);
-        if(this.numChunks < 1)
-            throw new VoldemortException(VoldemortBuildAndPushJob.NUM_CHUNKS + " not specified in the job conf.");
+        this.numChunks = conf.getInt(NUM_CHUNKS, -1);
+        if(this.numChunks < 1) {
+            // A bit of defensive code for good measure, but should never happen anymore, now that the config cannot
+            // be overridden by the user.
+            throw new VoldemortException(NUM_CHUNKS + " not specified in the MapReduce JobConf (should NEVER happen)");
+        }
 
         this.saveKeys = conf.getBoolean(VoldemortBuildAndPushJob.SAVE_KEYS, true);
         this.reducerPerBucket = conf.getBoolean(VoldemortBuildAndPushJob.REDUCER_PER_BUCKET, true);

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/HadoopStoreBuilder.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/HadoopStoreBuilder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008-2009 LinkedIn, Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -70,7 +70,7 @@ import voldemort.xml.StoreDefinitionsMapper;
 
 /**
  * Builds a read-only voldemort store as a hadoop job from the given input data.
- * 
+ *
  */
 @SuppressWarnings("deprecation")
 public class HadoopStoreBuilder extends AbstractHadoopJob {
@@ -102,8 +102,7 @@ public class HadoopStoreBuilder extends AbstractHadoopJob {
 
     /**
      * Create the store builder
-     *
-     * @param name Name of the job
+     *  @param name Name of the job
      * @param props The Build and Push job's {@link Props}
      * @param baseJobConf A base configuration to start with
      * @param mapperClass The class to use as the mapper
@@ -111,23 +110,20 @@ public class HadoopStoreBuilder extends AbstractHadoopJob {
      * @param cluster The voldemort cluster for which the stores are being built
      * @param storeDef The store definition of the store
      * @param tempDir The temporary directory to use in hadoop for intermediate
-     *        reducer output
+*        reducer output
      * @param outputDir The directory in which to place the built stores
      * @param inputPath The path from which to read input data
      * @param checkSumType The checksum algorithm to use
      * @param saveKeys Boolean to signify if we want to save the key as well
      * @param reducerPerBucket Boolean to signify whether we want to have a
-     *        single reducer for a bucket ( thereby resulting in all chunk files
-     *        for a bucket being generated in a single reducer )
+*        single reducer for a bucket ( thereby resulting in all chunk files
+*        for a bucket being generated in a single reducer )
      * @param chunkSizeBytes Size of each chunks (ignored if numChunksOverride is > 0)
-     * @param numChunksOverride Number of chunks per bucket ( partition or partition
-     *        replica )
      * @param isAvro whether the data format is avro
      * @param minNumberOfRecords if job generates fewer records than this, fail.
      * @param buildPrimaryReplicasOnly if true: build each partition only once,
-     *                                 and store the files grouped by partition.
-     *                                 if false: build all replicas redundantly,
-     *                                 and store the files grouped by node.
+*                                 and store the files grouped by partition.
+*                                 if false: build all replicas redundantly,
      */
     public HadoopStoreBuilder(String name,
                               Props props,
@@ -143,7 +139,6 @@ public class HadoopStoreBuilder extends AbstractHadoopJob {
                               boolean saveKeys,
                               boolean reducerPerBucket,
                               long chunkSizeBytes,
-                              int numChunksOverride,
                               boolean isAvro,
                               Long minNumberOfRecords,
                               boolean buildPrimaryReplicasOnly) {
@@ -160,7 +155,6 @@ public class HadoopStoreBuilder extends AbstractHadoopJob {
         this.saveKeys = saveKeys;
         this.reducerPerBucket = reducerPerBucket;
         this.chunkSizeBytes = chunkSizeBytes;
-        this.numChunksOverride = numChunksOverride;
         this.isAvro = isAvro;
         this.minNumberOfRecords = minNumberOfRecords == null ? 1 : minNumberOfRecords;
         this.buildPrimaryReplicasOnly = buildPrimaryReplicasOnly;
@@ -266,14 +260,7 @@ public class HadoopStoreBuilder extends AbstractHadoopJob {
                 numReducers = numReducers * numChunks;
             }
 
-            if (this.numChunksOverride > 0) {
-                logger.info("The " + VoldemortBuildAndPushJob.NUM_CHUNKS + " setting is overridden " +
-                            "by config, so we'll use the override (" + this.numChunksOverride + ") " +
-                            "and discard the dynamically computed value (" + numChunks + ").");
-                numChunks = this.numChunksOverride;
-            }
-
-            conf.setInt(VoldemortBuildAndPushJob.NUM_CHUNKS, numChunks);
+            conf.setInt(AbstractStoreBuilderConfigurable.NUM_CHUNKS, numChunks);
             conf.setNumReduceTasks(numReducers);
 
             if(isAvro) {
@@ -413,15 +400,15 @@ public class HadoopStoreBuilder extends AbstractHadoopJob {
 
     /**
      * For the given node, following three actions are done:
-     * 
+     *
      * 1. Computes checksum of checksums
-     * 
+     *
      * 2. Computes total data size
-     * 
+     *
      * 3. Computes total index size
-     * 
+     *
      * Finally updates the metadata file with those information
-     * 
+     *
      * @param directoryName
      * @param outputFs
      * @param checkSumGenerator

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -122,7 +122,6 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
     // others.optional
     public final static String KEY_SELECTION = "key.selection";
     public final static String VALUE_SELECTION = "value.selection";
-    public final static String NUM_CHUNKS = "num.chunks";
     public final static String BUILD = "build";
     public final static String PUSH = "push";
     public final static String VOLDEMORT_FETCHER_PROTOCOL = "voldemort.fetcher.protocol";
@@ -703,7 +702,6 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
                                                             props.getBoolean(SAVE_KEYS, true),
                                                             props.getBoolean(REDUCER_PER_BUCKET, true),
                                                             props.getInt(BUILD_CHUNK_SIZE, 1024 * 1024 * 1024),
-                                                            props.getInt(NUM_CHUNKS, -1),
                                                             this.isAvroJob,
                                                             this.minNumberOfRecords,
                                                             this.buildPrimaryReplicasOnly);

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/disk/HadoopStoreWriterTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/disk/HadoopStoreWriterTest.java
@@ -26,6 +26,7 @@ import voldemort.routing.RoutingStrategyType;
 import voldemort.store.StoreDefinition;
 import voldemort.store.readonly.checksum.CheckSum;
 import voldemort.store.readonly.mr.AbstractCollectorWrapper;
+import voldemort.store.readonly.mr.AbstractStoreBuilderConfigurable;
 import voldemort.store.readonly.mr.BuildAndPushMapper;
 import voldemort.store.readonly.mr.azkaban.VoldemortBuildAndPushJob;
 import voldemort.store.readonly.utils.ReadOnlyTestUtils;
@@ -79,7 +80,7 @@ public class HadoopStoreWriterTest {
 
         // Setup before each test method
         conf = new JobConf();
-        conf.setInt(VoldemortBuildAndPushJob.NUM_CHUNKS, 2);
+        conf.setInt(AbstractStoreBuilderConfigurable.NUM_CHUNKS, numChunks);
         conf.set("final.output.dir", tmpOutPutDirectory.getAbsolutePath());
         conf.set("mapred.output.dir", tmpOutPutDirectory.getAbsolutePath());
         conf.set("mapred.task.id", "1234");

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/HadoopStoreBuilderCollisionTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/HadoopStoreBuilderCollisionTest.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.LongWritable;
@@ -56,7 +55,7 @@ import com.google.common.collect.Maps;
 /**
  * Test for {@link ReadOnlyStorageFormat}-READONLY_V2 where-in we try to
  * generate collisions and check if edge cases are caught correctly
- * 
+ *
  */
 @SuppressWarnings("deprecation")
 public class HadoopStoreBuilderCollisionTest {
@@ -239,7 +238,6 @@ public class HadoopStoreBuilderCollisionTest {
                                                             true,
                                                             false,
                                                             1024 * 1024 * 1024,
-                                                            -1,
                                                             false,
                                                             null,
                                                             false);

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/HadoopStoreBuilderTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/HadoopStoreBuilderTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
@@ -168,7 +167,6 @@ public class HadoopStoreBuilderTest {
                                                             saveKeys,
                                                             false,
                                                             64 * 1024,
-                                                            -1,
                                                             false,
                                                             0L,
                                                             false);
@@ -246,7 +244,6 @@ public class HadoopStoreBuilderTest {
                                                             saveKeys,
                                                             false,
                                                             64 * 1024,
-                                                            -1,
                                                             false,
                                                             null,
                                                             false);
@@ -266,7 +263,6 @@ public class HadoopStoreBuilderTest {
                                          saveKeys,
                                          false,
                                          64 * 1024,
-                                         -1,
                                          false,
                                          null,
                                          false);


### PR DESCRIPTION
Setting this parameter introduced a subtle failure mode when there were
too few records in the store. It's not worth fixing the other bug since
'num.chunks' is automatically calculated anyway, based on input data size.

This change removes a bit of rope for users to hang themselves with (: