### PR TITLE
Adhere target/source java compatibility for contrib projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 apply plugin: 'java'
 apply plugin: 'war'
 
@@ -76,7 +75,7 @@ allprojects {
             options.addStringOption('Xdoclint:none', '-quiet')
         }
     }
-    
+
     tasks.withType(Javadoc) {
         enabled = javadocEnabled
     }
@@ -621,6 +620,9 @@ subprojects {
     // note at the moment there dependencies are still
     // declared in the dependency block above.
     apply plugin:'java'
+    sourceCompatibility = javacVersion
+    targetCompatibility = javacVersion
+
     sourceSets {
         // note that the contrib projects don't currently have resource
         // directories so below is actually just a to keep idea & gradle from
@@ -653,9 +655,7 @@ allprojects {
 
     eclipse {
         jdt {
-            // Currently the javac Version of jar is set to 1.5
-            // But @Override works differently between both, so overriding here
-            sourceCompatibility = targetCompatibility = 1.6
+            sourceCompatibility = targetCompatibility = 1.7
         }
         classpath {
             defaultOutputDir = project.file('classes') // overrides the default of /bin which is where our scripts are

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ tomcat.manager.password=tomcat
 tomcat.context=/voldemort
 
 ## Java version
-javac.version=1.6
+javac.version=1.7
 
 ## Release
 curr.release=1.10.22


### PR DESCRIPTION
We are using Java 1.7 on our hadoop cluster, but locally I use JDK 1.8
for building, so contrib got build with 1.8 by default because its
source and target version is not specified explicitly. Consequentially
the resulting jar didn't work in our cluster environment. This
reconfiguration fixes this.

But since the contrib projects don't build anymore with 1.6 source
compatibility I bumped up the configured javac.version to 1.7, even
though two other options are available:
1. Fix contrib to make it 1.6 compatible again
2. Specify different versions for the main and contrib projects

But since Java 1.6 is EOL since quite a while I suggest that no
Voldemort servers with a Java 1.6 runtime should be running anymore and
it should be save to upgrade and keep the configuration simple.
