### PR TITLE
Fix: Extend the timeout of admin request

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortSwapJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortSwapJob.java
@@ -119,10 +119,11 @@ public class VoldemortSwapJob extends AbstractJob {
                     dataDir, e);
         }
 
+        // While processing an admin request, HDFSFailedLock could take long time because of multiple HDFS operations,
+        // especially when the name node is in a different data center. So extend timeout to 5 minutes.
         AdminClientConfig adminConfig = new AdminClientConfig().setMaxConnectionsPerNode(cluster.getNumberOfNodes())
-                                                               .setAdminConnectionTimeoutSec(15)
                                                                .setMaxBackoffDelayMs(maxBackoffDelayMs)
-                                                               .setAdminSocketTimeoutSec(60);
+                                                               .setAdminSocketTimeoutSec(60 * 5);
 
         ClientConfig clientConfig = new ClientConfig().setBootstrapUrls(cluster.getBootStrapUrls())
                                                       .setConnectionTimeout(httpTimeoutMs,

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/swapper/HdfsFailedFetchLock.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/swapper/HdfsFailedFetchLock.java
@@ -199,6 +199,7 @@ public class HdfsFailedFetchLock extends FailedFetchLock {
 
     @Override
     public synchronized void acquireLock() throws Exception {
+        logger.info("Try to acquire HDFS distributed lock.");
         if (lockAcquired) {
             logger.info("HdfsFailedFetchLock.acquireLock() called while it is already acquired!");
             return;
@@ -236,6 +237,7 @@ public class HdfsFailedFetchLock extends FailedFetchLock {
         if (!this.lockAcquired) {
             throw new VoldemortException(exceptionMessage(ACQUIRE_LOCK));
         }
+        logger.info("HDFS distributed lock acquired.");
     }
 
     @Override

--- a/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
+++ b/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
@@ -2083,6 +2083,7 @@ public class AdminServiceRequestHandler implements RequestHandler {
                     for (Integer nodeId: nodesFailedInThisFetch) {
                         logger.warn("Will disable store '" + storeName + "' on node " + nodeId);
                         distributedLock.addDisabledNode(nodeId, storeName, pushVersion);
+                        logger.warn("Store '" + storeName + "' is disabled on node " + nodeId);
                         if (firstNode) {
                             firstNode = false;
                         } else {


### PR DESCRIPTION
Fix: Extend the timeout of admin request from 1min to 5min and add more logs for handling fetch failed request.