### PR TITLE
Changed the DeleteAllFailedFetchStrategy so that it affects all nodes.

### DIFF
--- a/src/java/voldemort/store/readonly/swapper/DeleteAllFailedFetchStrategy.java
+++ b/src/java/voldemort/store/readonly/swapper/DeleteAllFailedFetchStrategy.java
@@ -17,16 +17,16 @@ public class DeleteAllFailedFetchStrategy extends FailedFetchStrategy {
     protected boolean dealWithIt(String storeName,
                                  long pushVersion,
                                  Map<Node, AdminStoreSwapper.Response> fetchResponseMap) {
-        // Delete data from successful nodes
-        for(Node node: fetchResponseMap.keySet()) {
+        // We attempt to delete data from all nodes, even the ones that failed their fetch.
+        for (Node node: fetchResponseMap.keySet()) {
             AdminStoreSwapper.Response response = fetchResponseMap.get(node);
-            if (response.isSuccessful()) {
-                try {
-                    logger.info("Deleting fetched data from node " + node);
-                    adminClient.readonlyOps.failedFetchStore(node.getId(), storeName, response.getResponse());
-                } catch(Exception e) {
-                    logger.error("Exception thrown during delete operation on node " + node + " : ", e);
-                }
+            String nodeDescription = node.briefToString() + " (which " +
+                (response.isSuccessful() ? "succeeded" : "failed") + " on its fetch).";
+            try {
+                adminClient.readonlyOps.failedFetchStore(node.getId(), storeName, response.getResponse());
+                logger.info("Deleted fetched data from " + nodeDescription);
+            } catch(Exception e) {
+                logger.error("Exception thrown during delete operation on " + nodeDescription, e);
             }
         }
         return false;


### PR DESCRIPTION
Changed the DeleteAllFailedFetchStrategy so that it affects all nodes.

Previously, the DeleteAllFailedFetchStrategy would only attempt to
delete data from nodes which succeeded in their fetch. In some failure
modes, this is appropriate, but in other cases, it isn't. In any case,
there is no harm in trying to delete data on all nodes, even those
that failed their fetch. This commit makes it so.