### PR TITLE
Rolling restart during BnP

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/fetcher/HdfsFetcher.java
@@ -38,6 +38,7 @@ import voldemort.routing.RoutingStrategyFactory;
 import voldemort.server.VoldemortConfig;
 import voldemort.server.protocol.admin.AdminServiceRequestHandler;
 import voldemort.server.protocol.admin.AsyncOperationStatus;
+import voldemort.server.protocol.admin.StoreVersionAlreadyExistsException;
 import voldemort.store.StoreDefinition;
 import voldemort.store.metadata.MetadataStore;
 import voldemort.store.quota.QuotaExceededException;
@@ -222,8 +223,7 @@ public class HdfsFetcher implements FileFetcher {
             File destination = new File(destinationFile);
 
             if(destination.exists()) {
-                throw new VoldemortException("Version directory " + destination.getAbsolutePath()
-                                             + " already exists");
+                throw new StoreVersionAlreadyExistsException(destination);
             }
 
             boolean isFile = isFile(fs, rootPath);

--- a/src/java/voldemort/server/protocol/admin/AsyncOperationNotFoundException.java
+++ b/src/java/voldemort/server/protocol/admin/AsyncOperationNotFoundException.java
@@ -1,0 +1,20 @@
+package voldemort.server.protocol.admin;
+
+import voldemort.VoldemortException;
+
+/**
+ * This exception means that an AsyncOperation with a specific ID was not found
+ * on the server.
+ */
+public class AsyncOperationNotFoundException extends VoldemortException {
+    /**
+     * DO NOT CHANGE THIS STRING.
+     *
+     * This string is used to identify this kind of exception coming from
+     * older servers who did not have this as a dedicated exception type.
+     */
+    public final static String MESSAGE = "No operation with id %s found";
+    public AsyncOperationNotFoundException(int requestId) {
+        super(String.format(MESSAGE, requestId));
+    }
+}

--- a/src/java/voldemort/server/protocol/admin/AsyncOperationService.java
+++ b/src/java/voldemort/server/protocol/admin/AsyncOperationService.java
@@ -84,7 +84,7 @@ public class AsyncOperationService extends AbstractService {
      */
     public synchronized boolean isComplete(int requestId, boolean remove) {
         if (!operations.containsKey(requestId))
-            throw new VoldemortException("No operation with id " + requestId + " found");
+            throw new AsyncOperationNotFoundException(requestId);
 
         if (operations.get(requestId).getStatus().isComplete()) {
             if (logger.isDebugEnabled())
@@ -112,7 +112,7 @@ public class AsyncOperationService extends AbstractService {
         try {
             return getOperationStatus(id).toString();
         } catch(VoldemortException e) {
-            return "No operation with id " + id + " found";
+            return String.format(AsyncOperationNotFoundException.MESSAGE, id);
         }
     }
 
@@ -168,7 +168,7 @@ public class AsyncOperationService extends AbstractService {
 
     public AsyncOperationStatus getOperationStatus(int requestId) {
         if(!operations.containsKey(requestId))
-            throw new VoldemortException("No operation with id " + requestId + " found");
+            throw new AsyncOperationNotFoundException(requestId);
 
         return operations.get(requestId).getStatus();
     }
@@ -187,7 +187,7 @@ public class AsyncOperationService extends AbstractService {
 
     public void stopOperation(int requestId) {
         if(!operations.containsKey(requestId))
-            throw new VoldemortException("No operation with id " + requestId + " found");
+            throw new AsyncOperationNotFoundException(requestId);
 
         operations.get(requestId).stop();
     }

--- a/src/java/voldemort/store/ErrorCodeMapper.java
+++ b/src/java/voldemort/store/ErrorCodeMapper.java
@@ -22,8 +22,10 @@ import java.util.Map;
 import voldemort.VoldemortApplicationException;
 import voldemort.VoldemortException;
 import voldemort.VoldemortUnsupportedOperationalException;
+import voldemort.server.protocol.admin.AsyncOperationNotFoundException;
 import voldemort.server.protocol.admin.AsyncOperationStoppedException;
 import voldemort.server.protocol.admin.ReadOnlyFetchDisabledException;
+import voldemort.server.protocol.admin.StoreVersionAlreadyExistsException;
 import voldemort.server.rebalance.AlreadyRebalancingException;
 import voldemort.server.rebalance.VoldemortRebalancingException;
 import voldemort.store.quota.QuotaExceededException;
@@ -69,6 +71,8 @@ public class ErrorCodeMapper {
         codeToException.put((short) 20, AsyncOperationStoppedException.class);
         codeToException.put((short) 21, ReadOnlyFetchDisabledException.class);
         codeToException.put((short) 22, StoreNotFoundException.class);
+        codeToException.put((short) 23, AsyncOperationNotFoundException.class);
+        codeToException.put((short) 24, StoreVersionAlreadyExistsException.class);
 
         exceptionToCode = new HashMap<Class<? extends VoldemortException>, Short>();
         for(Map.Entry<Short, Class<? extends VoldemortException>> entry: codeToException.entrySet())

--- a/src/java/voldemort/store/readonly/ReadOnlyStorageConfiguration.java
+++ b/src/java/voldemort/store/readonly/ReadOnlyStorageConfiguration.java
@@ -67,8 +67,8 @@ public class ReadOnlyStorageConfiguration implements StorageConfiguration {
                                                                 this.searcher,
                                                                 this.routingStrategy,
                                                                 this.nodeId,
-                                                                new File(storageDir,
-                                                                         storeDef.getName()),
+                                                                getStoreDirectory(storageDir.getAbsolutePath(),
+                                                                                  storeDef.getName()),
                                                                 numBackups,
                                                                 deleteBackupMs,
                                                                 maxValueBufferAllocationSize,
@@ -90,5 +90,9 @@ public class ReadOnlyStorageConfiguration implements StorageConfiguration {
      */
     @Override
     public void removeStorageEngine(StorageEngine<ByteArray, byte[], byte[]> engine) {
+    }
+
+    public static File getStoreDirectory(String storageDir, String storeName) {
+        return new File(storageDir, storeName);
     }
 }

--- a/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
+++ b/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
@@ -60,6 +60,10 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
 
     private static Logger logger = Logger.getLogger(ReadOnlyStorageEngine.class);
     public static final int NO_FETCH_IN_PROGRESS = -1;
+    public static final String VERSION_DIR_NAME = "version-%s";
+    public static String getVersionDirName(String storeDir, long version) {
+        return storeDir + File.separator + String.format(VERSION_DIR_NAME, version);
+    }
 
     // Immutable state
     private final int numBackups, nodeId, deleteBackupMs, maxValueBufferAllocationSize;
@@ -196,7 +200,7 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
                 versionDir = ReadOnlyUtils.getCurrentVersion(storeDir);
 
                 if(versionDir == null)
-                    versionDir = new File(storeDir, "version-0");
+                    versionDir = new File(storeDir, String.format(VERSION_DIR_NAME, 0));
             }
 
             // Set the max version id
@@ -237,8 +241,7 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
      * @return Returns the absolute path of the current dir
      */
     public String getCurrentDirPath() {
-        return storeDir.getAbsolutePath() + File.separator + "version-"
-               + Long.toString(getCurrentVersionId());
+        return getVersionDirName(storeDir.getAbsolutePath(), getCurrentVersionId());
     }
 
     /**


### PR DESCRIPTION
Since I've been fixing BnP issues left right and center since last week, and I had to re-read a lot of that code, I figured I might as well implement BnP rolling restart support as well, while I'm at it... So I did just that in the past 2-3 hours.

This commit is based on #461, so it's actually a bit smaller than it looks. This is the `--shortstat` for just rolling restart part: 8 files changed, 136 insertions(+), 17 deletions(-)

In any case, it is a bit finicky and would probably require extensive review and testing before being signed off.