### PR TITLE
Admin client fixes

### DIFF
--- a/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
+++ b/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
@@ -1493,24 +1493,13 @@ public class AdminServiceRequestHandler implements RequestHandler {
                                              "supported on this version of the Voldemort server.");
             }
 
-            /**
-             * GET can be done on any of the standard metadata keys
-             * ('cluster.xml', 'server.state', 'node.id', ...) or any of the
-             * store names.
-             */
-            if(MetadataStore.METADATA_KEYS.contains(keyString)
-               || metadataStore.isValidStore(keyString)) {
-                List<Versioned<byte[]>> versionedList = metadataStore.get(key, null);
-                int size = (versionedList.size() > 0) ? 1 : 0;
+            List<Versioned<byte[]>> versionedList = metadataStore.get(key, null);
 
-                if(size > 0) {
-                    Versioned<byte[]> versioned = versionedList.get(0);
-                    response.setVersion(ProtoUtils.encodeVersioned(versioned));
-                }
-            } else {
-                throw new VoldemortException("Metadata Key passed '" + keyString
-                                             + "' is not handled yet");
+            if(versionedList.size() > 0) {
+                Versioned<byte[]> versioned = versionedList.get(0);
+                response.setVersion(ProtoUtils.encodeVersioned(versioned));
             }
+
         } catch(VoldemortException e) {
             response.setError(ProtoUtils.encodeError(errorCodeMapper, e));
             logger.error("handleGetMetadata failed for request(" + request.toString() + ")", e);

--- a/src/java/voldemort/store/ErrorCodeMapper.java
+++ b/src/java/voldemort/store/ErrorCodeMapper.java
@@ -68,6 +68,7 @@ public class ErrorCodeMapper {
         codeToException.put((short) 19, UnauthorizedStoreException.class);
         codeToException.put((short) 20, AsyncOperationStoppedException.class);
         codeToException.put((short) 21, ReadOnlyFetchDisabledException.class);
+        codeToException.put((short) 22, StoreNotFoundException.class);
 
         exceptionToCode = new HashMap<Class<? extends VoldemortException>, Short>();
         for(Map.Entry<Short, Class<? extends VoldemortException>> entry: codeToException.entrySet())

--- a/src/java/voldemort/store/StoreNotFoundException.java
+++ b/src/java/voldemort/store/StoreNotFoundException.java
@@ -1,0 +1,18 @@
+package voldemort.store;
+
+import voldemort.VoldemortApplicationException;
+
+
+public class StoreNotFoundException extends VoldemortApplicationException {
+
+    private static final long serialVersionUID = 1L;
+
+    public StoreNotFoundException(String s) {
+        super(s);
+    }
+
+    public StoreNotFoundException(String s, Throwable t) {
+        super(s, t);
+    }
+
+}

--- a/src/java/voldemort/store/metadata/MetadataStore.java
+++ b/src/java/voldemort/store/metadata/MetadataStore.java
@@ -53,6 +53,7 @@ import voldemort.store.StorageEngine;
 import voldemort.store.Store;
 import voldemort.store.StoreCapabilityType;
 import voldemort.store.StoreDefinition;
+import voldemort.store.StoreNotFoundException;
 import voldemort.store.StoreUtils;
 import voldemort.store.configuration.ConfigurationStorageEngine;
 import voldemort.store.memory.InMemoryStorageEngine;
@@ -559,7 +560,7 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
                // Since there is no way to tell the difference between 1&2, the error message
                // is focused on use case 2. In the future, if that is a problem the error message
                // can be made to reflect both the cases.
-                throw new VoldemortException("Store " + key + " does not exist on node "
+                throw new StoreNotFoundException("Store " + key + " does not exist on node "
                                              + this.getNodeId());
             }
         } finally {

--- a/src/java/voldemort/utils/MetadataVersionStoreUtils.java
+++ b/src/java/voldemort/utils/MetadataVersionStoreUtils.java
@@ -72,6 +72,20 @@ public class MetadataVersionStoreUtils {
         }
     }
 
+    public static Long getVersion(Properties prop, String versionKey) {
+        long value = 0;
+
+        if(prop != null && prop.getProperty(versionKey) != null) {
+            String strValue = prop.getProperty(versionKey);
+            value = tryParse(strValue);
+        }
+
+        if(logger.isDebugEnabled()) {
+            logger.debug("*********** For key : " + versionKey + " received value = " + value);
+        }
+        return value;
+    }
+
     public static Properties mergeVersions(Properties prop1, Properties prop2) {
         if(prop1 == null) {
             return prop2;

--- a/test/common/voldemort/config/readonly-store.xml
+++ b/test/common/voldemort/config/readonly-store.xml
@@ -1,0 +1,17 @@
+<stores>
+<store>
+  <name>abc-xyz-read-only</name>
+  <persistence>read-only</persistence>
+  <routing-strategy>consistent-routing</routing-strategy>
+  <routing>client</routing>
+  <replication-factor>1</replication-factor>
+  <required-reads>1</required-reads>
+  <required-writes>1</required-writes>
+  <key-serializer>
+    <type>string</type>
+  </key-serializer>
+  <value-serializer>
+    <type>string</type>
+  </value-serializer>
+</store>
+</stores>

--- a/test/unit/voldemort/client/AdminServiceBasicTest.java
+++ b/test/unit/voldemort/client/AdminServiceBasicTest.java
@@ -237,11 +237,14 @@ public class AdminServiceBasicTest {
     public void testUpdateClusterMetadata() {
         Cluster updatedCluster = ServerTestUtils.getLocalCluster(4);
         AdminClient client = getAdminClient();
+        assertFalse("Newly Created admin client has valid cluster", client.isClusterModified());
         for(int i = 0; i < NUM_RUNS; i++) {
             VectorClock clock = ((VectorClock) client.metadataMgmtOps.getRemoteCluster(0)
                                                                      .getVersion()).incremented(0,
                                                                                                 System.currentTimeMillis());
             client.metadataMgmtOps.updateRemoteCluster(0, updatedCluster, clock);
+
+            assertTrue("After cluster update", client.isClusterModified());
 
             assertEquals("Cluster should match",
                          updatedCluster,

--- a/test/unit/voldemort/client/VerifyOrAddStoreTest.java
+++ b/test/unit/voldemort/client/VerifyOrAddStoreTest.java
@@ -1,0 +1,243 @@
+package voldemort.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import voldemort.ServerTestUtils;
+import voldemort.VoldemortException;
+import voldemort.client.protocol.admin.AdminClient;
+import voldemort.client.protocol.admin.AdminClientConfig;
+import voldemort.cluster.Cluster;
+import voldemort.cluster.Node;
+import voldemort.server.VoldemortServer;
+import voldemort.store.StoreDefinition;
+import voldemort.store.memory.InMemoryStorageConfiguration;
+import voldemort.xml.StoreDefinitionsMapper;
+
+
+@RunWith(Parameterized.class)
+public class VerifyOrAddStoreTest {
+
+    private final static String storesXmlfile = "test/common/voldemort/config/stores.xml";
+    private final static String readOnlyXmlFilePath = "test/common/voldemort/config/readonly-store.xml";
+    
+    private final static String PROCESS_NAME = "unit-test";
+
+    private VoldemortServer[] servers;
+
+    private Cluster cluster;
+
+    private AdminClient adminClient;
+
+    private StoreDefinition newStoreDef;
+    private String newStoreName;
+    private final ClientConfig clientConfig;
+
+    @Parameters
+    public static Collection<Object[]> configs() {
+        return Arrays.asList(new Object[][] { { true }, { false } });
+    }
+
+    public VerifyOrAddStoreTest(boolean fetchAllStores) {
+        clientConfig = new ClientConfig().setFetchAllStoresXmlInBootstrap(fetchAllStores);
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        int numServers = 4;
+        servers = new VoldemortServer[numServers];
+        int partitionMap[][] = { { 0, 1, 2, 3 }, { 4, 5, 6, 7 }, { 8, 9, 10, 11 }, { 12, 13, 14, 15 } };
+        cluster = ServerTestUtils.startVoldemortCluster(servers, partitionMap, new Properties(), storesXmlfile);
+
+        newStoreDef = new StoreDefinitionsMapper().readStoreList(new File(readOnlyXmlFilePath)).get(0);
+        newStoreName = newStoreDef.getName();
+
+        Node node = cluster.getNodeById(0);
+        String bootstrapUrl = "tcp://" + node.getHost() + ":" + node.getSocketPort();
+        clientConfig.setBootstrapUrls(bootstrapUrl);
+
+        adminClient = new AdminClient(new AdminClientConfig(), clientConfig);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        adminClient.close();
+        for(VoldemortServer server: servers) {
+            ServerTestUtils.stopVoldemortServer(server);
+        }
+    }
+
+    private StoreDefinition retrieveStoreOnNode(String storeName, int nodeId) {
+        List<StoreDefinition> storeDefs = adminClient.metadataMgmtOps.getRemoteStoreDefList(nodeId).getValue();
+        StoreDefinition retrieved = null;
+        for (StoreDefinition storeDef : storeDefs) {
+            if (storeDef.getName().equals(newStoreName)) {
+                retrieved = storeDef;
+                break;
+            }
+        }
+        return retrieved;
+    }
+
+    private void verifyStoreAddedOnAllNodes() {
+        for (Integer nodeId : cluster.getNodeIds()) {
+            StoreDefinition retrieved = retrieveStoreOnNode(newStoreName, nodeId);
+            assertNotNull("Created store can't be retrieved", retrieved);
+            assertEquals("Store Created and retrieved are different ", newStoreDef, retrieved);
+        }
+    }
+
+    private void verifyStoreDoesNotExist() {
+        for (Integer nodeId : cluster.getNodeIds()) {
+            StoreDefinition retrieved = retrieveStoreOnNode(newStoreName, nodeId);
+            assertNull("Store should not be created", retrieved);
+        }
+    }
+
+    @Test
+    public void verifyNewStoreAddition() {
+        adminClient.storeMgmtOps.verifyOrAddStore(newStoreDef, PROCESS_NAME);
+        verifyStoreAddedOnAllNodes();
+    }
+
+    @Test
+    public void verifyNoStoreCreated() {
+        try {
+            adminClient.storeMgmtOps.verifyOrAddStore(newStoreDef, PROCESS_NAME, false);
+            Assert.fail("Non existent store create with flag disabled should have thrown error");
+        } catch (VoldemortException ex) {
+            // Pass
+        }
+        verifyStoreDoesNotExist();
+    }
+
+    @Test
+    public void verifyPartialCreatedStores() {
+        // Add the store on one node with same definition.
+        adminClient.storeMgmtOps.addStore(newStoreDef, 0);
+        adminClient.storeMgmtOps.verifyOrAddStore(newStoreDef, PROCESS_NAME);
+        verifyStoreAddedOnAllNodes();
+    }
+    
+    private StoreDefinition getIncompatibleStoreDef() {
+        // Create store with same definition but modify the type.
+        return new StoreDefinition(newStoreDef.getName(),
+                InMemoryStorageConfiguration.TYPE_NAME,
+                newStoreDef.getDescription(),
+                newStoreDef.getKeySerializer(), 
+                newStoreDef.getValueSerializer(),
+                newStoreDef.getTransformsSerializer(),
+                newStoreDef.getRoutingPolicy(),
+                newStoreDef.getRoutingStrategyType(),
+                newStoreDef.getReplicationFactor(),
+                newStoreDef.getPreferredReads(),
+                newStoreDef.getRequiredReads(),
+                newStoreDef.getPreferredWrites(),
+                newStoreDef.getRequiredWrites(),
+                newStoreDef.getViewTargetStoreName(),
+                newStoreDef.getValueTransformation(),
+                newStoreDef.getZoneReplicationFactor(),
+                newStoreDef.getZoneCountReads(),
+                newStoreDef.getZoneCountWrites(),
+                newStoreDef.getRetentionDays(),
+                newStoreDef.getRetentionScanThrottleRate(),
+                newStoreDef.getRetentionFrequencyDays(),
+                newStoreDef.getSerializerFactory(),
+                newStoreDef.getHintedHandoffStrategyType(),
+                newStoreDef.getHintPrefListSize(),
+                newStoreDef.getOwners(),
+                newStoreDef.getMemoryFootprintMB());
+    }
+
+    @Test
+    public void verifyMisMatchFails() throws Exception {
+        StoreDefinition incompatibleDef = getIncompatibleStoreDef();
+        final int NODE_ID = 0;
+        // Add the incompatible store definition to Node 0
+        adminClient.storeMgmtOps.addStore(incompatibleDef, NODE_ID);
+
+        // Adding the store with different definition should fail.
+        try {
+            adminClient.storeMgmtOps.verifyOrAddStore(newStoreDef, PROCESS_NAME, false);
+            Assert.fail("Non existent store create with flag disabled should have thrown error");
+        } catch (VoldemortException ex) {
+            // Pass
+        }
+
+        for (Integer nodeId : cluster.getNodeIds()) {
+            StoreDefinition retrieved = retrieveStoreOnNode(newStoreName, nodeId);
+            if (nodeId == NODE_ID) {
+                assertEquals("mismatched store def should be left intact", incompatibleDef, retrieved);
+            } else {
+                assertNull("Store should not exist in this node", retrieved);
+            }
+        }
+    }
+
+    @Test
+    public void verifyCreateWithNodeFailure() throws Exception {
+        final int NODE_ID = servers.length - 1;
+        ServerTestUtils.stopVoldemortServer(servers[NODE_ID]);
+
+        try {
+            adminClient.storeMgmtOps.verifyOrAddStore(newStoreDef, PROCESS_NAME);
+            Assert.fail("Non existent store create with flag disabled should have thrown error");
+        } catch(VoldemortException ex) {
+            // Pass
+        }
+
+        for(Integer nodeId: cluster.getNodeIds()) {
+            if(nodeId == NODE_ID) {
+                // this is a dead server, continue;
+            } else {
+                StoreDefinition retrieved = retrieveStoreOnNode(newStoreName, nodeId);
+                assertEquals("store successfully created on online nodes", newStoreDef, retrieved);
+            }
+        }
+    }
+
+    @Test
+    public void verifyAdminClientAcrossNodeRestart() throws Exception {
+        // Do a query create the connections.
+        adminClient.storeMgmtOps.verifyOrAddStore(newStoreDef, PROCESS_NAME);
+
+        final int NODE_ID = servers.length - 1;
+        ServerTestUtils.stopVoldemortServer(servers[NODE_ID]);
+
+        try {
+            retrieveStoreOnNode(newStoreName, NODE_ID);
+            Assert.fail("Downed node retrieval should have thrown an error");
+        } catch (VoldemortException ex) {
+            // Expected
+        }
+
+        try {
+            adminClient.storeMgmtOps.verifyOrAddStore(newStoreDef, PROCESS_NAME);
+            Assert.fail("Downed node should have thrown an error");
+        } catch (VoldemortException ex) {
+            // Expected
+        }
+
+        servers[NODE_ID] = ServerTestUtils.restartServer(servers[NODE_ID], NODE_ID, cluster);
+        StoreDefinition retrieved = retrieveStoreOnNode(newStoreName, NODE_ID);
+        assertEquals("After restart, should retrieve the store", newStoreDef, retrieved);
+        adminClient.storeMgmtOps.verifyOrAddStore(newStoreDef, PROCESS_NAME);
+    }
+}


### PR DESCRIPTION
1) verifyOrAddStore option to retireve only single store, instead of fetching all stores, which on some clusters with large number of stores , take a long amount of time.
2) a way to check is it easy to re-use the AdminClient for a longer period of time.