### PR TITLE
Voldemort server cleans up HA state.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/swapper/HdfsFailedFetchLock.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/swapper/HdfsFailedFetchLock.java
@@ -395,7 +395,7 @@ public class HdfsFailedFetchLock extends FailedFetchLock {
                         this.fileSystem.delete(failedStorePath, true);
                     }
                 } catch (FileNotFoundException e) {
-                    logger.info("The shared state has no obsolete versions in: " + failedStorePath.toString(), e);
+                    logger.info("The shared state has no obsolete versions in: " + failedStorePath.toString());
                 }
 
                 // Let's see if there's still anything left for this node?
@@ -408,7 +408,7 @@ public class HdfsFailedFetchLock extends FailedFetchLock {
                         this.fileSystem.delete(disabledStoresPath, true);
                     }
                 } catch (FileNotFoundException e) {
-                    logger.info("The shared state has no obsolete stores in: " + disabledStoresPath.toString(), e);
+                    logger.info("The shared state has no obsolete stores in: " + disabledStoresPath.toString());
                 }
 
                 success = true;

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/swapper/HdfsFailedFetchLock.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/swapper/HdfsFailedFetchLock.java
@@ -87,9 +87,9 @@ public class HdfsFailedFetchLock extends FailedFetchLock {
     private final static String AZKABAN_EXEC_ID = "azkaban.flow.execid";
 
     // Azkaban state
-    private final String flowId = props.getString(AZKABAN_FLOW_ID);
-    private final String jobId = props.getString(AZKABAN_JOB_ID);
-    private final String execId = props.getString(AZKABAN_EXEC_ID);
+    private final String flowId = props.getString(AZKABAN_FLOW_ID, "null." + AZKABAN_FLOW_ID);
+    private final String jobId = props.getString(AZKABAN_JOB_ID, "null." + AZKABAN_JOB_ID);
+    private final String execId = props.getString(AZKABAN_EXEC_ID, "null." + AZKABAN_EXEC_ID);
 
     // Default total try time = 10000 ms timeOut * 360 maxAttempts = 15 minutes
     private final Integer waitBetweenRetries = props.getInt(PUSH_HA_LOCK_HDFS_TIMEOUT, 10000);

--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -866,6 +866,7 @@ public class VoldemortConfig implements Serializable {
         this.highAvailabilityPushLockImplementation = this.allProps.getString(PUSH_HA_LOCK_IMPLEMENTATION);
         this.highAvailabilityPushMaxNodeFailures = this.allProps.getInt(PUSH_HA_MAX_NODE_FAILURES);
         this.highAvailabilityPushEnabled = this.allProps.getBoolean(PUSH_HA_ENABLED);
+        this.highAvailabilityStateAutoCleanUp = this.allProps.getBoolean(PUSH_HA_STATE_AUTO_CLEANUP);
 
         this.mysqlUsername = this.allProps.getString(MYSQL_USER);
         this.mysqlPassword = this.allProps.getString(MYSQL_PASSWORD);

--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -148,6 +148,7 @@ public class VoldemortConfig implements Serializable {
     public static final String PUSH_HA_LOCK_PATH = "push.ha.lock.path";
     public static final String PUSH_HA_LOCK_IMPLEMENTATION = "push.ha.lock.implementation";
     public static final String PUSH_HA_MAX_NODE_FAILURES = "push.ha.max.node.failure";
+    public static final String PUSH_HA_STATE_AUTO_CLEANUP = "push.ha.state.auto.cleanup";
     public static final String MYSQL_USER = "mysql.user";
     public static final String MYSQL_PASSWORD = "mysql.password";
     public static final String MYSQL_HOST = "mysql.host";
@@ -283,6 +284,7 @@ public class VoldemortConfig implements Serializable {
     public static final int DEFAULT_RO_MAX_VALUE_BUFFER_ALLOCATION_SIZE = 25 * 1024 * 1024;
 
     private static final Props defaultConfig = new Props();
+
     static {
         defaultConfig.put(BDB_CACHE_SIZE, 200 * 1024 * 1024);
         defaultConfig.put(BDB_WRITE_TRANSACTIONS, false);
@@ -354,6 +356,7 @@ public class VoldemortConfig implements Serializable {
         defaultConfig.put(PUSH_HA_LOCK_IMPLEMENTATION, (String) null);
         defaultConfig.put(PUSH_HA_MAX_NODE_FAILURES, 0);
         defaultConfig.put(PUSH_HA_ENABLED, false);
+        defaultConfig.put(PUSH_HA_STATE_AUTO_CLEANUP, false);
 
         defaultConfig.put(MYSQL_USER, "root");
         defaultConfig.put(MYSQL_PASSWORD, "");
@@ -590,6 +593,7 @@ public class VoldemortConfig implements Serializable {
     private String highAvailabilityPushLockPath;
     private String highAvailabilityPushLockImplementation;
     private int highAvailabilityPushMaxNodeFailures;
+    private boolean highAvailabilityStateAutoCleanUp;
 
     private OpTimeMap testingSlowQueueingDelays;
     private OpTimeMap testingSlowConcurrentDelays;
@@ -3566,6 +3570,30 @@ public class VoldemortConfig implements Serializable {
      */
     public void setHighAvailabilityPushLockImplementation(String highAvailabilityPushLockImplementation) {
         this.highAvailabilityPushLockImplementation = highAvailabilityPushLockImplementation;
+    }
+
+    public boolean getHighAvailabilityStateAutoCleanUp() {
+        return highAvailabilityStateAutoCleanUp;
+    }
+
+    /**
+     * When using a high-availability push strategy, there is a shared state which
+     * accumulates in order to prevent race conditions. This state can become stale
+     * if Voldemort has been recovered, which prevents the cluster from continuing
+     * to be highly-available in the future. This configuration allows the server
+     * to automatically clean up this shared state when it transitions from offline
+     * to online, as well as when old store-versions are deleted, which happens
+     * asynchronously after a new store-version is swapped in.
+     *
+     * N.B.: This is an experimental feature! Hence it is disabled by default.
+     *
+     * <ul>
+     * <li>Property : "{@value #PUSH_HA_STATE_AUTO_CLEANUP}"</li>
+     * <li>Default : false</li>
+     * </ul>
+     */
+    public void setHighAvailabilityStateAutoCleanUp(boolean highAvailabilityStateAutoCleanUp) {
+        this.highAvailabilityStateAutoCleanUp = highAvailabilityStateAutoCleanUp;
     }
 
     public boolean isNetworkClassLoaderEnabled() {

--- a/src/java/voldemort/server/VoldemortServer.java
+++ b/src/java/voldemort/server/VoldemortServer.java
@@ -527,9 +527,9 @@ public class VoldemortServer extends AbstractService {
         ReadOnlyStoreStatusValidation validation = validateReadOnlyStoreStatusBeforeGoingOnline();
 
         if (validation.readyToGoOnline) {
+            getMetadataStore().setOfflineState(false);
             createOnlineServices();
             startOnlineServices();
-            getMetadataStore().setOfflineState(false);
         }
 
         if (validation.e != null) {

--- a/src/java/voldemort/server/VoldemortServer.java
+++ b/src/java/voldemort/server/VoldemortServer.java
@@ -581,6 +581,9 @@ public class VoldemortServer extends AbstractService {
                     } finally {
                         IOUtils.closeQuietly(failedFetchLock);
                     }
+                } else {
+                    logger.info(VoldemortConfig.PUSH_HA_STATE_AUTO_CLEANUP +
+                            "=false, so the server will NOT attempt to delete the HA state for this node, if any.");
                 }
 
                 logger.info("No Read-Only stores are disabled. Going online as planned.");

--- a/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
+++ b/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
@@ -2034,15 +2034,7 @@ public class AdminServiceRequestHandler implements RequestHandler {
         } else {
             FailedFetchLock distributedLock = null;
             try {
-                Class<? extends FailedFetchLock> failedFetchLockClass =
-                        (Class<? extends FailedFetchLock>) Class.forName(voldemortConfig.getHighAvailabilityPushLockImplementation());
-
-                Props props = new Props(extraInfoProperties);
-
-                // Pass both server properties and the remote job's properties to the FailedFetchLock constructor
-                Object[] failedFetchLockParams = new Object[]{voldemortConfig, props};
-
-                distributedLock = ReflectUtils.callConstructor(failedFetchLockClass, failedFetchLockParams);
+                distributedLock = FailedFetchLock.getLock(voldemortConfig, new Props(extraInfoProperties));
 
                 distributedLock.acquireLock();
 

--- a/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
+++ b/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
@@ -2046,8 +2046,32 @@ public class AdminServiceRequestHandler implements RequestHandler {
 
                 if (allNodesToBeDisabled.size() > maxNodeFailure) {
                     // Too many exceptions to tolerate this strategy... let's bail out.
-                    responseMessage = "We cannot use pushHighAvailability because it would bring the total number of " +
-                                         "nodes with disabled stores to more than " + maxNodeFailure + "...";
+                    StringBuilder stringBuilder = new StringBuilder();
+                    stringBuilder.append("We cannot use pushHighAvailability because it would bring the total ");
+                    stringBuilder.append("number of nodes with disabled stores to more than ");
+                    stringBuilder.append(maxNodeFailure);
+                    stringBuilder.append("... alreadyDisabledNodes: [");
+                    boolean firstItem = true;
+                    for (Integer nodeId: alreadyDisabledNodes) {
+                        if (firstItem) {
+                            firstItem = false;
+                        } else {
+                            stringBuilder.append(", ");
+                        }
+                        stringBuilder.append(nodeId);
+                    }
+                    stringBuilder.append("], nodesFailedInThisFetch: [");
+                    firstItem = true;
+                    for (Integer nodeId: nodesFailedInThisFetch) {
+                        if (firstItem) {
+                            firstItem = false;
+                        } else {
+                            stringBuilder.append(", ");
+                        }
+                        stringBuilder.append(nodeId);
+                    }
+                    stringBuilder.append("]");
+                    responseMessage = stringBuilder.toString();
                     logger.error(responseMessage);
                 } else {
                     String nodesString = "node";

--- a/src/java/voldemort/store/readonly/ReadOnlyStorageConfiguration.java
+++ b/src/java/voldemort/store/readonly/ReadOnlyStorageConfiguration.java
@@ -36,12 +36,13 @@ public class ReadOnlyStorageConfiguration implements StorageConfiguration {
     private final File storageDir;
     private final SearchStrategy searcher;
     private final int nodeId;
-    private final FailedFetchLock failedFetchLock;
+    private final VoldemortConfig config;
     private RoutingStrategy routingStrategy = null;
     private final int deleteBackupMs;
     private final int maxValueBufferAllocationSize;
 
     public ReadOnlyStorageConfiguration(VoldemortConfig config) {
+        this.config = config;
         this.storageDir = new File(config.getReadOnlyDataStorageDirectory());
         this.numBackups = config.getNumReadOnlyVersions();
         this.searcher = (SearchStrategy) ReflectUtils.callConstructor(ReflectUtils.loadClass(config.getReadOnlySearchStrategy()
@@ -49,18 +50,6 @@ public class ReadOnlyStorageConfiguration implements StorageConfiguration {
         this.nodeId = config.getNodeId();
         this.deleteBackupMs = config.getReadOnlyDeleteBackupMs();
         this.maxValueBufferAllocationSize = config.getReadOnlyMaxValueBufferAllocationSize();
-
-        FailedFetchLock failedFetchLockInstance;
-        if (config.getHighAvailabilityStateAutoCleanUp()) {
-            try {
-                failedFetchLockInstance = FailedFetchLock.getLock(config, null);
-            } catch (ClassNotFoundException e) {
-                failedFetchLockInstance = null;
-            }
-        } else {
-            failedFetchLockInstance = null;
-        }
-        this.failedFetchLock = failedFetchLockInstance;
     }
 
     public void close() {
@@ -83,7 +72,7 @@ public class ReadOnlyStorageConfiguration implements StorageConfiguration {
                                                                 numBackups,
                                                                 deleteBackupMs,
                                                                 maxValueBufferAllocationSize,
-                                                                failedFetchLock);
+                                                                config);
         return store;
     }
 

--- a/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
+++ b/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
@@ -41,6 +41,7 @@ import voldemort.store.DisabledStoreException;
 import voldemort.store.StoreCapabilityType;
 import voldemort.store.StoreUtils;
 import voldemort.store.readonly.chunk.ChunkedFileSet;
+import voldemort.store.readonly.swapper.FailedFetchLock;
 import voldemort.utils.ByteArray;
 import voldemort.utils.ByteUtils;
 import voldemort.utils.ClosableIterator;
@@ -98,7 +99,8 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
              storeDir,
              numBackups,
              0,
-             VoldemortConfig.DEFAULT_RO_MAX_VALUE_BUFFER_ALLOCATION_SIZE);
+             VoldemortConfig.DEFAULT_RO_MAX_VALUE_BUFFER_ALLOCATION_SIZE,
+             null);
     }
 
     /**
@@ -120,8 +122,8 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
                                  File storeDir,
                                  int numBackups,
                                  int deleteBackupMs,
-                                 int maxValueBufferAllocationSize) {
-
+                                 int maxValueBufferAllocationSize,
+                                 FailedFetchLock failedFetchLock) {
         super(name);
         this.deleteBackupMs = deleteBackupMs;
         this.storeDir = storeDir;
@@ -137,7 +139,7 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
          */
         this.fileModificationLock = new ReentrantReadWriteLock();
         this.isOpen = false;
-        storeVersionManager = new StoreVersionManager(storeDir);
+        storeVersionManager = new StoreVersionManager(storeDir, failedFetchLock, nodeId);
         open(null);
 
         lastFetchReqestId = NO_FETCH_IN_PROGRESS;

--- a/src/java/voldemort/store/readonly/swapper/FailedFetchLock.java
+++ b/src/java/voldemort/store/readonly/swapper/FailedFetchLock.java
@@ -28,9 +28,11 @@ public abstract class FailedFetchLock implements Closeable {
     public abstract void addDisabledNode(int nodeId,
                                          String storeName,
                                          long storeVersion) throws Exception;
-    public abstract void removeObsoleteState(int nodeId,
-                                             String storeName,
-                                             Map<Long, Boolean> versionToEnabledMap) throws Exception;
+    public abstract void removeObsoleteStateForStore(int nodeId,
+                                                     String storeName,
+                                                     Map<Long, Boolean> versionToEnabledMap) throws Exception;
+    public abstract void removeObsoleteStateForNode(int nodeId) throws Exception;
+
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + " for cluster: " + clusterId;

--- a/src/java/voldemort/store/readonly/swapper/FailedFetchLock.java
+++ b/src/java/voldemort/store/readonly/swapper/FailedFetchLock.java
@@ -2,8 +2,10 @@ package voldemort.store.readonly.swapper;
 
 import voldemort.server.VoldemortConfig;
 import voldemort.utils.Props;
+import voldemort.utils.ReflectUtils;
 
 import java.io.Closeable;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -26,8 +28,25 @@ public abstract class FailedFetchLock implements Closeable {
     public abstract void addDisabledNode(int nodeId,
                                          String storeName,
                                          long storeVersion) throws Exception;
+    public abstract void removeObsoleteState(int nodeId,
+                                             String storeName,
+                                             Map<Long, Boolean> versionToEnabledMap) throws Exception;
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + " for cluster: " + clusterId;
+    }
+
+    public static FailedFetchLock getLock(VoldemortConfig config, Props remoteJobProps) throws ClassNotFoundException {
+        Class<? extends FailedFetchLock> failedFetchLockClass =
+                (Class<? extends FailedFetchLock>) Class.forName(config.getHighAvailabilityPushLockImplementation());
+
+        if (remoteJobProps == null) {
+            remoteJobProps = new Props();
+        }
+
+        // Pass both server properties and the remote job's properties to the FailedFetchLock constructor
+        Object[] failedFetchLockParams = new Object[]{config, remoteJobProps};
+
+        return ReflectUtils.callConstructor(failedFetchLockClass, failedFetchLockParams);
     }
 }

--- a/test/unit/voldemort/store/readonly/StoreVersionManagerTest.java
+++ b/test/unit/voldemort/store/readonly/StoreVersionManagerTest.java
@@ -22,8 +22,8 @@ public class StoreVersionManagerTest extends TestCase {
         version1 = new File(rootDir, "version-1");
         Assert.assertTrue("Failed to create version directory!", version0.mkdir());
         Assert.assertTrue("Failed to create version directory!", version1.mkdir());
-        storeVersionManager = new StoreVersionManager(rootDir, null, -1);
-        storeVersionManager.syncInternalStateFromFileSystem();
+        storeVersionManager = new StoreVersionManager(rootDir, null);
+        storeVersionManager.syncInternalStateFromFileSystem(false);
     }
 
     @Test
@@ -42,8 +42,8 @@ public class StoreVersionManagerTest extends TestCase {
                           storeVersionManager.isCurrentVersionEnabled());
 
         // Verify that another instance of StoreVersionManager, freshly synced from disk, also has proper state.
-        StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir, null, -1);
-        storeVersionManager2.syncInternalStateFromFileSystem();
+        StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir, null);
+        storeVersionManager2.syncInternalStateFromFileSystem(false);
         Assert.assertTrue("Expected persistent state to have some store version disabled.",
                           storeVersionManager2.hasAnyDisabledVersion());
         Assert.assertTrue("Expected persistent state to have store version 1 enabled.",
@@ -74,8 +74,8 @@ public class StoreVersionManagerTest extends TestCase {
                           storeVersionManager.isCurrentVersionEnabled());
 
         // Verify that another instance of StoreVersionManager, freshly synced from disk, does NOT have proper state.
-        StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir, null, -1);
-        storeVersionManager2.syncInternalStateFromFileSystem();
+        StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir, null);
+        storeVersionManager2.syncInternalStateFromFileSystem(false);
         Assert.assertFalse("Expected persistent state to have no version disabled.",
                           storeVersionManager2.hasAnyDisabledVersion());
     }

--- a/test/unit/voldemort/store/readonly/StoreVersionManagerTest.java
+++ b/test/unit/voldemort/store/readonly/StoreVersionManagerTest.java
@@ -22,7 +22,7 @@ public class StoreVersionManagerTest extends TestCase {
         version1 = new File(rootDir, "version-1");
         Assert.assertTrue("Failed to create version directory!", version0.mkdir());
         Assert.assertTrue("Failed to create version directory!", version1.mkdir());
-        storeVersionManager = new StoreVersionManager(rootDir);
+        storeVersionManager = new StoreVersionManager(rootDir, null, -1);
         storeVersionManager.syncInternalStateFromFileSystem();
     }
 
@@ -42,7 +42,7 @@ public class StoreVersionManagerTest extends TestCase {
                           storeVersionManager.isCurrentVersionEnabled());
 
         // Verify that another instance of StoreVersionManager, freshly synced from disk, also has proper state.
-        StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir);
+        StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir, null, -1);
         storeVersionManager2.syncInternalStateFromFileSystem();
         Assert.assertTrue("Expected persistent state to have some store version disabled.",
                           storeVersionManager2.hasAnyDisabledVersion());
@@ -74,7 +74,7 @@ public class StoreVersionManagerTest extends TestCase {
                           storeVersionManager.isCurrentVersionEnabled());
 
         // Verify that another instance of StoreVersionManager, freshly synced from disk, does NOT have proper state.
-        StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir);
+        StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir, null, -1);
         storeVersionManager2.syncInternalStateFromFileSystem();
         Assert.assertFalse("Expected persistent state to have no version disabled.",
                           storeVersionManager2.hasAnyDisabledVersion());


### PR DESCRIPTION
Added code so that the Voldemort server automatically cleans
the shared High Availability state from HDFS when appropriate.

Currently, this new code runs when:
1. An old Read-Only store-version is deleted, which usually
happens asynchronously after a new store-version is activated.
2. When a server transitions from OFFLINE mode to ONLINE mode.

This new benahvior is disabled by default, but can be enabled via:

push.ha.state.auto.cleanup=true

N.B.: This is not tested yet.