### PR TITLE
Python client has an issue with inconsistent indentation

### DIFF
--- a/clients/python/voldemort/client.py
+++ b/clients/python/voldemort/client.py
@@ -168,7 +168,7 @@ class StoreClient:
             raise VoldemortException("Cannot find store [%s] at %s" % (store_name, bootstrap_urls))
 
         self.node_id = random.randint(0, len(self.nodes) - 1)
-	self.connection = None
+        self.connection = None
         self.node_id, self.connection = self._reconnect()
         self.reconnect_interval = reconnect_interval
         self.open = True


### PR DESCRIPTION
The indentation in the code is mostly spaces while the offending
line is tab indented. Hence, importing and initializing the client
fails with an Indentation error.

This fixes #431  