### PR TITLE
Fix detection for fetcher protocol warning

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -252,7 +252,7 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
 
 
         this.hdfsFetcherProtocol = props.getString(VOLDEMORT_FETCHER_PROTOCOL, RECOMMENDED_FETCHER_PROTOCOL);
-        if (this.hdfsFetcherProtocol != RECOMMENDED_FETCHER_PROTOCOL) {
+        if (!this.hdfsFetcherProtocol.equals(RECOMMENDED_FETCHER_PROTOCOL)) {
             log.warn("It is recommended to use the " + RECOMMENDED_FETCHER_PROTOCOL + " protocol only.");
         }
 


### PR DESCRIPTION
Fetcher protocol warning was shown if the recommended protocol is
specified explicitly, which is unnecessary confusing

I'm not sure what it takes for a PR to be merged, therefore I put out this very minimal PR.
