### PR TITLE
Auto detect node

### DIFF
--- a/config/single_node_cluster/config/server.properties
+++ b/config/single_node_cluster/config/server.properties
@@ -1,6 +1,5 @@
-# The ID of *this* particular cluster node
-node.id=0
-
+# Enable auto detection of node id
+enable.node.id.detection=true
 max.threads=100
 
 ############### DB options ######################

--- a/src/java/voldemort/common/nio/SelectorManagerWorker.java
+++ b/src/java/voldemort/common/nio/SelectorManagerWorker.java
@@ -106,11 +106,9 @@ public abstract class SelectorManagerWorker implements Runnable {
             else if(selectionKey.isWritable())
                 write(selectionKey);
             else if(!selectionKey.isValid())
-                throw new IllegalStateException("Selection key not valid for "
-                                                + socketChannel.socket());
+                throw new IllegalStateException("Selection key not valid for " + getDebugInfo());
             else
-                throw new IllegalStateException("Unknown state, not readable, writable, or valid for "
-                                                + socketChannel.socket());
+                throw new IllegalStateException("Unknown state, not readable, writable, or valid for " + getDebugInfo());
         } catch(ClosedByInterruptException e) {
             reportException(e);
             close();
@@ -122,12 +120,11 @@ public abstract class SelectorManagerWorker implements Runnable {
             reportException(e);
             close();
         } catch(IOException e) {
-            logger.info("Connection reset from " + socketChannel.socket() + " with message - "
-                        + e.getMessage());
+            logger.info("Connection reset from " + getDebugInfo() + " with message - " + e.getMessage());
             reportException(e);
             close();
         } catch(Throwable t) {
-            logger.error("Caught throwable from " + socketChannel.socket(), t);
+            logger.error("Caught throwable from " + getDebugInfo(), t);
             close();
         }
     }
@@ -208,6 +205,10 @@ public abstract class SelectorManagerWorker implements Runnable {
                      + inputStream.getBuffer().limit() + ", remaining: "
                      + inputStream.getBuffer().remaining() + ", capacity: "
                      + inputStream.getBuffer().capacity() + " - for " + socketChannel.socket());
+    }
+
+    protected String getDebugInfo() {
+        return String.valueOf(socketChannel.socket());
     }
 
 }

--- a/src/java/voldemort/server/Host.java
+++ b/src/java/voldemort/server/Host.java
@@ -1,0 +1,26 @@
+package voldemort.server;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import voldemort.VoldemortApplicationException;
+
+
+public class Host {
+
+    private static InetAddress getLocal() {
+        try {
+            return InetAddress.getLocalHost();
+        } catch(UnknownHostException ex) {
+            throw new VoldemortApplicationException("Error retrieving local host", ex);
+        }
+    }
+
+    public static String getName() {
+        return getLocal().getHostName();
+    }
+
+    public static String getFQDN() {
+        return getLocal().getCanonicalHostName();
+    }
+}

--- a/src/java/voldemort/server/HostMatcher.java
+++ b/src/java/voldemort/server/HostMatcher.java
@@ -1,0 +1,66 @@
+package voldemort.server;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+import voldemort.VoldemortApplicationException;
+import voldemort.cluster.Node;
+import voldemort.utils.ReflectUtils;
+
+
+public abstract class HostMatcher {
+
+    private final List<String> types;
+    public static final String HOSTNAME = "hostname";
+    public static final String FQDN = "fqdn";
+
+    public HostMatcher(List<String> types) {
+        this.types = types;
+    }
+
+    public boolean match(Node node) {
+        for(String type: types) {
+            String host = getHost(type);
+            if(match(node, host)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    abstract protected boolean match(Node node, String host);
+
+    protected String getHost(String type) {
+        if(type.equalsIgnoreCase(HOSTNAME)) {
+            return Host.getName();
+        } else if(type.equalsIgnoreCase(FQDN)) {
+            return Host.getFQDN();
+        } else {
+            throw new VoldemortApplicationException("Unrecognized type" + type);
+        }
+    }
+
+    public static HostMatcher getImplementation(String className, List<String> types) {
+        if(className == PosixHostMatcher.class.getName()) {
+            return new PosixHostMatcher(types);
+        } else {
+            Class<?> factoryClass = ReflectUtils.loadClass(className.trim());
+            return (HostMatcher) ReflectUtils.callConstructor(factoryClass,
+                                                              new Class<?>[] { types.getClass() },
+                                                              new Object[] { types });
+        }
+    }
+
+    public boolean isLocalAddress(Node node) {
+        String host = node.getHost();
+        InetAddress hostAddress;
+        try {
+            hostAddress = InetAddress.getByName(host);
+        } catch(UnknownHostException ex) {
+            throw new VoldemortApplicationException("Error retrieving InetAddress for host " + host,
+                                                    ex);
+        }
+        return hostAddress.isAnyLocalAddress() || hostAddress.isLoopbackAddress();
+    }
+}

--- a/src/java/voldemort/server/HostMatcher.java
+++ b/src/java/voldemort/server/HostMatcher.java
@@ -2,6 +2,7 @@ package voldemort.server;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.List;
 
 import voldemort.VoldemortApplicationException;
@@ -63,4 +64,15 @@ public abstract class HostMatcher {
         }
         return hostAddress.isAnyLocalAddress() || hostAddress.isLoopbackAddress();
     }
+
+    public String getDebugInfo() {
+        String debugInfo = "HostMatcher [types=" + Arrays.toString(types.toArray()) + "].";
+        for(String type: types) {
+            String host = getHost(type);
+            debugInfo += " Type : " + type;
+            debugInfo += " , Value " + host + " .";
+        }
+        return debugInfo;
+    }
+
 }

--- a/src/java/voldemort/server/NodeIdUtils.java
+++ b/src/java/voldemort/server/NodeIdUtils.java
@@ -1,0 +1,92 @@
+package voldemort.server;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+import voldemort.VoldemortApplicationException;
+import voldemort.cluster.Cluster;
+import voldemort.cluster.Node;
+
+import com.google.common.collect.Lists;
+
+
+public class NodeIdUtils {
+
+    private static final Logger logger = Logger.getLogger(NodeIdUtils.class.getName());
+    private static boolean isSingleLocalCluster(Cluster cluster, HostMatcher matcher) {
+        if(cluster.getNumberOfNodes() == 1) {
+            Node singleNode = cluster.getNodes().iterator().next();
+            boolean isSingleLocalNode = matcher.isLocalAddress(singleNode);
+            if(isSingleLocalNode) {
+                logger.info(singleNode.briefToString() + " is a single local node cluster");
+            }
+            return isSingleLocalNode;
+        }
+        return false;
+    }
+
+    public static int findNodeId(Cluster cluster, HostMatcher matcher) {
+        if(isSingleLocalCluster(cluster, matcher)) {
+            int nodeId = cluster.getNodeIds().iterator().next();
+            logger.info(" Cluster is a single local node cluster. Node Id " + nodeId);
+            return nodeId;
+        }
+
+        List<Node> matches = Lists.newArrayList();
+        for(Node node: cluster.getNodes()) {
+            if(matcher.match(node)) {
+                logger.info(node.briefToString() + " matched the current cluster ");
+                matches.add(node);
+            }
+        }
+
+        if(matches.isEmpty()) {
+            throw new VoldemortApplicationException(" No nodes in the cluster matched the current node "
+                                                + Arrays.toString(cluster.getNodes().toArray()));
+        } else if ( matches.size() > 1) {
+            throw new VoldemortApplicationException(" More than one node matched "
+                                                    + Arrays.toString(matches.toArray()));
+        } else {
+            logger.info(" computed node Id match successfully " + matches.get(0).briefToString());
+            return matches.get(0).getId();
+        }
+    }
+
+    public static void validateNodeId(Cluster cluster, HostMatcher matcher, int nodeId) {
+        if(isSingleLocalCluster(cluster, matcher)) {
+            // Make sure nodeId exists.
+            cluster.getNodeById(nodeId);
+            return;
+        }
+        
+        List<String> errors =  Lists.newArrayList();
+        for(Node node: cluster.getNodes()) {
+            if(nodeId == node.getId()) {
+                if(!matcher.match(node)) {
+                    errors.add(node.briefToString() + " selected as current node " + nodeId
+                               + " failed to match");
+                } 
+            }else {
+                if(matcher.match(node)) {
+                    errors.add(node.briefToString() + " matched, though the expected node is "
+                               + nodeId);
+                }
+            }
+        }
+
+        if(!errors.isEmpty()) {
+            if(errors.size() == 1) {
+                throw new VoldemortApplicationException(errors.get(0));
+            } else {
+                throw new VoldemortApplicationException(" Number of Validation failures "
+                                                        + errors.size() + ". Details : "
+                                                        + Arrays.toString(errors.toArray()));
+            }
+        } else {
+            logger.info("Node Id Validation succeeded. Node Id " + nodeId);
+        }
+
+    }
+}

--- a/src/java/voldemort/server/NodeIdUtils.java
+++ b/src/java/voldemort/server/NodeIdUtils.java
@@ -28,6 +28,7 @@ public class NodeIdUtils {
     }
 
     public static int findNodeId(Cluster cluster, HostMatcher matcher) {
+        logger.info(" Using Matcher " + matcher.getDebugInfo());
         if(isSingleLocalCluster(cluster, matcher)) {
             int nodeId = cluster.getNodeIds().iterator().next();
             logger.info(" Cluster is a single local node cluster. Node Id " + nodeId);
@@ -46,8 +47,10 @@ public class NodeIdUtils {
             throw new VoldemortApplicationException(" No nodes in the cluster matched the current node "
                                                 + Arrays.toString(cluster.getNodes().toArray()));
         } else if ( matches.size() > 1) {
-            throw new VoldemortApplicationException(" More than one node matched "
-                                                    + Arrays.toString(matches.toArray()));
+            String errorMessage = " More than one node matched "
+                                  + Arrays.toString(matches.toArray());
+            logger.error(errorMessage);
+            throw new VoldemortApplicationException(errorMessage);
         } else {
             logger.info(" computed node Id match successfully " + matches.get(0).briefToString());
             return matches.get(0).getId();
@@ -55,9 +58,11 @@ public class NodeIdUtils {
     }
 
     public static void validateNodeId(Cluster cluster, HostMatcher matcher, int nodeId) {
+        logger.info(" Using Matcher " + matcher.getDebugInfo());
+        // Make sure nodeId exists.
+        cluster.getNodeById(nodeId);
+
         if(isSingleLocalCluster(cluster, matcher)) {
-            // Make sure nodeId exists.
-            cluster.getNodeById(nodeId);
             return;
         }
         
@@ -77,12 +82,13 @@ public class NodeIdUtils {
         }
 
         if(!errors.isEmpty()) {
+            String errorMessage = " Number of Validation failures " + errors.size()
+                                  + ". Details : " + Arrays.toString(errors.toArray());
+            logger.error(errorMessage);
             if(errors.size() == 1) {
                 throw new VoldemortApplicationException(errors.get(0));
             } else {
-                throw new VoldemortApplicationException(" Number of Validation failures "
-                                                        + errors.size() + ". Details : "
-                                                        + Arrays.toString(errors.toArray()));
+                throw new VoldemortApplicationException(errorMessage);
             }
         } else {
             logger.info("Node Id Validation succeeded. Node Id " + nodeId);

--- a/src/java/voldemort/server/PosixHostMatcher.java
+++ b/src/java/voldemort/server/PosixHostMatcher.java
@@ -1,0 +1,19 @@
+package voldemort.server;
+
+import java.util.List;
+
+import voldemort.cluster.Node;
+
+
+public class PosixHostMatcher extends HostMatcher {
+
+    public PosixHostMatcher(List<String> types) {
+        super(types);
+    }
+
+    @Override
+    protected boolean match(Node node, String host) {
+        return node.getHost().equals(host);
+    }
+
+}

--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -25,7 +25,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.collect.Lists;
 import voldemort.client.ClientConfig;
 import voldemort.client.DefaultStoreClient;
 import voldemort.client.TimeoutConfig;
@@ -66,6 +65,7 @@ import voldemort.utils.UndefinedPropertyException;
 import voldemort.utils.Utils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 /**
  * Configuration parameters for the voldemort server.
@@ -259,6 +259,10 @@ public class VoldemortConfig implements Serializable {
     public static final String REPAIRJOB_MAX_KEYS_SCANNED_PER_SEC = "repairjob.max.keys.scanned.per.sec";
     public static final String PRUNEJOB_MAX_KEYS_SCANNED_PER_SEC = "prunejob.max.keys.scanned.per.sec";
     public static final String SLOP_PURGEJOB_MAX_KEYS_SCANNED_PER_SEC = "slop.purgejob.max.keys.scanned.per.sec";
+    public static final String ENABLE_NODE_ID_DETECTION = "enable.node.id.detection";
+    public static final String VALIDATE_NODE_ID = "validate.node.id";
+    public static final String NODE_ID_HOST_TYPES = "node.id.host.types";
+    public static final String NODE_ID_IMPLEMENTATION = "node.id.implementation";
     // Options prefixed with "rocksdb.db.options." or "rocksdb.cf.options." can be used to tune RocksDB performance
     // and are passed directly to the RocksDB configuration code. See the RocksDB documentation for details:
     //   https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h
@@ -505,8 +509,15 @@ public class VoldemortConfig implements Serializable {
                                                                  READONLY_KERBEROS_USER,
                                                                  READONLY_KERBEROS_KDC,
                                                                  READONLY_KERBEROS_REALM));
+
+        defaultConfig.put(ENABLE_NODE_ID_DETECTION, false);
+        defaultConfig.put(VALIDATE_NODE_ID, false);
+        defaultConfig.put(NODE_ID_HOST_TYPES,
+                          Lists.newArrayList(HostMatcher.HOSTNAME, HostMatcher.FQDN));
+        defaultConfig.put(NODE_ID_IMPLEMENTATION, PosixHostMatcher.class.getName());
     }
 
+    public static final int INVALID_NODE_ID = -1;
     private int nodeId;
     private String voldemortHome;
     private String dataDirectory;
@@ -559,6 +570,11 @@ public class VoldemortConfig implements Serializable {
     private String rocksdbDataDirectory;
     private boolean rocksdbPrefixKeysWithPartitionId;
     private boolean rocksdbEnableReadLocks;
+
+    private boolean enableNodeIdDetection;
+    private boolean validateNodeId;
+    private List<String> nodeIdHostTypes;
+    private HostMatcher nodeIdImplementation;
 
     private int numReadOnlyVersions;
     private String readOnlyStorageDir;
@@ -723,6 +739,23 @@ public class VoldemortConfig implements Serializable {
         this(new Props().with(NODE_ID, nodeId).with(VOLDEMORT_HOME, voldemortHome));
     }
 
+    private void initializeNodeId(Props combinedConfigs, Props dynamicDefaults) {
+        boolean nodeIdExists = combinedConfigs.containsKey(NODE_ID);
+        if(!nodeIdExists) {
+            try {
+                // If node Id is not present in the configs, look for the
+                // environment variable and save it in dynamic defaults.
+                int nodeId = getIntEnvVariable(VOLDEMORT_NODE_ID_VAR_NAME);
+                dynamicDefaults.put(NODE_ID, nodeId);
+            }catch(ConfigurationException ex) {
+                // missingNodeId is handled in the server startup.
+            }
+        } else {
+            // Make sure it is a valid integer
+            combinedConfigs.getInt(NODE_ID);
+        }
+    }
+
     /**
      * This function returns a set of default configs which cannot be defined statically,
      * because they (at least potentially) depend on the config values provided by the user.
@@ -735,12 +768,7 @@ public class VoldemortConfig implements Serializable {
         // Set of dynamic configs which depend on the combined configs in order to be determined.
         Props dynamicDefaults = new Props();
 
-        try {
-            combinedConfigs.getInt(NODE_ID);
-        } catch(UndefinedPropertyException e) {
-            // Pull node ID from an environment variable if it's not included in the config
-            dynamicDefaults.put(NODE_ID, getIntEnvVariable(VOLDEMORT_NODE_ID_VAR_NAME));
-        }
+        initializeNodeId(combinedConfigs, dynamicDefaults);
 
         // Define various paths
         String defaultDataDirectory = combinedConfigs.getString(VOLDEMORT_HOME) + File.separator + "data";
@@ -790,7 +818,7 @@ public class VoldemortConfig implements Serializable {
      * @throws UndefinedPropertyException if any required property has not been set.
      */
     private void initializeStateFromProps() throws UndefinedPropertyException {
-        this.nodeId = this.allProps.getInt(NODE_ID);
+        this.nodeId = this.allProps.getInt(NODE_ID, INVALID_NODE_ID);
         this.voldemortHome = this.allProps.getString(VOLDEMORT_HOME);
         this.dataDirectory = this.allProps.getString(DATA_DIRECTORY);
         this.metadataDirectory = this.allProps.getString(METADATA_DIRECTORY);
@@ -1013,6 +1041,14 @@ public class VoldemortConfig implements Serializable {
         this.rocksdbEnableReadLocks = this.allProps.getBoolean(ROCKSDB_ENABLE_READ_LOCKS);
 
         this.restrictedConfigs = this.allProps.getList(RESTRICTED_CONFIGS);
+        // Node Id auto detection configs
+        this.enableNodeIdDetection = this.allProps.getBoolean(ENABLE_NODE_ID_DETECTION, false);
+        // validation is defaulted based on node id detection.
+        this.validateNodeId = this.allProps.getBoolean(VALIDATE_NODE_ID);
+        this.nodeIdHostTypes = this.allProps.getList(NODE_ID_HOST_TYPES);
+        String nodeIdImplementationClass = this.allProps.get(NODE_ID_IMPLEMENTATION);
+        this.nodeIdImplementation = HostMatcher.getImplementation(nodeIdImplementationClass,
+                                                                  this.nodeIdHostTypes);
     }
 
     private void validateParams() {
@@ -4086,5 +4122,41 @@ public class VoldemortConfig implements Serializable {
 
     public boolean isNioConnectorKeepAlive() {
         return nioConnectorKeepAlive;
+    }
+
+    public boolean isEnableNodeIdDetection() {
+        return enableNodeIdDetection;
+    }
+
+    public void setEnableNodeIdDetection(boolean enableNodeIdDetection) {
+        this.enableNodeIdDetection = enableNodeIdDetection;
+    }
+
+    public boolean isValidateNodeId() {
+        return validateNodeId;
+    }
+
+    public void setValidateNodeId(boolean validateNodeId) {
+        this.validateNodeId = validateNodeId;
+    }
+
+    public List<String> getNodeIdHostTypes() {
+        return nodeIdHostTypes;
+    }
+
+    public void setNodeIdHostTypes(List<String> nodeIdHostTypes) {
+        this.nodeIdHostTypes = nodeIdHostTypes;
+    }
+
+    public HostMatcher getNodeIdImplementation() {
+        if(nodeIdImplementation == null) {
+             throw new ConfigurationException(VoldemortConfig.NODE_ID_IMPLEMENTATION
+                                                        + " is incorrectly configured ");
+        }
+        return nodeIdImplementation;
+    }
+
+    public void setNodeIdImplementation(HostMatcher nodeIdImplementation) {
+        this.nodeIdImplementation = nodeIdImplementation;
     }
 }

--- a/src/java/voldemort/server/VoldemortServer.java
+++ b/src/java/voldemort/server/VoldemortServer.java
@@ -124,10 +124,13 @@ public class VoldemortServer extends AbstractService {
             throw new VoldemortException("Voldmeort Config Node Id " + voldemortConfig.getNodeId() + 
                                          " does not match with metadata store node Id " + metadata.getNodeId());
         }
-        
-        if(voldemortConfig.isValidateNodeId() || voldemortConfig.isEnableNodeIdDetection()) {
-            HostMatcher matcher = voldemortConfig.getNodeIdImplementation();
-            NodeIdUtils.validateNodeId(metadata.getCluster(), matcher, metadata.getNodeId());
+        validateNodeId(voldemortConfig, metadata.getCluster());
+    }
+
+    public static void validateNodeId(VoldemortConfig config, Cluster cluster) {
+        if(config.isValidateNodeId() || config.isEnableNodeIdDetection()) {
+            HostMatcher matcher = config.getNodeIdImplementation();
+            NodeIdUtils.validateNodeId(cluster, matcher, config.getNodeId());
         } else {
             logger.info("Ignoring node id validation as it is disable in the config ");
         }

--- a/src/java/voldemort/server/VoldemortServer.java
+++ b/src/java/voldemort/server/VoldemortServer.java
@@ -46,7 +46,6 @@ import voldemort.server.niosocket.NioSocketService;
 import voldemort.server.protocol.ClientRequestHandlerFactory;
 import voldemort.server.protocol.RequestHandlerFactory;
 import voldemort.server.protocol.SocketRequestHandlerFactory;
-import voldemort.server.protocol.admin.AsyncOperation;
 import voldemort.server.protocol.admin.AsyncOperationService;
 import voldemort.server.rebalance.Rebalancer;
 import voldemort.server.rebalance.RebalancerService;
@@ -96,37 +95,66 @@ public class VoldemortServer extends AbstractService {
     private StorageService storageService;
     private JmxService jmxService;
 
-    public VoldemortServer(VoldemortConfig config) {
+    private VoldemortServer(VoldemortConfig config, MetadataStore metadataStore) {
         super(ServiceType.VOLDEMORT);
         this.voldemortConfig = config;
         this.setupSSLProvider();
+        this.metadata = metadataStore;
         this.storeRepository = new StoreRepository(config.isJmxEnabled());
-        this.metadata = MetadataStore.readFromDirectory(new File(this.voldemortConfig.getMetadataDirectory()),
-                                                        voldemortConfig.getNodeId());
-        this.identityNode = metadata.getCluster().getNodeById(voldemortConfig.getNodeId());
+        int nodeId = this.metadata.getNodeId();
+        // Update the config with right node Id
+        this.voldemortConfig.setNodeId(nodeId);
+        this.identityNode = metadata.getCluster().getNodeById(nodeId);
+
         this.checkHostName();
+        this.validateNodeId();
+
         this.validateRestServiceConfiguration();
         this.basicServices = createBasicServices();
         createOnlineServices();
     }
 
-    /**
-     * Constructor is used exclusively by tests. I.e., this is not a code path
-     * that is exercised in production.
-     *
-     * @param config
-     * @param cluster
-     */
-    public VoldemortServer(VoldemortConfig config, Cluster cluster) {
-        super(ServiceType.VOLDEMORT);
-        this.voldemortConfig = config;
-        this.setupSSLProvider();
-        this.identityNode = cluster.getNodeById(voldemortConfig.getNodeId());
+    public static int computeNodeId(VoldemortConfig config, Cluster cluster) {
+        HostMatcher matcher = config.getNodeIdImplementation();
+        return NodeIdUtils.findNodeId(cluster, matcher);
+    }
 
-        this.checkHostName();
-        this.validateRestServiceConfiguration();
-        this.storeRepository = new StoreRepository(config.isJmxEnabled());
-        // update cluster details in metaDataStore
+    public void validateNodeId() {
+        if(voldemortConfig.getNodeId() != metadata.getNodeId()) {
+            throw new VoldemortException("Voldmeort Config Node Id " + voldemortConfig.getNodeId() + 
+                                         " does not match with metadata store node Id " + metadata.getNodeId());
+        }
+        
+        if(voldemortConfig.isValidateNodeId() || voldemortConfig.isEnableNodeIdDetection()) {
+            HostMatcher matcher = voldemortConfig.getNodeIdImplementation();
+            NodeIdUtils.validateNodeId(metadata.getCluster(), matcher, metadata.getNodeId());
+        } else {
+            logger.info("Ignoring node id validation as it is disable in the config ");
+        }
+    }
+
+    public static int getNodeId(VoldemortConfig config, Cluster cluster) {
+        int configNodeId = config.getNodeId();
+        if(configNodeId >= 0) {
+            return configNodeId;
+        }
+        if(!config.isEnableNodeIdDetection()) {
+            // Node Id is missing and auto detection is disabled, error out.
+            throw new VoldemortException(VoldemortConfig.NODE_ID
+                                         + " is a required proeprty of the Voldmeort Server");
+        }
+        return computeNodeId(config, cluster);
+    }
+
+    private static MetadataStore createMetadataFromConfig(VoldemortConfig voldemortConfig) {
+        MetadataStore metadataStore = MetadataStore.readFromDirectory(new File(voldemortConfig.getMetadataDirectory()));
+        int nodeId = getNodeId(voldemortConfig, metadataStore.getCluster());
+        metadataStore.initNodeId(nodeId);
+        return metadataStore;
+    }
+
+    private static MetadataStore getTestMetadataStore(VoldemortConfig voldemortConfig,
+                                                      Cluster cluster) {
         ConfigurationStorageEngine metadataInnerEngine = new ConfigurationStorageEngine("metadata-config-store",
                                                                                         voldemortConfig.getMetadataDirectory());
 
@@ -139,16 +167,30 @@ public class VoldemortServer extends AbstractService {
         } else {
             version = (VectorClock) clusterXmlValue.get(0).getVersion();
         }
-        version.incrementVersion(voldemortConfig.getNodeId(), System.currentTimeMillis());
+
+        int nodeId = getNodeId(voldemortConfig, cluster);
+        version.incrementVersion(nodeId, System.currentTimeMillis());
 
         metadataInnerEngine.put(MetadataStore.CLUSTER_KEY,
-                new Versioned<String>(new ClusterMapper().writeCluster(cluster),
-                        version),
-                null);
-        this.metadata = new MetadataStore(metadataInnerEngine, voldemortConfig.getNodeId());
+                                new Versioned<String>(new ClusterMapper().writeCluster(cluster),
+                                                      version),
+                                null);
+        return MetadataStore.createInMemoryMetadataStore(metadataInnerEngine, nodeId);
+    }
 
-        this.basicServices = createBasicServices();
-        createOnlineServices();
+    public VoldemortServer(VoldemortConfig config) {
+        this(config, createMetadataFromConfig(config));
+    }
+
+    /**
+     * Constructor is used exclusively by tests. I.e., this is not a code path
+     * that is exercised in production.
+     *
+     * @param config
+     * @param cluster
+     */
+    public VoldemortServer(VoldemortConfig config, Cluster cluster) {
+        this(config, getTestMetadataStore(config, cluster));
     }
 
     private void setupSSLProvider() {

--- a/src/java/voldemort/store/metadata/MetadataStore.java
+++ b/src/java/voldemort/store/metadata/MetadataStore.java
@@ -382,6 +382,8 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
                 // do special stuff if needed
                 if(CLUSTER_KEY.equals(key)) {
                     updateRoutingStrategies((Cluster) value.getValue(), getStoreDefList());
+                } else if(NODE_ID_KEY.equals(key)) {
+                    initNodeId(getNodeIdNoLock());
                 } else if(SYSTEM_STORES_KEY.equals(key))
                     throw new VoldemortException("Cannot overwrite system store definitions");
 
@@ -643,11 +645,15 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
         }
     }
 
+    private int getNodeIdNoLock() {
+        return (Integer) (metadataCache.get(NODE_ID_KEY).getValue());
+    }
+
     public int getNodeId() {
         // acquire read lock
         readLock.lock();
         try {
-            return (Integer) (metadataCache.get(NODE_ID_KEY).getValue());
+            return getNodeIdNoLock();
         } finally {
             readLock.unlock();
         }
@@ -986,7 +992,7 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
                     put(READONLY_FETCH_ENABLED_KEY, true);
                     initCache(READONLY_FETCH_ENABLED_KEY);
                     init();
-                    initNodeId(getNodeId());
+                    initNodeId(getNodeIdNoLock());
                 } else {
                     logger.error("Cannot enter NORMAL_SERVER state from " + currentState);
                     throw new VoldemortException("Cannot enter NORMAL_SERVER state from "
@@ -1145,11 +1151,16 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
         }
     }
 
+    public void updateNodeId(Integer newNodeId) {
+        put(NODE_ID_KEY, newNodeId);
+        initNodeId(newNodeId);
+    }
+
     public void initNodeId(int nodeId) {
         writeLock.lock();
         try {
             initCache(NODE_ID_KEY, nodeId);
-            if(getNodeId() != nodeId)
+            if(getNodeIdNoLock() != nodeId)
                 throw new RuntimeException("Attempt to start previous node:"
                                            + getNodeId()
                                            + " as node:"

--- a/src/java/voldemort/store/metadata/MetadataStore.java
+++ b/src/java/voldemort/store/metadata/MetadataStore.java
@@ -1151,11 +1151,6 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
         }
     }
 
-    public void updateNodeId(Integer newNodeId) {
-        put(NODE_ID_KEY, newNodeId);
-        initNodeId(newNodeId);
-    }
-
     public void initNodeId(int nodeId) {
         writeLock.lock();
         try {

--- a/src/java/voldemort/store/metadata/MetadataStore.java
+++ b/src/java/voldemort/store/metadata/MetadataStore.java
@@ -155,30 +155,23 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
     private static final Logger logger = Logger.getLogger(MetadataStore.class);
 
     public MetadataStore(Store<String, String, String> innerStore,
-                         StorageEngine<String, String, String> storeDefinitionsStorageEngine,
-                         int nodeId) {
+                         StorageEngine<String, String, String> storeDefinitionsStorageEngine) {
         super(innerStore.getName());
         this.innerStore = innerStore;
         this.metadataCache = new HashMap<String, Versioned<Object>>();
         this.storeNameTolisteners = new ConcurrentHashMap<String, List<MetadataStoreListener>>();
         this.storeDefinitionsStorageEngine = storeDefinitionsStorageEngine;
         this.storeNames = new ArrayList<String>();
-
-        init(nodeId);
+        init();
     }
 
-    // This constructor is used exclusively by tests
-    public MetadataStore(Store<String, String, String> innerStore, int nodeId) {
-        super(innerStore.getName());
-        this.innerStore = innerStore;
-        this.metadataCache = new HashMap<String, Versioned<Object>>();
-        this.storeNameTolisteners = new ConcurrentHashMap<String, List<MetadataStoreListener>>();
-        this.storeNames = new ArrayList<String>();
+    public static MetadataStore createInMemoryMetadataStore(Store<String, String, String> innerStore,
+                                                            int nodeId) {
         StorageEngine<String, String, String> storesRepo = new InMemoryStorageEngine<String, String, String>("stores-repo");
 
         List<Versioned<String>> versionedStoreList = innerStore.get(STORES_KEY, "");
 
-        if(versionedStoreList != null) {
+        if(versionedStoreList != null && versionedStoreList.size() > 0) {
             String stores = versionedStoreList.get(0).getValue();
             StoreDefinitionsMapper mapper = new StoreDefinitionsMapper();
             List<StoreDefinition> storeDefinitions = mapper.readStoreList(new StringReader(stores));
@@ -187,9 +180,10 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
                 storesRepo.put(storeDef.getName(), versionedStoreValue, null);
             }
         }
-        this.storeDefinitionsStorageEngine = storesRepo;
 
-        init(nodeId);
+        MetadataStore store = new MetadataStore(innerStore, storesRepo);
+        store.initNodeId(nodeId);
+        return store;
     }
 
     public void addMetadataStoreListener(String storeName, MetadataStoreListener listener) {
@@ -208,7 +202,7 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
         this.storeNameTolisteners.remove(storeName);
     }
 
-    public static MetadataStore readFromDirectory(File dir, int nodeId) {
+    public static MetadataStore readFromDirectory(File dir) {
         if(!Utils.isReadableDir(dir))
             throw new IllegalArgumentException("Metadata directory " + dir.getAbsolutePath()
                                                + " does not exist or can not be read.");
@@ -263,7 +257,7 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
 
         Store<String, String, String> innerStore = new ConfigurationStorageEngine(MetadataStore.METADATA_STORE_NAME,
                                                                                   dir.getAbsolutePath());
-        MetadataStore store = new MetadataStore(innerStore, storesEngine, nodeId);
+        MetadataStore store = new MetadataStore(innerStore, storesEngine);
         ServerState state = new ServerState(store);
         JmxUtils.registerMbean(state.getClass().getCanonicalName(), state);
         return store;
@@ -592,7 +586,8 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
                                       getVersions(new ByteArray(ByteUtils.getBytes(key, "UTF-8"))).get(0));
             }
 
-            init(getNodeId());
+            init();
+            initNodeId(getNodeId());
         } finally {
             writeLock.unlock();
         }
@@ -990,7 +985,8 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
                     initCache(PARTITION_STREAMING_ENABLED_KEY);
                     put(READONLY_FETCH_ENABLED_KEY, true);
                     initCache(READONLY_FETCH_ENABLED_KEY);
-                    init(getNodeId());
+                    init();
+                    initNodeId(getNodeId());
                 } else {
                     logger.error("Cannot enter NORMAL_SERVER state from " + currentState);
                     throw new VoldemortException("Cannot enter NORMAL_SERVER state from "
@@ -1149,13 +1145,31 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
         }
     }
 
+    public void initNodeId(int nodeId) {
+        writeLock.lock();
+        try {
+            initCache(NODE_ID_KEY, nodeId);
+            if(getNodeId() != nodeId)
+                throw new RuntimeException("Attempt to start previous node:"
+                                           + getNodeId()
+                                           + " as node:"
+                                           + nodeId
+                                           + " (Did you copy config directory ? try deleting .temp .version in config dir to force clean) aborting ...");
+            // set transient values
+            updateRoutingStrategies(getCluster(), getStoreDefList());
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
     /**
      * Initializes the metadataCache for MetadataStore
      */
-    private void init(int nodeId) {
+    private void init() {
         logger.info("metadata init().");
 
         writeLock.lock();
+        try {
         // Required keys
         initCache(CLUSTER_KEY);
 
@@ -1171,14 +1185,6 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
         initSystemCache();
         initSystemRoutingStrategies(getCluster());
 
-        initCache(NODE_ID_KEY, nodeId);
-        if(getNodeId() != nodeId)
-            throw new RuntimeException("Attempt to start previous node:"
-                                       + getNodeId()
-                                       + " as node:"
-                                       + nodeId
-                                       + " (Did you copy config directory ? try deleting .temp .version in config dir to force clean) aborting ...");
-
         // Initialize with default if not present
         initCache(SLOP_STREAMING_ENABLED_KEY, true);
         initCache(PARTITION_STREAMING_ENABLED_KEY, true);
@@ -1189,10 +1195,10 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
         initCache(REBALANCING_SOURCE_CLUSTER_XML, null);
         initCache(REBALANCING_SOURCE_STORES_XML, null);
 
-        // set transient values
-        updateRoutingStrategies(getCluster(), getStoreDefList());
 
-        writeLock.unlock();
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     /**

--- a/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutor.java
+++ b/src/java/voldemort/store/socket/clientrequest/ClientRequestExecutor.java
@@ -80,6 +80,12 @@ public class ClientRequestExecutor extends SelectorManagerWorker implements Clos
 
     }
 
+    @Override
+    protected String getDebugInfo() {
+        return "Destination: " + String.valueOf(socketDesination) + " . Socket: "
+               + String.valueOf(socketChannel.socket());
+    }
+
     public SocketChannel getSocketChannel() {
         return socketChannel;
     }

--- a/src/java/voldemort/tools/DeleteKeysCLI.java
+++ b/src/java/voldemort/tools/DeleteKeysCLI.java
@@ -101,7 +101,7 @@ import voldemort.versioning.Versioned;
 
 public class DeleteKeysCLI {
 
-    private static final Logger logger = Logger.getLogger(ZoneClipperCLI.class);
+    private static final Logger logger = Logger.getLogger(DeleteKeysCLI.class);
 
     private static OptionParser setupParser() {
         OptionParser parser = new OptionParser();

--- a/src/java/voldemort/tools/GenerateScriptCLI.java
+++ b/src/java/voldemort/tools/GenerateScriptCLI.java
@@ -1,0 +1,130 @@
+package voldemort.tools;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Random;
+
+import joptsimple.OptionException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+
+import org.apache.log4j.Logger;
+
+import voldemort.client.protocol.admin.AdminClient;
+import voldemort.cluster.Node;
+import voldemort.tools.admin.AdminToolUtils;
+import voldemort.utils.Utils;
+
+
+public class GenerateScriptCLI {
+
+    private static final Logger logger = Logger.getLogger(GenerateScriptCLI.class);
+
+    private static OptionParser setupParser() {
+        OptionParser parser = new OptionParser();
+        parser.accepts("help", "Print usage information").withOptionalArg();
+        parser.acceptsAll(Arrays.asList("s", "script"), "Script")
+              .withRequiredArg()
+              .describedAs("script")
+              .ofType(String.class);
+        parser.acceptsAll(Arrays.asList("u", "url"), "bootstrapUrl")
+              .withRequiredArg()
+              .describedAs("url")
+              .ofType(String.class);
+        parser.acceptsAll(Arrays.asList("scp", "scpFile"), "file to be scp ed")
+              .withRequiredArg()
+              .describedAs("scp")
+              .ofType(String.class);
+        parser.acceptsAll(Arrays.asList("o", "output"), "outputScript")
+              .withRequiredArg()
+              .describedAs("output")
+              .ofType(String.class);
+        return parser;
+    }
+
+    private static void printUsage() {
+        StringBuilder help = new StringBuilder();
+        help.append("GenerateScriptCLI\n");
+        help.append("  Given a script, Generates a new script which will use SSH to run the given \n");
+        help.append(" script on all hosts in a given cluster. The variable @@ID@@ , @@HOST@@ , @@URL@@ \n");
+        help.append(" will be replaced with the node id, host name and bootstrap Url respectively\n");
+        help.append("Options:\n");
+        help.append("  Required:\n");
+        help.append("    --url <bootstrapUrl>\n");
+        help.append("    --script <Script to run on each host>\n");
+        System.out.print(help.toString());
+    }
+
+    private static void printUsageAndDie(String errMessage) {
+        printUsage();
+        Utils.croak("\n" + errMessage);
+    }
+
+    public static String getFilePath(OptionSet options, String name) {
+        String path = (String) options.valueOf(name);
+        return path.replace("~", System.getProperty("user.home"));
+    }
+
+    public static void main(String[] args) throws IOException {
+        OptionParser parser = null;
+        OptionSet options = null;
+        try {
+            parser = setupParser();
+            options = parser.parse(args);
+        } catch(OptionException oe) {
+            parser.printHelpOn(System.out);
+            printUsageAndDie("Exception when parsing arguments : " + oe.getMessage());
+            return;
+        }
+
+        /* validate options */
+        if(options.has("help")) {
+            printUsage();
+            return;
+        }
+
+        if(!options.hasArgument("url") || !options.hasArgument("script")
+           || !options.hasArgument("output")) {
+            printUsageAndDie("Missing a required argument.");
+            return;
+        }
+        
+        String url = (String) options.valueOf("url");
+        String inputScriptPath = getFilePath(options, "script");
+        String outputScriptPath = getFilePath(options, "output");
+        String scpFilePath = getFilePath(options, "scp");
+
+        AdminClient client = AdminToolUtils.getAdminClient(url);
+
+        PrintWriter writer = new PrintWriter(outputScriptPath, "UTF-8");
+        for(Node node: client.getAdminClientCluster().getNodes()) {
+            FileInputStream fis = new FileInputStream(inputScriptPath);
+            BufferedReader br = new BufferedReader(new InputStreamReader(fis));
+
+            if(scpFilePath != null && scpFilePath.length() > 0) {
+                writer.println("scp " + scpFilePath + "  " + node.getHost() + ":~");
+            }
+            int randomNumber = 1000 + new Random().nextInt(100000);
+            String hereDocumentTag = "NODE_" + node.getId() + "_" + randomNumber;
+            // Use SSH here script
+            writer.println("ssh -T " + node.getHost() + "  << " + hereDocumentTag);
+            String line = null;
+            while((line = br.readLine()) != null) {
+                line = line.replace("@@ID@@", Integer.toString(node.getId()));
+                line = line.replace("@@HOST@@", node.getHost());
+                line = line.replace("@@URL@@", node.getSocketUrl().toString());
+                writer.println(line);
+            }
+
+            writer.println(hereDocumentTag);
+            writer.println("\n\n\n");
+            br.close();
+        }
+        writer.close();
+        System.out.println("Ouput script generated at " + outputScriptPath);
+    }
+}

--- a/src/java/voldemort/tools/ValidateNodeIdCLI.java
+++ b/src/java/voldemort/tools/ValidateNodeIdCLI.java
@@ -1,0 +1,135 @@
+package voldemort.tools;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Properties;
+
+import joptsimple.OptionException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+
+import org.apache.log4j.Logger;
+
+import voldemort.VoldemortApplicationException;
+import voldemort.cluster.Cluster;
+import voldemort.server.VoldemortConfig;
+import voldemort.server.VoldemortServer;
+import voldemort.utils.Utils;
+import voldemort.xml.ClusterMapper;
+
+import com.google.common.io.Files;
+
+
+public class ValidateNodeIdCLI {
+
+    private static final Logger logger = Logger.getLogger(ValidateNodeIdCLI.class);
+
+    private static OptionParser setupParser() {
+        OptionParser parser = new OptionParser();
+        parser.accepts("help", "Print usage information").withOptionalArg();
+        parser.acceptsAll(Arrays.asList("id", "nodeId"), "expected node Id")
+              .withRequiredArg()
+              .describedAs("expected node Id")
+              .ofType(String.class);
+        parser.acceptsAll(Arrays.asList("path", "clusterPath"), "clusterPath")
+              .withRequiredArg()
+              .describedAs("clusterPath")
+              .ofType(String.class);
+        return parser;
+    }
+
+    private static void printUsage() {
+        StringBuilder help = new StringBuilder();
+        help.append("ValidateNodeIdCLI\n");
+        help.append("  Validate if the auto detection agrees with the expected node Id \n");
+        help.append("Options:\n");
+        help.append("  Required:\n");
+        help.append("    --id <expected nodeId>\n");
+        help.append("    --path <comma seperated list of file paths>\n");
+        System.out.print(help.toString());
+    }
+
+    private static void printUsageAndDie(String errMessage) {
+        printUsage();
+        Utils.croak("\n" + errMessage);
+    }
+
+    public static String getFilePath(OptionSet options, String name) {
+        String path = (String) options.valueOf(name);
+        return path.replace("~", System.getProperty("user.home"));
+    }
+
+    private static Cluster getCluster(File clusterXML) throws IOException {
+        return new ClusterMapper().readCluster(clusterXML);
+    }
+
+    private static String getTempDirPath() {
+        File tempdir = Files.createTempDir();
+        tempdir.delete();
+        tempdir.mkdir();
+        tempdir.deleteOnExit();
+        return tempdir.getAbsolutePath();
+    }
+
+    public static void main(String[] args) throws IOException {
+        OptionParser parser = null;
+        OptionSet options = null;
+        try {
+            parser = setupParser();
+            options = parser.parse(args);
+        } catch(OptionException oe) {
+            parser.printHelpOn(System.out);
+            printUsageAndDie("Exception when parsing arguments : " + oe.getMessage());
+            return;
+        }
+
+        /* validate options */
+        if(options.has("help")) {
+            printUsage();
+            return;
+        }
+
+        if(!options.hasArgument("id") || !options.hasArgument("path")) {
+            printUsageAndDie("Missing a required argument.");
+            return;
+        }
+        String id = (String) options.valueOf("id");
+        int expectedNodeId = Integer.parseInt(id);
+
+        String clusterPaths = getFilePath(options, "path");
+        String[] allPaths = clusterPaths.split(",");
+        boolean isMatch = false;
+        for(String path: allPaths) {
+            path = path.replace("~", System.getProperty("user.home"));
+            File filePath = new File(path);
+            if(filePath.exists()) {
+                isMatch = true;
+                Cluster cluster = getCluster(filePath);
+                
+                Properties properties = new Properties();
+                properties.setProperty(VoldemortConfig.ENABLE_NODE_ID_DETECTION,
+                                       Boolean.toString(true));
+                properties.setProperty(VoldemortConfig.VOLDEMORT_HOME, getTempDirPath());
+                VoldemortConfig config = new VoldemortConfig(properties);
+
+                int actualNodeId = VoldemortServer.getNodeId(config, cluster);
+                if(actualNodeId != expectedNodeId) {
+                    throw new VoldemortApplicationException(" Mismatch deteced. Computed Node Id "
+                                                            + actualNodeId + " Expected "
+                                                            + expectedNodeId);
+                } else {
+                    System.out.println("Expected and Computed node Id matched " + expectedNodeId);
+                }
+
+                config.setNodeId(actualNodeId);
+                VoldemortServer.validateNodeId(config, cluster);
+                System.out.println("Validation of node Id passed");
+            }
+        }
+
+        if(!isMatch) {
+            throw new VoldemortApplicationException("None of the paths matched the cluster.xml");
+        }
+    }
+}

--- a/test/common/voldemort/ServerTestUtils.java
+++ b/test/common/voldemort/ServerTestUtils.java
@@ -780,7 +780,7 @@ public class ServerTestUtils {
                        new Versioned<String>(new StoreDefinitionsMapper().writeStoreList(storeDefs)),
                        null);
 
-        return new MetadataStore(innerStore, 0);
+        return MetadataStore.createInMemoryMetadataStore(innerStore, 0);
     }
 
     public static MetadataStore createMetadataStore(Cluster cluster,
@@ -794,7 +794,7 @@ public class ServerTestUtils {
                        new Versioned<String>(new StoreDefinitionsMapper().writeStoreList(storeDefs)),
                        null);
 
-        return new MetadataStore(innerStore, nodeId);
+        return MetadataStore.createInMemoryMetadataStore(innerStore, nodeId);
     }
 
     public static List<StoreDefinition> getStoreDefs(int numStores) {

--- a/test/unit/voldemort/client/ClientTrafficVerifier.java
+++ b/test/unit/voldemort/client/ClientTrafficVerifier.java
@@ -142,8 +142,7 @@ public class ClientTrafficVerifier implements Runnable {
                 // as it is irrelevant for the refactoring I am doing.
 
             } catch(Exception e) {
-                logger.info("CLIENT EXCEPTION FAILURE on key [" + k + "]" + e.toString());
-                e.printStackTrace();
+                logger.info("CLIENT EXCEPTION FAILURE on key [" + k + "]", e);
                 String exceptionName = "Key " + k + " " + e.getClass().toString();
                 if(exceptionCount.containsKey(exceptionName)) {
                     exceptionCount.put(exceptionName, exceptionCount.get(exceptionName) + 1);

--- a/test/unit/voldemort/client/rebalance/RebalanceMetadataConsistencyTest.java
+++ b/test/unit/voldemort/client/rebalance/RebalanceMetadataConsistencyTest.java
@@ -114,7 +114,7 @@ public class RebalanceMetadataConsistencyTest {
                                                                  .setRequiredWrites(1)
                                                                  .build();
 
-        metadataStore = new MetadataStore(innerStore, 0);
+        metadataStore = MetadataStore.createInMemoryMetadataStore(innerStore, 0);
         rebalancer = new Rebalancer(null, metadataStore, null, null);
 
     }

--- a/test/unit/voldemort/server/HostMatcherTest.java
+++ b/test/unit/voldemort/server/HostMatcherTest.java
@@ -19,7 +19,7 @@ public class HostMatcherTest {
 
     private static final int PORT = 6666; // No socket is created, so hard coded
 
-    private Cluster getCluster(List<String> hostNames, List<Integer> nodeIds) {
+    public static Cluster getCluster(List<String> hostNames, List<Integer> nodeIds) {
         List<Node> nodes = Lists.newArrayList();
         for(int i = 0; i < hostNames.size(); i++) {
             int nodeId = (nodeIds == null) ? i : nodeIds.get(i);
@@ -28,7 +28,7 @@ public class HostMatcherTest {
         return new Cluster("HostMatcherTest", nodes);
     }
 
-    private Cluster getCluster(List<String> hostNames) {
+    public static Cluster getCluster(List<String> hostNames) {
         return getCluster(hostNames, null);
     }
 

--- a/test/unit/voldemort/server/HostMatcherTest.java
+++ b/test/unit/voldemort/server/HostMatcherTest.java
@@ -1,0 +1,212 @@
+package voldemort.server;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import voldemort.ServerTestUtils;
+import voldemort.VoldemortException;
+import voldemort.cluster.Cluster;
+import voldemort.cluster.Node;
+
+import com.google.common.collect.Lists;
+
+public class HostMatcherTest {
+
+    private static final int PORT = 6666; // No socket is created, so hard coded
+
+    private Cluster getCluster(List<String> hostNames, List<Integer> nodeIds) {
+        List<Node> nodes = Lists.newArrayList();
+        for(int i = 0; i < hostNames.size(); i++) {
+            int nodeId = (nodeIds == null) ? i : nodeIds.get(i);
+            nodes.add(new Node(nodeId, hostNames.get(i), PORT, PORT + 1, PORT + 2, Arrays.asList(i)));
+        }
+        return new Cluster("HostMatcherTest", nodes);
+    }
+
+    private Cluster getCluster(List<String> hostNames) {
+        return getCluster(hostNames, null);
+    }
+
+    private Cluster singleNodeCluster(int nodeId) {
+        return getCluster(Arrays.asList("localhost"), Arrays.asList(nodeId));
+    }
+
+    private List<String> allTypes = Arrays.asList(HostMatcher.FQDN, HostMatcher.HOSTNAME);
+
+    private void validateNodeId(Cluster cluster,
+                                HostMatcher matcher,
+                                List<Integer> nodeIdsToValidate,
+                                int actualNodeId) {
+        NodeIdUtils.validateNodeId(cluster, matcher, actualNodeId);
+
+        for(Integer nodeId: nodeIdsToValidate) {
+            if(nodeId == actualNodeId) {
+                // validate one more time
+                NodeIdUtils.validateNodeId(cluster, matcher, actualNodeId);
+                continue;
+            }
+
+            try {
+                // Increment node Id by 1 and make sure it fails
+                NodeIdUtils.validateNodeId(cluster, matcher, nodeId);
+                Assert.fail("Validation should have failed");
+            } catch(VoldemortException ex) {
+                // Expected Ignore
+            }
+        }
+    }
+
+    @Test
+    public void testLocalHost() {
+        for(int nodeId = 0; nodeId < 5; nodeId++) {
+            Cluster localCluster = singleNodeCluster(nodeId);
+            HostMatcher matcher = new PosixHostMatcher(allTypes);
+            int actual = NodeIdUtils.findNodeId(localCluster, matcher);
+            Assert.assertEquals("Node Id is different", nodeId, actual);
+            validateNodeId(localCluster, matcher, Arrays.asList(nodeId + 1), nodeId);
+        }
+    }
+
+    private void validateCluster(Cluster cluster,
+                                        List<String> hostNames,
+                                        List<String> fqdns,
+                                        List<Integer> nodeIds,
+                                        List<String> types,
+                                        final int NUM_NODES) {
+
+        HostMatcher invalidMatcher = new MockHostMatcher(types, "invalidHost", "invalidDomain");
+        try {
+            NodeIdUtils.findNodeId(cluster, invalidMatcher);
+            Assert.fail("None of the hosts should have matched");
+        } catch(VoldemortException ex) {
+            // Ignore
+        }
+        
+
+        for(int i = 0; i < NUM_NODES; i++) {
+            String hostName = hostNames.get(i);
+            int expectedNodeId = nodeIds.get(i);
+            String fqdn = fqdns.get(i);
+            HostMatcher matcher = new MockHostMatcher(types, hostName, fqdn);
+            int actulaNodeId = NodeIdUtils.findNodeId(cluster, matcher);
+            Assert.assertEquals("Node Id is different", expectedNodeId, actulaNodeId);
+            validateNodeId(cluster, matcher, nodeIds, actulaNodeId);
+        }
+    }
+
+    private void validateCluster(Cluster cluster,
+                                 List<String> hostNames,
+                                 List<String> fqdns,
+                                 List<Integer> nodeIds,
+                                 String type,
+                                 final int NUM_NODES) {
+
+
+        validateCluster(cluster, hostNames, fqdns, nodeIds, allTypes, NUM_NODES);
+        validateCluster(cluster,
+                        hostNames,
+                        fqdns,
+                        nodeIds,
+                        Arrays.asList(type),
+                        NUM_NODES);
+    }
+
+    @Test
+    public void testHostMatch() {
+        final int NUM_NODES = 60;
+        List<String> hostNames = Lists.newArrayList();
+        List<Integer> nodeIds = Lists.newArrayList();
+        for(int i = 0; i < NUM_NODES; i++) {
+            hostNames.add("host" + i);
+            nodeIds.add(i);
+        }
+
+        Collections.shuffle(hostNames);
+        Collections.shuffle(nodeIds);
+
+        List<String> fqdns = Lists.newArrayList();
+        for(int i = 0; i < NUM_NODES; i++) {
+            fqdns.add(hostNames.get(i) + ".domain");
+        }
+
+        Cluster cluster = getCluster(hostNames, nodeIds);
+        validateCluster(cluster, hostNames, fqdns, nodeIds, HostMatcher.HOSTNAME, NUM_NODES);
+
+        cluster = getCluster(fqdns, nodeIds);
+        validateCluster(cluster, hostNames, fqdns, nodeIds, HostMatcher.FQDN, NUM_NODES);
+    }
+
+    private void validateMatchFails(Cluster cluster, HostMatcher matcher) {
+        try {
+            NodeIdUtils.findNodeId(cluster, matcher);
+            Assert.fail("multiple match should have failed");
+        } catch(VoldemortException ex) {
+            // Ignore.
+        }
+
+        for(int nodeId: cluster.getNodeIds()) {
+            try {
+                NodeIdUtils.validateNodeId(cluster, matcher, nodeId);
+                Assert.fail("multiple match should have failed");
+            } catch(VoldemortException ex) {
+                // Ignore.
+            }
+        }
+    }
+
+    @Test
+    public void testMultipleMatchFails() {
+        final String SOMEHOST = "samehost";
+        Cluster cluster = getCluster(Arrays.asList(SOMEHOST, SOMEHOST));
+
+        HostMatcher matcher = new MockHostMatcher(allTypes, SOMEHOST, SOMEHOST + ".domain");
+        validateMatchFails(cluster, matcher);
+    }
+
+    @Test
+    public void testConflictingMatchFails() {
+        final String SOMEHOST = "somehost";
+        final String SOMEFQDN = "somehost.domain";
+
+        Cluster cluster = getCluster(Arrays.asList(SOMEFQDN, SOMEHOST));
+        HostMatcher matcher = new MockHostMatcher(allTypes, SOMEHOST, SOMEFQDN);
+        validateMatchFails(cluster, matcher);
+    }
+
+    @Test
+    public void testMultipleLocalHostFails() {
+        Cluster cluster = ServerTestUtils.getLocalCluster(2);
+        HostMatcher matcher = new PosixHostMatcher(allTypes);
+        validateMatchFails(cluster, matcher);
+    }
+
+    @Test
+    public void testMixPasses() {
+        final String SOMEHOST = "somehost";
+        final String SOMEFQDN = "somehost.domain";
+
+        final int HOST_NODE_ID = 5;
+        final int FQDN_NODE_ID = 10;
+
+        Cluster cluster = getCluster(Arrays.asList(SOMEHOST, SOMEFQDN),
+                                     Arrays.asList(HOST_NODE_ID, FQDN_NODE_ID));
+        
+        HostMatcher matcher1 = new MockHostMatcher(Arrays.asList(HostMatcher.HOSTNAME),
+                                                  SOMEHOST,
+                                                  SOMEFQDN);
+
+        int hostNodeId = NodeIdUtils.findNodeId(cluster, matcher1);
+        Assert.assertEquals("matcher found a different node id", HOST_NODE_ID, hostNodeId);
+        
+        HostMatcher matcher2 = new MockHostMatcher(Arrays.asList(HostMatcher.FQDN),
+                                                   SOMEHOST,
+                                                   SOMEFQDN);
+        int fqdnNodeId = NodeIdUtils.findNodeId(cluster, matcher2);
+        Assert.assertEquals("matcher found a different node id", FQDN_NODE_ID, fqdnNodeId);
+    }
+}

--- a/test/unit/voldemort/server/MockHostMatcher.java
+++ b/test/unit/voldemort/server/MockHostMatcher.java
@@ -1,0 +1,28 @@
+package voldemort.server;
+
+import java.util.List;
+
+import voldemort.VoldemortApplicationException;
+
+public class MockHostMatcher extends PosixHostMatcher {
+
+    private final String mockHostName;
+    private final String mockFQDN;
+
+    public MockHostMatcher(List<String> types, String mockHostName, String mockFQDN) {
+        super(types);
+        this.mockFQDN = mockFQDN;
+        this.mockHostName = mockHostName;
+    }
+
+    @Override
+    protected String getHost(String type) {
+        if(type.equals(HostMatcher.HOSTNAME)) {
+            return mockHostName;
+        } else if(type.equals(HostMatcher.FQDN)) {
+            return mockFQDN;
+        } else {
+            throw new VoldemortApplicationException("Unrecognized type " + type);
+        }
+    }
+}

--- a/test/unit/voldemort/server/NodeIdHostMatcher.java
+++ b/test/unit/voldemort/server/NodeIdHostMatcher.java
@@ -1,0 +1,21 @@
+package voldemort.server;
+
+import java.util.Arrays;
+
+import voldemort.cluster.Node;
+
+
+public class NodeIdHostMatcher extends PosixHostMatcher {
+
+    private final int nodeId;
+    public NodeIdHostMatcher(int nodeId) {
+        super(Arrays.asList(HostMatcher.FQDN, HostMatcher.HOSTNAME));
+        this.nodeId = nodeId;
+    }
+
+    @Override
+    public boolean match(Node node) {
+        return node.getId() == nodeId;
+    }
+
+}

--- a/test/unit/voldemort/server/VoldemortServerTest.java
+++ b/test/unit/voldemort/server/VoldemortServerTest.java
@@ -50,9 +50,9 @@ public class VoldemortServerTest {
     private VoldemortServer server;
 
     @After
-    public void tearDown() {
+    public void tearDown() throws IOException {
         if(server != null) {
-            server.stop();
+            ServerTestUtils.stopVoldemortServer(server);
         }
     }
 

--- a/test/unit/voldemort/server/VoldemortServerTest.java
+++ b/test/unit/voldemort/server/VoldemortServerTest.java
@@ -21,7 +21,10 @@ import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import java.security.Security;
+import java.util.List;
 import java.util.Properties;
+
+import junit.framework.Assert;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.After;
@@ -29,7 +32,14 @@ import org.junit.Test;
 
 import voldemort.ServerTestUtils;
 import voldemort.TestUtils;
+import voldemort.VoldemortException;
+import voldemort.client.protocol.admin.AdminClient;
 import voldemort.cluster.Cluster;
+import voldemort.cluster.Node;
+import voldemort.store.metadata.MetadataStore;
+import voldemort.versioning.VectorClockUtils;
+
+import com.google.common.collect.Lists;
 
 
 /**
@@ -46,7 +56,7 @@ public class VoldemortServerTest {
         }
     }
 
-    private VoldemortServer getVoldemortServer(Properties properties) throws IOException {
+    private VoldemortConfig getVoldemortConfig(Properties properties) throws IOException {
         properties.setProperty(VoldemortConfig.ENABLE_NODE_ID_DETECTION, Boolean.toString(true));
         VoldemortConfig config = ServerTestUtils.createServerConfig(true,
                                                                     -1,
@@ -54,9 +64,15 @@ public class VoldemortServerTest {
                                            null,
                                            null,
                                            properties);
+        return config;
+    }
+
+    private VoldemortServer getVoldemortServer(Properties properties) throws IOException {
+        VoldemortConfig config = getVoldemortConfig(properties);
         Cluster cluster = ServerTestUtils.getLocalCluster(1);
         return new VoldemortServer(config, cluster);
     }
+
     @Test
     public void testJCEProvider() throws IOException {
         Properties properties = new Properties();
@@ -74,5 +90,130 @@ public class VoldemortServerTest {
 
         server = getVoldemortServer(properties);
         assertEquals(BouncyCastleProvider.PROVIDER_NAME, Security.getProviders()[0].getName());
+    }
+
+    @Test
+    public void testNodeIdDetection() throws IOException {
+        final int NUM_NODES = 10;
+        final int NODE_ID = 5;
+        VoldemortConfig config = getVoldemortConfig(new Properties());
+        final String SOMEHOST = "host" + NODE_ID;
+        config.setNodeIdImplementation(new MockHostMatcher(config.getNodeIdHostTypes(),
+                                                           SOMEHOST,
+                                                           SOMEHOST + ".domain"));
+        
+        List<String> hostNames = Lists.newArrayList();
+        for(int i = 0; i < NUM_NODES; i ++) {
+            hostNames.add("host"+i);
+        }
+        
+        Assert.assertEquals("At first no node Id", -1, config.getNodeId());
+        Cluster cluster = HostMatcherTest.getCluster(hostNames);
+        server = new VoldemortServer(config, cluster);
+        server.start();
+
+        Assert.assertEquals("Node id is not auto detected", NODE_ID, config.getNodeId());
+        Assert.assertEquals("Node id is not auto detected", NODE_ID, server.getMetadataStore()
+                                                                           .getNodeId());
+    }
+
+    @Test
+    public void testInvalidNodeIdUpdateFails() throws IOException {
+        final int NUM_NODES = 5;
+        Cluster localCluster = ServerTestUtils.getLocalCluster(1);
+        VoldemortConfig config = getVoldemortConfig(new Properties());
+        server = new VoldemortServer(config, localCluster);
+        server.start();
+
+        final int UPDATED_NODE_ID = 3;
+        Node oldNode = localCluster.getNodes().iterator().next();
+        // For single local node, host matcher is not used.
+        config.setNodeIdImplementation(new NodeIdHostMatcher(UPDATED_NODE_ID));
+        Cluster updatedCluster = ServerTestUtils.getLocalCluster(UPDATED_NODE_ID + 1);
+
+        AdminClient oldAdminClient = new AdminClient(localCluster);
+        try {
+            oldAdminClient.metadataMgmtOps.updateRemoteMetadata(oldNode.getId(),
+                                                            MetadataStore.NODE_ID_KEY,
+                                                            Integer.toString(UPDATED_NODE_ID));
+            Assert.fail("Invalid node id should have failed");
+        } catch(VoldemortException ex) {
+            // Expected, ignore
+        }
+    }
+    
+    @Test
+    public void testClusterWithDifferentStateFails() throws IOException {
+        final int NUM_NODES = 5;
+        Cluster localCluster = ServerTestUtils.getLocalCluster(1);
+        VoldemortConfig config = getVoldemortConfig(new Properties());
+        server = new VoldemortServer(config, localCluster);
+        server.start();
+
+        final int UPDATED_NODE_ID = 3;
+        Node oldNode = localCluster.getNodes().iterator().next();
+        // For single local node, host matcher is not used.
+        config.setNodeIdImplementation(new NodeIdHostMatcher(UPDATED_NODE_ID));
+        Cluster updatedCluster = ServerTestUtils.getLocalCluster(UPDATED_NODE_ID + 1);
+
+        AdminClient oldAdminClient = new AdminClient(localCluster);
+        try {
+            oldAdminClient.metadataMgmtOps.updateRemoteCluster(oldNode.getId(),
+                                                           updatedCluster,
+                                                           VectorClockUtils.makeClockWithCurrentTime(localCluster.getNodeIds()));
+            Assert.fail("Invalid node id should have failed");
+        } catch(VoldemortException ex) {
+            // Expected, ignore
+        }
+    }
+
+    @Test
+    public void testClusterUpdateWithAutoDetection() throws IOException {
+        final int NUM_NODES = 5;
+        Cluster localCluster = ServerTestUtils.getLocalCluster(1);
+        VoldemortConfig config = getVoldemortConfig(new Properties());
+        server = new VoldemortServer(config, localCluster);
+        server.start();
+
+        final int UPDATED_NODE_ID = 3;
+        Node oldNode = localCluster.getNodes().iterator().next();
+        // For single local node, host matcher is not used.
+        config.setNodeIdImplementation(new NodeIdHostMatcher(UPDATED_NODE_ID));
+        Cluster updatedCluster = ServerTestUtils.getLocalCluster(UPDATED_NODE_ID + 1);
+
+        AdminClient oldAdminClient = new AdminClient(localCluster);
+        List<Node> newNodes = Lists.newArrayList();
+        for(Node node: updatedCluster.getNodes()) {
+            if(node.getId() != UPDATED_NODE_ID) {
+                newNodes.add(node);
+            }
+        }
+        Node nodeToBeReplaced = updatedCluster.getNodeById(UPDATED_NODE_ID);
+        Node updatedNode = new Node(UPDATED_NODE_ID,
+                                    oldNode.getHost(),
+                                    oldNode.getHttpPort(),
+                                    oldNode.getSocketPort(),
+                                    oldNode.getAdminPort(),
+                                    nodeToBeReplaced.getPartitionIds());
+
+        newNodes.add(updatedNode);
+
+        Cluster updatedClusterWithCorrectNode = new Cluster("updated-cluster", newNodes);
+
+        oldAdminClient.metadataMgmtOps.updateRemoteCluster(oldNode.getId(),
+                                                           updatedClusterWithCorrectNode,
+                                                           VectorClockUtils.makeClockWithCurrentTime(localCluster.getNodeIds()));
+
+        Assert.assertEquals("Identity node is not auto detected",
+                            UPDATED_NODE_ID,
+                            server.getIdentityNode().getId());
+
+        Assert.assertEquals("Voldemort config is not updated",
+                            UPDATED_NODE_ID,
+                            server.getVoldemortConfig().getNodeId());
+
+        Assert.assertEquals("Metadata store is not updated",
+                            UPDATED_NODE_ID,
+                            server.getMetadataStore().getNodeId());
     }
 }

--- a/test/unit/voldemort/server/VoldemortServerTest.java
+++ b/test/unit/voldemort/server/VoldemortServerTest.java
@@ -74,7 +74,16 @@ public class VoldemortServerTest {
     }
 
     @Test
-    public void testJCEProvider() throws IOException {
+    public void testSSLProviders() throws IOException {
+        // The SSL providers changes the state of the JVM
+        // if the methods are run in parallel or the ordering
+        // changes the test fails. TestBouncyCastle is the
+        // only test to enable this SSL. If other tests introduce
+        // them the test could fails as well.
+        testJCEProvider();
+        testBouncyCastleProvider();
+    }
+    private void testJCEProvider() throws IOException {
         Properties properties = new Properties();
 
         // Default configuration. Bouncy castle provider will not be used.
@@ -82,8 +91,7 @@ public class VoldemortServerTest {
         assertNull(Security.getProvider(BouncyCastleProvider.PROVIDER_NAME));
     }
 
-    @Test
-    public void testBouncyCastleProvider() throws IOException {
+    private void testBouncyCastleProvider() throws IOException {
         Properties properties = new Properties();
         // Use bouncy castle as first choice of JCE provider.
         properties.setProperty("use.bouncycastle.for.ssl", "true");

--- a/test/unit/voldemort/tools/admin/QuotaOperationsTest.java
+++ b/test/unit/voldemort/tools/admin/QuotaOperationsTest.java
@@ -16,6 +16,7 @@
 
 package voldemort.tools.admin;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -105,7 +106,8 @@ public class QuotaOperationsTest {
             // get quota value
             Versioned<String> versionedQuotaValueToVerify = adminClient.quotaMgmtOps.getQuota(storeName,
                                                                                               quotaType);
-            assertTrue(versionedQuotaValueToVerify == null);
+            assertNull("Value retrieved should be null" + versionedQuotaValueToVerify,
+                       versionedQuotaValueToVerify);
         }
     }
 


### PR DESCRIPTION
 Voldemort server takes node id as configuration parameters.
It relies on the node id to identify its role in the cluster.
But most production deployments has only one voldemort server
per host in a cluster. Under these conditions the deduction
of node ids can be automated.

All Configuration is disabled by default, but validation is enforced for the cluster update and the node id update.