### PR TITLE
Data Cleanup job Does not run on system stores

### DIFF
--- a/src/java/voldemort/server/protocol/admin/FetchStreamRequestHandler.java
+++ b/src/java/voldemort/server/protocol/admin/FetchStreamRequestHandler.java
@@ -38,7 +38,6 @@ import voldemort.store.StorageEngine;
 import voldemort.store.StoreDefinition;
 import voldemort.store.metadata.MetadataStore;
 import voldemort.store.stats.StreamingStats;
-import voldemort.store.system.SystemStoreConstants;
 import voldemort.utils.ByteArray;
 import voldemort.utils.EventThrottler;
 import voldemort.utils.NetworkClassLoader;
@@ -113,7 +112,7 @@ public abstract class FetchStreamRequestHandler implements StreamRequestHandler 
         }
 
         this.operation = operation;
-        this.storeDef = getStoreDef(request.getStore(), metadataStore);
+        this.storeDef = MetadataStore.getStoreDef(request.getStore(), metadataStore);
         if(request.hasInitialCluster()) {
             this.initialCluster = new ClusterMapper().readCluster(new StringReader(request.getInitialCluster()));
         } else {
@@ -138,16 +137,6 @@ public abstract class FetchStreamRequestHandler implements StreamRequestHandler 
             this.recordsPerPartition = 0;
         }
         this.fetchOrphaned = request.hasFetchOrphaned() && request.getFetchOrphaned();
-    }
-
-    private StoreDefinition getStoreDef(String store, MetadataStore metadataStore) {
-        StoreDefinition def = null;
-        if(SystemStoreConstants.isSystemStore(store)) {
-            def = SystemStoreConstants.getSystemStoreDef(store);
-        } else {
-            def = metadataStore.getStoreDef(request.getStore());
-        }
-        return def;
     }
 
     @Override

--- a/src/java/voldemort/server/scheduler/DataCleanupJob.java
+++ b/src/java/voldemort/server/scheduler/DataCleanupJob.java
@@ -99,19 +99,17 @@ public class DataCleanupJob<K, V, T> implements Runnable {
 
         StoreDefinition storeDef = null;
         try {
-            storeDef = metadataStore.getStoreDef(storeName);
+            storeDef = MetadataStore.getStoreDef(storeName, metadataStore);
         } catch (VoldemortException ex) {
             logger.info("Error retrieving store " + storeName + " for data cleanup job ", ex);
-        }
-
-        if (storeDef == null) {
             return;
         }
 
         Integer retentionDays = storeDef.getRetentionDays();
-        if (retentionDays != null && retentionDays > 0) {
+        if (retentionDays == null || retentionDays <= 0) {
             logger.info("Store " + storeName
                     + " does not have retention period set, skipping cleanup job . RetentionDays " + retentionDays);
+            return;
         }
         long maxAgeMs = retentionDays * Time.MS_PER_DAY;
         logger.info("Store " + storeName + " cleanup job is starting with RetentionDays " + retentionDays);

--- a/src/java/voldemort/store/metadata/MetadataStore.java
+++ b/src/java/voldemort/store/metadata/MetadataStore.java
@@ -1168,6 +1168,20 @@ public class MetadataStore extends AbstractStorageEngine<ByteArray, byte[], byte
         }
     }
 
+    public static StoreDefinition getStoreDef(String storeName, MetadataStore metadataStore) {
+        StoreDefinition def = null;
+        if(SystemStoreConstants.isSystemStore(storeName)) {
+            def = SystemStoreConstants.getSystemStoreDef(storeName);
+        } else {
+            def = metadataStore.getStoreDef(storeName);
+        }
+
+        if(def == null) {
+            throw new StoreNotFoundException("Store" + storeName + " does not exist");
+        }
+        return def;
+    }
+
     /**
      * Initializes the metadataCache for MetadataStore
      */


### PR DESCRIPTION
1) Client registry System store is a in-memory store and supposed to be cleaned up after 7 days.
Last change to the DataCleanupJob made the system stores fail with the missing store exception.

Clients re-use the same client id, so unless lots of clients become
dead and removed, this will not cause a leak on the server resources. The effect is negligible.

Now the DataCleanupJob checks for both system stores and normal stores for a store definition.

2) If the store retention days is modified to zero, then the store will
delete all the records. But if the store is started with 0 retention days
it means the data retention is not enabled. Fixed the discrepancy.