### PR TITLE
Last commit regressed the Hadoop Fetcher

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -243,7 +243,7 @@ public class HdfsFetcher implements FileFetcher {
                                                                  stats,
                                                                  status,
                                                                  bufferSize);
-            if(isFile) { // We are asked to fetch a directory
+            if(!isFile) { // We are asked to fetch a directory
                 Utils.mkdirs(destination);
                 HdfsDirectory rootDirectory = new HdfsDirectory(fs, rootPath, this.voldemortConfig);
                 List<HdfsDirectory> directoriesToFetch = Lists.newArrayList();


### PR DESCRIPTION
There were tests failing, and on investigation it turned out that
negation was missed.

My preference was to write == false instead of negation, but that is C++
style.