### PR TITLE
Introduced new boolean "readonly.omit.port" server configuration.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -210,8 +210,7 @@ public class HdfsFetcher implements FileFetcher {
         ObjectName jmxName = null;
         HdfsCopyStats stats = null;
         FileSystem fs = null;
-        sourceFileUrl = VoldemortUtils
-            .modifyURL(sourceFileUrl, voldemortConfig.getModifiedProtocol(), voldemortConfig.getModifiedPort());
+        sourceFileUrl = VoldemortUtils.modifyURL(sourceFileUrl, voldemortConfig);
         // Flag to indicate whether the fetch is complete or not
         boolean isCompleteFetch = false;
         try {

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortSwapJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortSwapJob.java
@@ -104,7 +104,7 @@ public class VoldemortSwapJob extends AbstractJob {
          */
         try {
             modifiedDataDir =
-                VoldemortUtils.modifyURL(modifiedDataDir, hdfsFetcherProtocol, Integer.valueOf(hdfsFetcherPort));
+                VoldemortUtils.modifyURL(modifiedDataDir, hdfsFetcherProtocol, Integer.valueOf(hdfsFetcherPort), false);
         } catch (NumberFormatException nfe) {
             info("The dataDir will not be modified, since hdfsFetcherPort is not a valid port number");
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
When set to true, the port will be removed from the fetch URI. In
this case, the already-existing "readonly.modify.port" setting is
ignored.

When set to false (which is the default), then the port will be
left as part of the fetch URI (according to the already-existing
"readonly.modify.port" setting).