### PR TITLE
Fix Voldemort URLs

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -1,6 +1,6 @@
 Getting Started
 
-For the most up-to-date information see http://project-voldemort.com
+For the most up-to-date information see http://www.project-voldemort.com
 
 ## checkout and build
 jkreps@jkreps-md:/tmp > svn co svn+ssh://cm01.corp/lirepo/voldemort/trunk voldemort

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -9,7 +9,7 @@ setup(name='voldemort',
       packages=['voldemort', 'voldemort.protocol', 'voldemort.serialization'],
       author='LinkedIn Corporation',
       license='Apache 2.0',
-      url='http://project-voldemort.com',
+      url='http://www.project-voldemort.com',
       install_requires=['protobuf>=2.3.0', 'simplejson>=2.1.1'],
       setup_requires=['nose>=0.11'],
 )

--- a/contrib/collections/src/java/voldemort/collections/VStack.java
+++ b/contrib/collections/src/java/voldemort/collections/VStack.java
@@ -22,7 +22,7 @@ import voldemort.versioning.Versioned;
  * "stable" : "boolean", "value" : <JSON serialization format of E>}
  * 
  * @param <K> the type of key used to identify this stack. Must conform to valid
- *        voldemort JSON formats: http://project-voldemort.com/design.php
+ *        voldemort JSON formats: http://www.project-voldemort.com/design.php
  * @param <E> the type of element being stored
  */
 public class VStack<K, E> implements Queue<E> {


### PR DESCRIPTION
Replaced the following instances with http://www.project-voldemort.com since urls don't resolve from some places

$ grep -r 'http://project-voldemort' .
./clients/python/setup.py:      url='http://project-voldemort.com',
./NOTES:For the most up-to-date information see http://project-voldemort.com
./contrib/collections/src/java/voldemort/collections/VStack.java: *        voldemort JSON formats: http://project-voldemort.com/design.php