### PR TITLE
Ignore Storage Space Quota for RW store

### DIFF
--- a/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
+++ b/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
@@ -1656,13 +1656,18 @@ public class AdminServiceRequestHandler implements RequestHandler {
                     try {
                         metadataStore.addStoreDefinition(def);
                         
-                        long defaultQuota = voldemortConfig.getDefaultStorageSpaceQuotaInKB();
+                        final boolean isReadOnlyStore = def.getType()
+                                                                .compareTo(ReadOnlyStorageConfiguration.TYPE_NAME) == 0;
 
-                        QuotaUtils.setQuota(def.getName(), 
-                                            QuotaType.STORAGE_SPACE, 
-                                            storeRepository, 
-                                            metadataStore.getCluster().getNodeIds(),
-                                            defaultQuota);
+                        if(isReadOnlyStore) {
+                            // The Storage SPACE quota is enforced only for Read Only Store.
+                            long defaultQuota = voldemortConfig.getDefaultStorageSpaceQuotaInKB();
+                            QuotaUtils.setQuota(def.getName(),
+                                                QuotaType.STORAGE_SPACE,
+                                                storeRepository,
+                                                metadataStore.getCluster().getNodeIds(),
+                                                defaultQuota);
+                        }
                     } catch(Exception e) {
                         // rollback open store operation
                         boolean isReadOnly = ReadOnlyStorageConfiguration.TYPE_NAME.equals(def.getType());

--- a/test/unit/voldemort/client/AdminServiceBasicTest.java
+++ b/test/unit/voldemort/client/AdminServiceBasicTest.java
@@ -79,7 +79,6 @@ import voldemort.store.InvalidMetadataException;
 import voldemort.store.Store;
 import voldemort.store.StoreDefinition;
 import voldemort.store.StoreDefinitionBuilder;
-import voldemort.store.bdb.BdbStorageConfiguration;
 import voldemort.store.memory.InMemoryStorageConfiguration;
 import voldemort.store.metadata.MetadataStore;
 import voldemort.store.quota.QuotaType;
@@ -643,8 +642,6 @@ public class AdminServiceBasicTest {
                                                  .setRequiredWrites(1)
                                                  .build();
         adminClient.storeMgmtOps.addStore(definition);
-        validateQuota(definition.getName());
-
         // now test the store
         StoreClientFactory factory = new SocketStoreClientFactory(new ClientConfig().setBootstrapUrls(cluster.getNodeById(0)
                                                                                                              .getSocketUrl()


### PR DESCRIPTION
Set the STORAGE space quota only for Read-Only Store. For other store types, ignore setting the storage space quota.
