### PR TITLE
RO Store Create floods the Log with error messages

### DIFF
--- a/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
+++ b/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
@@ -67,6 +67,7 @@ import voldemort.store.StorageEngine;
 import voldemort.store.StoreCapabilityType;
 import voldemort.store.StoreDefinition;
 import voldemort.store.StoreDefinitionBuilder;
+import voldemort.store.StoreNotFoundException;
 import voldemort.store.StoreOperationFailureException;
 import voldemort.store.backup.NativeBackupable;
 import voldemort.store.metadata.MetadataStore;
@@ -1505,7 +1506,13 @@ public class AdminServiceRequestHandler implements RequestHandler {
 
         } catch(VoldemortException e) {
             response.setError(ProtoUtils.encodeError(errorCodeMapper, e));
-            logger.error("handleGetMetadata failed for request(" + request.toString() + ")", e);
+            String errorMessage = "handleGetMetadata failed for request(" + request.toString() + ")";
+            
+            if(e instanceof StoreNotFoundException) {
+                logger.info(errorMessage + " with " + StoreNotFoundException.class.getSimpleName());
+            } else {
+                logger.error(errorMessage, e);
+            }
         }
 
         return response.build();


### PR DESCRIPTION
Creating a RO store queries for an existing store, which
fails with StoreNotFoundException. This exception is logged with call
stack, which floods the logs on every store creation.

This may trick the alerting system into treating this as error.
Not logging a call stack and reducing the log to info, when such
exceptions are logged.