### PR TITLE
Lower the node unavailable error to debug

### DIFF
--- a/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutorFactory.java
+++ b/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutorFactory.java
@@ -212,8 +212,10 @@ public class ClientRequestExecutorFactory implements
                                                               new ConnectException(e.getMessage()));
                         }
 
-                        logger.info("Reporting exception to pool " + e.getClass()
-                                    + " for destination " + dest);
+                        if(logger.isDebugEnabled()) {
+                          logger.debug("Reporting exception to pool " + e.getClass()
+                                      + " for destination " + dest);
+                        }
 
                         pool.reportException(dest, e);
                     }

--- a/src/java/voldemort/utils/pool/KeyedResourcePool.java
+++ b/src/java/voldemort/utils/pool/KeyedResourcePool.java
@@ -557,9 +557,10 @@ public class KeyedResourcePool<K, V> {
                 skippedExceptionCount++;
                 if(elapsedTime <= excpetionReportTimeMS) {
                     Exception e = entry.getSecond();
-                    logger.info(" Throwing remembered exception. time elapsed (ms) " + elapsedTime
-                                + ". Exception : "
-                                + e.getMessage());
+                    if(logger.isDebugEnabled()) {
+                      logger.debug(" Throwing remembered exception. time elapsed (ms) " + elapsedTime
+                                  + ". Exception : " + e.getMessage());
+                    }
                     throw e;
                 }
             }


### PR DESCRIPTION
When async connect fails, selector reports the error and it is cached in
memory. Next connect call will get the error if it happens within twice
the timeout period.

The logs are logged at the info level, which spams the logs when the
server is unavailable for extended period of times. Now it is dropped
down to debug level.