### PR TITLE
Make nodes option working again for generate_cluster_xml.py

### DIFF
--- a/bin/generate_cluster_xml.py
+++ b/bin/generate_cluster_xml.py
@@ -97,10 +97,11 @@ genType.add_argument('--seed', type=int, default=rseed, dest='seed',
 args = parser.parse_args()
 
 # Check if the input file exists
-try:
-   with open(args.file): pass
-except IOError:
-   print 'File does not exist'
+if args.file:
+  try:
+     with open(args.file): pass
+  except IOError:
+     print 'File does not exist'
 
 # create output-dir if it does not exist
 try:


### PR DESCRIPTION
The `nodes` option for `generate_cluster_xml.py` is confusing because it does nothing when the `file` option is provided, but the `file` option got mandatory about 3 years ago when the file exists check was added.

Therefore I propose this fix, or alternatively remove this option altogether (since it's not working since 3 years I guess nobody will miss it?)
