### PR TITLE
Tweaked the semantics of the "readonly.modify.port" server configuration.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/utils/VoldemortUtils.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/utils/VoldemortUtils.java
@@ -144,8 +144,8 @@ public class VoldemortUtils {
         return new StoreDefinitionsMapper().readStore(new StringReader(xml));
     }
 
-    public static String modifyURL(String originalUrl, String newProtocol, int newPort) {
-        if (newProtocol == null || newProtocol.isEmpty() || newPort < 0) {
+    public static String modifyURL(String originalUrl, String newProtocol, Integer newPort) {
+        if (newProtocol == null || newProtocol.isEmpty() || newPort == null) {
             return originalUrl;
         }
 

--- a/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/utils/VoldemortUtilsTest.java
+++ b/contrib/hadoop-store-builder/test/voldemort/store/readonly/mr/utils/VoldemortUtilsTest.java
@@ -3,49 +3,55 @@ package voldemort.store.readonly.mr.utils;
 import java.util.Properties;
 import junit.framework.TestCase;
 import voldemort.server.VoldemortConfig;
-import voldemort.store.readonly.fetcher.HdfsFetcher;
-
 
 /**
  * Tests for VoldemortUtils.
  */
 public class VoldemortUtilsTest extends TestCase {
+    private static final String PATH = "user/testpath";
     public void testModifyURLByConfig() {
-        String url = "swebhdfs://localhost:50470/user/testpath";
+        String url = "swebhdfs://localhost:50470/" + PATH;
         Properties properties = new Properties();
-        properties.setProperty("node.id", "1");
-        properties.setProperty("voldemort.home", "/test");
+        properties.setProperty(VoldemortConfig.NODE_ID, "1");
+        properties.setProperty(VoldemortConfig.VOLDEMORT_HOME, "/test");
         VoldemortConfig config = new VoldemortConfig(properties);
 
-        //Default configuration. Should not modify url.
-        HdfsFetcher fetcher = new HdfsFetcher(config);
-        String newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getMysqlPort());
+        // Default configuration. Should not modify url.
+        String newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
         assertEquals(url, newUrl);
 
-        //Enable modify feature. URL should be replace to webhdfs with 50070 port number.
-        properties.setProperty("readonly.modify.protocol", "webhdfs");
-        properties.setProperty("readonly.modify.port", "50070");
+        // Enable modify feature. URL should be replace to webhdfs with 50070 port number.
+        properties.setProperty(VoldemortConfig.READONLY_MODIFY_PROTOCOL, "webhdfs");
+        properties.setProperty(VoldemortConfig.READONLY_MODIFY_PORT, "50070");
         config = new VoldemortConfig(properties);
         newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
-        assertEquals("webhdfs://localhost:50070/user/testpath", newUrl);
+        assertEquals("webhdfs://localhost:50070/" + PATH, newUrl);
 
-        //No modified protocol assigned. Should not modify URL.
-        properties.remove("readonly.modify.protocol");
-        config = new VoldemortConfig(properties);
-        newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
-        assertEquals(url, newUrl);
-
-        //No Modified port assigned. Should not modify URL.
-        properties.remove("readonly.modify.port");
-        properties.setProperty("readonly.modify.protocol", "testprotocol");
+        // No modified protocol assigned. Should not modify URL.
+        properties.remove(VoldemortConfig.READONLY_MODIFY_PORT);
         config = new VoldemortConfig(properties);
         newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
         assertEquals(url, newUrl);
 
-        //Local path. Should throw IAE because it's not a valid URL.
+        // No Modified port assigned. Should not modify URL.
+        properties.remove(VoldemortConfig.READONLY_MODIFY_PORT);
+        properties.setProperty(VoldemortConfig.READONLY_MODIFY_PROTOCOL, "testprotocol");
+        config = new VoldemortConfig(properties);
+        newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
+        assertEquals(url, newUrl);
+
+        // Port set to -1 should remove the port from the URI
+        String expectedUrl = "testprotocol://localhost/" + PATH;
+        properties.setProperty(VoldemortConfig.READONLY_MODIFY_PROTOCOL, "testprotocol");
+        properties.setProperty(VoldemortConfig.READONLY_MODIFY_PORT, "-1");
+        config = new VoldemortConfig(properties);
+        newUrl = VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());
+        assertEquals(expectedUrl, newUrl);
+
+        // Local path. Should throw IAE because it's not a valid URL.
         url = "/testpath/file";
-        properties.setProperty("readonly.modify.protocol", "webhdfs");
-        properties.setProperty("readonly.modify.port", "50070");
+        properties.setProperty(VoldemortConfig.READONLY_MODIFY_PROTOCOL, "webhdfs");
+        properties.setProperty(VoldemortConfig.READONLY_MODIFY_PORT, "50070");
         config = new VoldemortConfig(properties);
         try {
             VoldemortUtils.modifyURL(url, config.getModifiedProtocol(), config.getModifiedPort());

--- a/src/java/voldemort/server/VoldemortConfig.java
+++ b/src/java/voldemort/server/VoldemortConfig.java
@@ -349,7 +349,7 @@ public class VoldemortConfig implements Serializable {
         // To enable block-level compression over the wire for Read-Only fetches, set this property to "GZIP"
         defaultConfig.put(READONLY_COMPRESSION_CODEC, "NO_CODEC");
         defaultConfig.put(READONLY_MODIFY_PROTOCOL, "");
-        defaultConfig.put(READONLY_MODIFY_PORT, -1);
+        defaultConfig.put(READONLY_MODIFY_PORT, (Integer) null);
         defaultConfig.put(USE_BOUNCYCASTLE_FOR_SSL, false);
         defaultConfig.put(READONLY_BUILD_PRIMARY_REPLICAS_ONLY, true);
 
@@ -595,7 +595,7 @@ public class VoldemortConfig implements Serializable {
     private long readOnlyLoginIntervalMs;
     private long defaultStorageSpaceQuotaInKB;
     private String modifiedProtocol;
-    private int modifiedPort;
+    private Integer modifiedPort;
     private boolean bouncyCastleEnabled;
     private boolean readOnlyBuildPrimaryReplicasOnly;
 
@@ -880,7 +880,7 @@ public class VoldemortConfig implements Serializable {
         this.readOnlyMaxValueBufferAllocationSize = this.allProps.getInt(READONLY_MAX_VALUE_BUFFER_ALLOCATION_SIZE);
         this.readOnlyCompressionCodec = this.allProps.getString(READONLY_COMPRESSION_CODEC);
         this.modifiedProtocol = this.allProps.getString(READONLY_MODIFY_PROTOCOL);
-        this.modifiedPort = this.allProps.getInt(READONLY_MODIFY_PORT);
+        this.modifiedPort = this.allProps.getNullableInt(READONLY_MODIFY_PORT);
         this.bouncyCastleEnabled = this.allProps.getBoolean(USE_BOUNCYCASTLE_FOR_SSL);
         this.readOnlyBuildPrimaryReplicasOnly = this.allProps.getBoolean(READONLY_BUILD_PRIMARY_REPLICAS_ONLY);
 
@@ -3453,19 +3453,23 @@ public class VoldemortConfig implements Serializable {
         this.modifiedProtocol = modifiedProtocol;
     }
 
-    public int getModifiedPort() {
+    public Integer getModifiedPort() {
         return this.modifiedPort;
     }
 
     /**
      * Set modified port used to fetch file.
      *
+     * If null, the port will not be modified.
+     *
+     * If -1, the port will be completely omitted (i.e.: a URL like host:port/path will be changed to host/path).
+     *
      * <ul>
      * <li>Property : "{@value #READONLY_MODIFY_PORT}"</li>
-     * <li>Default : -1</li>
+     * <li>Default : null</li>
      * </ul>
      */
-    public void setModifiedPort(int modifiedPort) {
+    public void setModifiedPort(Integer modifiedPort) {
         this.modifiedPort = modifiedPort;
     }
 

--- a/src/java/voldemort/utils/Props.java
+++ b/src/java/voldemort/utils/Props.java
@@ -128,7 +128,11 @@ public class Props implements Map<String, String> {
     }
 
     public String put(String key, Integer value) {
-        return props.put(key, value.toString());
+        if (null == value) {
+          return props.remove(key);
+        } else {
+          return props.put(key, value.toString());
+        }
     }
 
     public String put(String key, Long value) {


### PR DESCRIPTION
Tweaked the semantics of the "readonly.modify.port" server configuration.

Previously, -1 (the default) meant that the port will not be modified.

Now, -1 means that the port will be removed from the fetch URI, while
null (the new default) means that the port will not be modified.

Therefore, the default behavior is still the same.