### PR TITLE
Idle connection timeout

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -49,6 +49,7 @@ import org.apache.log4j.Logger;
 import voldemort.VoldemortException;
 import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
+import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.client.protocol.pb.VAdminProto;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
@@ -194,9 +195,11 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
                 if (clusterURLs.contains(url))
                     throw new VoldemortException("the URL: " + url + " is duplicated. Please check it out.");
                 this.clusterURLs.add(url);
-                AdminClient adminClient = new AdminClient(new ClientConfig().setBootstrapUrls(url)
-                                                                            .setConnectionTimeout(15,
-                                                                                                  TimeUnit.SECONDS));
+                ClientConfig config = new ClientConfig().setBootstrapUrls(url)
+                                    .setConnectionTimeout(15,TimeUnit.SECONDS);
+                
+                AdminClientConfig adminConfig = new AdminClientConfig().setAdminSocketTimeoutSec(60);
+                AdminClient adminClient = new AdminClient(adminConfig, config);
                 this.adminClientPerCluster.put(url, adminClient);
                 this.closeables.add(adminClient);
             }

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortRollbackJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortRollbackJob.java
@@ -27,7 +27,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.log4j.Logger;
 
 import voldemort.VoldemortException;
+import voldemort.client.ClientConfig;
 import voldemort.client.protocol.admin.AdminClient;
+import voldemort.client.protocol.admin.AdminClientConfig;
 import voldemort.cluster.Cluster;
 import voldemort.cluster.Node;
 import voldemort.store.readonly.mr.utils.VoldemortUtils;
@@ -74,7 +76,9 @@ public class VoldemortRollbackJob extends AbstractJob {
             ExecutorService service = null;
             try {
                 service = Executors.newCachedThreadPool();
-                adminClient = new AdminClient(clusterUrl);
+                ClientConfig config = new ClientConfig().setBootstrapUrls(clusterUrl);
+                AdminClientConfig adminConfig = new AdminClientConfig().setAdminSocketTimeoutSec(60);
+                adminClient = new AdminClient(adminConfig, config);
                 Cluster cluster = adminClient.getAdminClientCluster();
                 AdminStoreSwapper swapper = new AdminStoreSwapper(
                         cluster,

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortSwapJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortSwapJob.java
@@ -120,8 +120,9 @@ public class VoldemortSwapJob extends AbstractJob {
         }
 
         AdminClientConfig adminConfig = new AdminClientConfig().setMaxConnectionsPerNode(cluster.getNumberOfNodes())
-                                                               .setAdminConnectionTimeoutSec(httpTimeoutMs / 1000)
-                                                               .setMaxBackoffDelayMs(maxBackoffDelayMs);
+                                                               .setAdminConnectionTimeoutSec(15)
+                                                               .setMaxBackoffDelayMs(maxBackoffDelayMs)
+                                                               .setAdminSocketTimeoutSec(60);
 
         ClientConfig clientConfig = new ClientConfig().setBootstrapUrls(cluster.getBootStrapUrls())
                                                       .setConnectionTimeout(httpTimeoutMs,

--- a/src/java/voldemort/client/ClientInfo.java
+++ b/src/java/voldemort/client/ClientInfo.java
@@ -21,9 +21,11 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.log4j.Logger;
+
 
 /**
  * A collection of voldemort client side information what will be populated into
@@ -207,11 +209,11 @@ public class ClientInfo implements Serializable {
          * client_zone_id, failuredetector_implementation
          * 
          */
+        builder.append("bootstrap_urls=")
+               .append(Arrays.toString(this.config.getBootstrapUrls()))
+               .append("\n");
         builder.append("max_connections=")
                .append(this.config.getMaxConnectionsPerNode())
-               .append("\n");
-        builder.append("max_total_connections=")
-               .append(this.config.getMaxTotalConnections())
                .append("\n");
         builder.append("connection_timeout_ms=")
                .append(this.config.getConnectionTimeout(TimeUnit.MILLISECONDS))
@@ -237,6 +239,12 @@ public class ClientInfo implements Serializable {
                .append("\n");
         builder.append("failuredetector_threshold_async_recovery_interval=")
                .append(this.config.getFailureDetectorAsyncRecoveryInterval())
+               .append("\n");
+        builder.append("fetch_all_stores_xml_in_bootstrap=")
+               .append(this.config.isFetchAllStoresXmlInBootstrap())
+               .append("\n");
+        builder.append("idle_connection_timeout_minutes=")
+               .append(this.config.getIdleConnectionTimeout(TimeUnit.MINUTES))
                .append("\n");
 
         return builder.toString();

--- a/src/java/voldemort/client/SocketStoreClientFactory.java
+++ b/src/java/voldemort/client/SocketStoreClientFactory.java
@@ -66,6 +66,7 @@ public class SocketStoreClientFactory extends AbstractStoreClientFactory {
                                                           config.getMaxConnectionsPerNode(),
                                                           config.getConnectionTimeout(TimeUnit.MILLISECONDS),
                                                           config.getSocketTimeout(TimeUnit.MILLISECONDS),
+                                                          config.getIdleConnectionTimeout(TimeUnit.MILLISECONDS),
                                                           config.getSocketBufferSize(),
                                                           config.getSocketKeepAlive(),
                                                           config.isJmxEnabled(),

--- a/src/java/voldemort/client/SystemStoreClientFactory.java
+++ b/src/java/voldemort/client/SystemStoreClientFactory.java
@@ -46,6 +46,7 @@ public class SystemStoreClientFactory<K, V> {
             identifierString = "system";
         }
 
+        long idleConnectionTimeout = clientConfig.getIdleConnectionTimeout(TimeUnit.MILLISECONDS);
         systemStoreConfig.setSelectors(1)
                          .setBootstrapUrls(clientConfig.getBootstrapUrls())
                          .setMaxConnectionsPerNode(clientConfig.getSysMaxConnectionsPerNode())
@@ -53,6 +54,7 @@ public class SystemStoreClientFactory<K, V> {
                                                TimeUnit.MILLISECONDS)
                          .setSocketTimeout(clientConfig.getSysSocketTimeout(),
                                            TimeUnit.MILLISECONDS)
+                         .setIdleConnectionTimeout(idleConnectionTimeout, TimeUnit.MILLISECONDS)
                          .setRoutingTimeout(clientConfig.getSysRoutingTimeout(),
                                             TimeUnit.MILLISECONDS)
                          .setEnableJmx(clientConfig.getSysEnableJmx())

--- a/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutorFactory.java
+++ b/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutorFactory.java
@@ -58,6 +58,7 @@ public class ClientRequestExecutorFactory implements
     private static final int SHUTDOWN_TIMEOUT_MS = 15000;
     private final int connectTimeoutMs;
     private final int soTimeoutMs;
+    private final long idleConnectionTimeoutNs;
     private final int socketBufferSize;
     private final AtomicInteger created;
     private final AtomicInteger destroyed;
@@ -72,6 +73,7 @@ public class ClientRequestExecutorFactory implements
     public ClientRequestExecutorFactory(int selectors,
                                         int connectTimeoutMs,
                                         int soTimeoutMs,
+                                        long idleConnectionTimeoutMs,
                                         int socketBufferSize,
                                         boolean socketKeepAlive,
                                         ClientSocketStats stats,
@@ -79,6 +81,11 @@ public class ClientRequestExecutorFactory implements
                                         ClientRequestExecutorPool executorPool) {
         this.connectTimeoutMs = connectTimeoutMs;
         this.soTimeoutMs = soTimeoutMs;
+        if (idleConnectionTimeoutMs > 0) {
+            this.idleConnectionTimeoutNs = TimeUnit.NANOSECONDS.convert(idleConnectionTimeoutMs, TimeUnit.MILLISECONDS);
+        } else {
+            this.idleConnectionTimeoutNs = -1;
+        }
         this.created = new AtomicInteger(0);
         this.destroyed = new AtomicInteger(0);
         this.socketBufferSize = socketBufferSize;
@@ -167,6 +174,7 @@ public class ClientRequestExecutorFactory implements
             clientRequestExecutor = new ClientRequestExecutor(selector,
                                                               socketChannel,
                                                               socketBufferSize,
+                                                              idleConnectionTimeoutNs,
                                                               dest);
             int timeoutMs = this.getTimeout();
 

--- a/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutorPool.java
+++ b/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutorPool.java
@@ -58,6 +58,7 @@ public class ClientRequestExecutorPool implements SocketStoreFactory {
     public static final Boolean DEFAULT_SOCKET_KEEP_ALIVE = false;
     public static final Boolean DEFAULT_JMX_ENABLED = false;
     public static final String DEFAULT_IDENTIFIER_STRING = "";
+    public static final long DEFAULT_IDLE_CONNECTION_TIMEOUT_MS  = -1 ; //Disabled by default.
 
     private final QueuedKeyedResourcePool<SocketDestination, ClientRequestExecutor> queuedPool;
     private final ClientRequestExecutorFactory factory;
@@ -76,6 +77,7 @@ public class ClientRequestExecutorPool implements SocketStoreFactory {
                                      int maxConnectionsPerNode,
                                      int connectionTimeoutMs,
                                      int soTimeoutMs,
+                                     long idleConnectionTimeoutMs,
                                      int socketBufferSize,
                                      boolean socketKeepAlive,
                                      boolean jmxEnabled,
@@ -96,6 +98,7 @@ public class ClientRequestExecutorPool implements SocketStoreFactory {
         this.factory = new ClientRequestExecutorFactory(selectors,
                                                         connectionTimeoutMs,
                                                         soTimeoutMs,
+                                                        idleConnectionTimeoutMs,
                                                         socketBufferSize,
                                                         socketKeepAlive,
                                                         stats,
@@ -120,6 +123,7 @@ public class ClientRequestExecutorPool implements SocketStoreFactory {
              maxConnectionsPerNode,
              connectionTimeoutMs,
              soTimeoutMs,
+             DEFAULT_IDLE_CONNECTION_TIMEOUT_MS,
              socketBufferSize,
              socketKeepAlive,
              DEFAULT_JMX_ENABLED,
@@ -137,6 +141,7 @@ public class ClientRequestExecutorPool implements SocketStoreFactory {
              maxConnectionsPerNode,
              connectionTimeoutMs,
              soTimeoutMs,
+             DEFAULT_IDLE_CONNECTION_TIMEOUT_MS,
              socketBufferSize,
              socketKeepAlive,
              DEFAULT_JMX_ENABLED,
@@ -152,6 +157,7 @@ public class ClientRequestExecutorPool implements SocketStoreFactory {
              maxConnectionsPerNode,
              connectionTimeoutMs,
              soTimeoutMs,
+             DEFAULT_IDLE_CONNECTION_TIMEOUT_MS,
              socketBufferSize,
              DEFAULT_SOCKET_KEEP_ALIVE,
              DEFAULT_JMX_ENABLED,

--- a/src/java/voldemort/utils/MetadataVersionStoreUtils.java
+++ b/src/java/voldemort/utils/MetadataVersionStoreUtils.java
@@ -80,7 +80,12 @@ public class MetadataVersionStoreUtils {
             return prop1;
         }
 
-        Properties result = new Properties(prop1);
+        Properties result = new Properties();
+
+        for(String propName: prop1.stringPropertyNames()) {
+            result.setProperty(propName, prop1.getProperty(propName));
+        }
+
         for(String propName: prop2.stringPropertyNames()) {
             String currValue = result.getProperty(propName);
             long currlValue = tryParse(currValue);

--- a/test/common/voldemort/store/socket/TestSocketStoreFactory.java
+++ b/test/common/voldemort/store/socket/TestSocketStoreFactory.java
@@ -26,6 +26,7 @@ public class TestSocketStoreFactory extends ClientRequestExecutorPool {
     static final Integer DEFAULT_CONNECTION_TIMEOUT_MS = 10000;
     static final Integer DEFAULT_SO_TIMEOUT_MS = 100000;
     static final Integer DEFAULT_SOCKET_BUFFER_SIZE = 1024;
+    static final long DEFAULT_IDLE_CONNECTION_TIMEOUT_MS = -1;
     static final ClientConfig DEFAULT_CLIENT_CONFIG = new ClientConfig();
 
     public TestSocketStoreFactory() {
@@ -33,6 +34,7 @@ public class TestSocketStoreFactory extends ClientRequestExecutorPool {
               DEFAULT_MAX_CONNECTIONS_PER_NODE,
               DEFAULT_CONNECTION_TIMEOUT_MS,
               DEFAULT_SO_TIMEOUT_MS,
+              DEFAULT_IDLE_CONNECTION_TIMEOUT_MS,
               DEFAULT_SOCKET_BUFFER_SIZE,
               DEFAULT_SOCKET_KEEP_ALIVE,
               DEFAULT_JMX_ENABLED,

--- a/test/unit/voldemort/client/ClientConfigTest.java
+++ b/test/unit/voldemort/client/ClientConfigTest.java
@@ -1,8 +1,10 @@
 package voldemort.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
@@ -43,6 +45,64 @@ public class ClientConfigTest {
             } catch (IllegalArgumentException ex) {
                 assertEquals("bootstrap fails for positive number", 0, val);
             }
+        }
+    }
+
+    @Test
+    public void testIdleConnectionTimeout() {
+        String idleConnectionTimeoutProperty = "idle_connection_timeout_minutes";
+
+        // Disabled test cases
+        ClientConfig config1 = new ClientConfig().setIdleConnectionTimeout(0, TimeUnit.NANOSECONDS);
+        assertEquals("setting to 0, should return -1, regardless of the unit",
+                     -1,
+                     config1.getIdleConnectionTimeout(TimeUnit.DAYS));
+
+        Properties props1 = new Properties();
+        props1.setProperty("idle_connection_timeout_minutes", "-1");
+        ClientConfig config2 = new ClientConfig(props1);
+        assertEquals("setting to 0, should return -1, regardless of the unit",
+                     -1,
+                     config2.getIdleConnectionTimeout(TimeUnit.DAYS));
+
+        // Negative test cases, where it should throw
+        for (int i = 1; i < 10; i++) {
+            for (TimeUnit unit : new TimeUnit[] { TimeUnit.MINUTES, TimeUnit.SECONDS }) {
+                try {
+                    ClientConfig config = new ClientConfig().setIdleConnectionTimeout(i, unit);
+                    fail("Any thing with less than 10 minute should throw" + i);
+                } catch (IllegalArgumentException e) {
+                    // expected
+                }
+            }
+        }
+
+        for (int i = 1; i < 10; i++) {
+            Properties props = new Properties();
+            props.setProperty("idle_connection_timeout_minutes", Integer.toString(i));
+
+            try {
+                ClientConfig config = new ClientConfig(props);
+                fail("Any thing with less than 10 minute should throw");
+            } catch (IllegalArgumentException e) {
+                // expected
+            }
+        }
+
+        // Positive test cases
+        for (int i = 10; i < 100; i++) {
+            for (TimeUnit unit : new TimeUnit[] { TimeUnit.MINUTES, TimeUnit.DAYS }) {
+                ClientConfig config = new ClientConfig().setIdleConnectionTimeout(i, unit);
+                assertEquals(" set valud is not same as retrieved", i, config.getIdleConnectionTimeout(unit));
+            }
+        }
+        
+        for (int i = 10; i < 100; i++) {
+            Properties props = new Properties();
+            props.setProperty("idle_connection_timeout_minutes", Integer.toString(i));
+            
+            ClientConfig config = new ClientConfig(props);
+            assertEquals(" set valud is not same as retrieved", i, config.getIdleConnectionTimeout(TimeUnit.MINUTES));
         }
     }
 }

--- a/test/unit/voldemort/store/routed/HintedHandoffSendHintTest.java
+++ b/test/unit/voldemort/store/routed/HintedHandoffSendHintTest.java
@@ -93,6 +93,7 @@ public class HintedHandoffSendHintTest {
     private final static int KEY_LENGTH = 32;
     private final static int VALUE_LENGTH = 32;
     private final static int SOCKET_TIMEOUT_MS = 500;
+    private final static long IDLE_CONNECTION_TIMEOUT_MS = -1;
 
     private final Class<? extends FailureDetector> failureDetectorCls = ThresholdFailureDetector.class;
     private final HintedHandoffStrategyType hintRoutingStrategy;
@@ -129,6 +130,7 @@ public class HintedHandoffSendHintTest {
                                                          config.getMaxConnectionsPerNode(),
                                                          config.getConnectionTimeout(TimeUnit.MILLISECONDS),
                                                          SOCKET_TIMEOUT_MS,
+                                                         IDLE_CONNECTION_TIMEOUT_MS,
                                                          config.getSocketBufferSize(),
                                                          config.getSocketKeepAlive(),
                                                          false,


### PR DESCRIPTION
1) Add idle connection timeout support to Voldemort.
2) Reduce the socket timeout ( timeout once socket.read() is called from 24 hours to 1 minute)
3) Minor fixes to remove Properties(properties)
4) Debug information fix.