### PR TITLE
Replace Unicode quotes in scripts with ASCII quotes

### DIFF
--- a/bin/rebalance-cluster-expansion.sh
+++ b/bin/rebalance-cluster-expansion.sh
@@ -60,7 +60,7 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 vold_home="$(dirname "$dir")"
 
 # Parse options
-while getopts “hc:s:i:o:” OPTION
+while getopts "hc:s:i:o:" OPTION
 do
   case $OPTION in
   h)
@@ -131,7 +131,7 @@ $vold_home/bin/run-class.sh voldemort.tools.RepartitionerCLI \
                             --output-dir $output_dir/step1/$i
 
 if [ ! -e $output_dir/step1/final-cluster.xml ]; then
-    usage_and_exit "File '$final-cluster.xml' does not exist."
+    usage_and_exit "File '$output_dir/step1/final-cluster.xml' does not exist."
 fi
 
 # Step 2

--- a/bin/rebalance-new-zoned-cluster.sh
+++ b/bin/rebalance-new-zoned-cluster.sh
@@ -50,7 +50,7 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 vold_home="$(dirname "$dir")"
 
 # Parse options
-while getopts “hc:s:o:” OPTION
+while getopts "hc:s:o:" OPTION
 do
   case $OPTION in
   h)
@@ -113,7 +113,7 @@ $vold_home/bin/run-class.sh voldemort.tools.RepartitionerCLI \
                             --output-dir $output_dir/step1/
 
 if [ ! -e $output_dir/step1/final-cluster.xml ]; then
-    usage_and_exit "File '$final-cluster.xml' does not exist."
+    usage_and_exit "File '$output_dir/step1/final-cluster.xml' does not exist."
 fi
 
 # Step 2
@@ -127,7 +127,7 @@ $vold_home/bin/run-class.sh voldemort.tools.RepartitionerCLI \
                             --random-swap-successes $step2_swap_successes
 
 if [ ! -e $output_dir/step2/final-cluster.xml ]; then
-    usage_and_exit "File '$final-cluster.xml' does not exist."
+    usage_and_exit "File '$output_dir/step2/final-cluster.xml' does not exist."
 fi
 
 mkdir -p $output_dir/step3/

--- a/bin/rebalance-shuffle.sh
+++ b/bin/rebalance-shuffle.sh
@@ -65,7 +65,7 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 vold_home="$(dirname "$dir")"
 
 # Parse options
-while getopts “hc:s:o:m:” OPTION
+while getopts "hc:s:o:m:" OPTION
 do
   case $OPTION in
   h)
@@ -157,7 +157,7 @@ $vold_home/bin/run-class.sh voldemort.tools.RepartitionerCLI \
                             --random-swap-successes $swap_successes
 
 if [ ! -e $output_dir/step1/final-cluster.xml ]; then
-    usage_and_exit "File '$final-cluster.xml' does not exist."
+    usage_and_exit "File '$output_dir/step1/final-cluster.xml' does not exist."
 fi
 
 # Step 2

--- a/bin/rebalance-zone-expansion.sh
+++ b/bin/rebalance-zone-expansion.sh
@@ -54,7 +54,7 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 vold_home="$(dirname "$dir")"
 
 # Parse options
-while getopts “hc:s:i:f:o:” OPTION
+while getopts "hc:s:i:f:o:" OPTION
 do
   case $OPTION in
   h)
@@ -121,7 +121,7 @@ fi
 # Step 2: In step 2, the cluster.xml from step 1 is fed to the repartitioner along with random swap 
 #         attempts. The repartitioner randomly swaps the partitions only in zone 2 
 #         and tries to balance the ring.
-# Step 3: Finally, a plan is generated on how to reach from the orignal cluster topology to
+# Step 3: Finally, a plan is generated on how to reach from the original cluster topology to
 #         the one that is generated in step 2. 
 #
 

--- a/bin/rebalance-zone-shrinkage.sh
+++ b/bin/rebalance-zone-shrinkage.sh
@@ -54,7 +54,7 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 vold_home="$(dirname "$dir")"
 
 # Parse options
-while getopts “hc:s:d:o:” OPTION
+while getopts "hc:s:d:o:" OPTION
 do
   case $OPTION in
   h)


### PR DESCRIPTION
Some issues I noticed during an IDEA analysis run. I don't know how these scripts could ever work, they seem to contain Unicode " (code point 0x201c) since the beginning (which can happen when copy and pasting from a blog for instance).

I couldn't test these scripts, but since they couldn't work anyway I'm wondering if anybody is using these. For the benefits of users outside of LinkedIn I would prefer to clean them up in order to make the Voldemort distribution less confusing. I could provide an alternative PR for that.