### PR TITLE
Update Avro from 1.4.0 to 1.7.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,9 @@ clean {
 // Dependencies used by both BnP and Voldemort
 // TODO: Decide if we want to do that for all dependencies, even if they're used just in Voldemort...
 
-def depAvro = 'org.apache.avro:avro:1.4.0'
+def depAvro = 'org.apache.avro:avro:1.7.7'
+def depAvroIpc = 'org.apache.avro:avro-ipc:1.7.7'
+def depAvroMapred = 'org.apache.avro:avro-mapred:1.7.7'
 def depProtoBuf = 'com.google.protobuf:protobuf-java:2.3.0'
 def depJdom = 'org.jdom:jdom:1.1'
 def depAzkaban = 'com.linkedin.azkaban:azkaban:2.5.0'
@@ -451,6 +453,8 @@ task wrapper(type: Wrapper) { gradleVersion = '2.9' }
 dependencies {
     // Avro serialization format
     compile depAvro
+    compile depAvroIpc
+    compile depAvroMapred
 
     // INTERNAL_LIBS azkaban version not found
     // azkaban-common-0.05.jar

--- a/src/java/voldemort/VoldemortAdminTool.java
+++ b/src/java/voldemort/VoldemortAdminTool.java
@@ -57,6 +57,7 @@ import joptsimple.OptionSet;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.JsonDecoder;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.io.FileUtils;
@@ -2125,7 +2126,7 @@ public class VoldemortAdminTool {
                     String keySerializerName = keySerializerDef.getName();
                     if(isAvroSchema(keySerializerName)) {
                         Schema keySchema = Schema.parse(keySerializerDef.getCurrentSchemaInfo());
-                        JsonDecoder decoder = new JsonDecoder(keySchema, keyString);
+                        JsonDecoder decoder = DecoderFactory.get().jsonDecoder(keySchema, keyString);
                         GenericDatumReader<Object> datumReader = new GenericDatumReader<Object>(keySchema);
                         keyObject = datumReader.read(null, decoder);
                     } else if(keySerializerName.equals(DefaultSerializerFactory.JSON_SERIALIZER_TYPE_NAME)) {

--- a/src/java/voldemort/VoldemortAvroClientShell.java
+++ b/src/java/voldemort/VoldemortAvroClientShell.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.JsonDecoder;
 
 import voldemort.client.ClientConfig;
@@ -144,7 +145,7 @@ public class VoldemortAvroClientShell {
                     System.out.println("Enter key:");
                     line = reader.readLine();
 
-                    JsonDecoder decoder = new JsonDecoder(keySchema, line);
+                    JsonDecoder decoder = DecoderFactory.get().jsonDecoder(keySchema, line);
                     GenericDatumReader<Object> datumReader = null;
                     Object key = null;
                     try {
@@ -170,8 +171,8 @@ public class VoldemortAvroClientShell {
                     line = reader.readLine();
                     valueString = line;
 
-                    JsonDecoder keyDecoder = new JsonDecoder(keySchema, keyString);
-                    JsonDecoder valueDecoder = new JsonDecoder(valueSchema, valueString);
+                    JsonDecoder keyDecoder = DecoderFactory.get().jsonDecoder(keySchema, line);
+                    JsonDecoder valueDecoder = DecoderFactory.get().jsonDecoder(valueSchema, line);
 
                     GenericDatumReader<Object> datumReader = null;
                     Object key = null;

--- a/src/java/voldemort/VoldemortClientShell.java
+++ b/src/java/voldemort/VoldemortClientShell.java
@@ -41,6 +41,7 @@ import joptsimple.OptionSet;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.JsonDecoder;
 import org.apache.commons.lang.mutable.MutableInt;
 
@@ -248,7 +249,7 @@ public class VoldemortClientShell {
                 // From here on, this is just normal avro parsing.
                 Schema latestSchema = Schema.parse(serializerDef.getCurrentSchemaInfo());
                 try {
-                    JsonDecoder decoder = new JsonDecoder(latestSchema, avroString);
+                    JsonDecoder decoder = DecoderFactory.get().jsonDecoder(latestSchema, avroString);
                     GenericDatumReader<Object> datumReader = new GenericDatumReader<Object>(latestSchema);
                     obj = datumReader.read(null, decoder);
                 } catch(IOException io) {

--- a/src/java/voldemort/rest/coordinator/config/ClientConfigUtil.java
+++ b/src/java/voldemort/rest/coordinator/config/ClientConfigUtil.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.util.Utf8;
 
@@ -35,7 +36,7 @@ public class ClientConfigUtil {
     public static Properties readSingleClientConfigAvro(String configAvro) {
         Properties props = new Properties();
         try {
-            JsonDecoder decoder = new JsonDecoder(CLIENT_CONFIG_AVRO_SCHEMA, configAvro);
+            JsonDecoder decoder = DecoderFactory.get().jsonDecoder(CLIENT_CONFIGS_AVRO_SCHEMA, configAvro);
             GenericDatumReader<Object> datumReader = new GenericDatumReader<Object>(CLIENT_CONFIG_AVRO_SCHEMA);
             Map<Utf8, Utf8> flowMap = (Map<Utf8, Utf8>) datumReader.read(null, decoder);
             for(Utf8 key: flowMap.keySet()) {
@@ -58,7 +59,7 @@ public class ClientConfigUtil {
     public static Map<String, Properties> readMultipleClientConfigAvro(String configAvro) {
         Map<String, Properties> mapStoreToProps = Maps.newHashMap();
         try {
-            JsonDecoder decoder = new JsonDecoder(CLIENT_CONFIGS_AVRO_SCHEMA, configAvro);
+            JsonDecoder decoder = DecoderFactory.get().jsonDecoder(CLIENT_CONFIGS_AVRO_SCHEMA, configAvro);
             GenericDatumReader<Object> datumReader = new GenericDatumReader<Object>(CLIENT_CONFIGS_AVRO_SCHEMA);
 
             Map<Utf8, Map<Utf8, Utf8>> storeConfigs = (Map<Utf8, Map<Utf8, Utf8>>) datumReader.read(null,

--- a/src/java/voldemort/serialization/avro/AvroGenericSerializer.java
+++ b/src/java/voldemort/serialization/avro/AvroGenericSerializer.java
@@ -21,10 +21,10 @@ import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
-import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
 
 import voldemort.serialization.SerializationException;
 import voldemort.serialization.SerializationUtils;
@@ -51,7 +51,7 @@ public class AvroGenericSerializer implements Serializer<Object> {
 
     public byte[] toBytes(Object object) {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        Encoder encoder = new BinaryEncoder(output);
+        Encoder encoder = EncoderFactory.get().binaryEncoder(output, null);
         GenericDatumWriter<Object> datumWriter = null;
         try {
             datumWriter = new GenericDatumWriter<Object>(typeDef);

--- a/src/java/voldemort/serialization/avro/AvroReflectiveSerializer.java
+++ b/src/java/voldemort/serialization/avro/AvroReflectiveSerializer.java
@@ -18,10 +18,10 @@ package voldemort.serialization.avro;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.avro.reflect.ReflectDatumWriter;
 
@@ -69,7 +69,7 @@ public class AvroReflectiveSerializer<T> implements Serializer<T> {
 
     public byte[] toBytes(T object) {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        Encoder encoder = new BinaryEncoder(output);
+        Encoder encoder = EncoderFactory.get().binaryEncoder(output, null);
         ReflectDatumWriter<T> datumWriter = null;
         try {
             datumWriter = new ReflectDatumWriter<T>(clazz);

--- a/src/java/voldemort/serialization/avro/AvroSpecificSerializer.java
+++ b/src/java/voldemort/serialization/avro/AvroSpecificSerializer.java
@@ -18,10 +18,10 @@ package voldemort.serialization.avro;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecord;
@@ -67,7 +67,7 @@ public class AvroSpecificSerializer<T extends SpecificRecord> implements Seriali
 
     public byte[] toBytes(T object) {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        Encoder encoder = new BinaryEncoder(output);
+        Encoder encoder = EncoderFactory.get().binaryEncoder(output, null);
         SpecificDatumWriter<T> datumWriter = null;
         try {
             datumWriter = new SpecificDatumWriter<T>(clazz);

--- a/src/java/voldemort/serialization/avro/versioned/AvroVersionedGenericSerializer.java
+++ b/src/java/voldemort/serialization/avro/versioned/AvroVersionedGenericSerializer.java
@@ -26,10 +26,10 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
-import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
 
 import voldemort.serialization.SerializationException;
 import voldemort.serialization.SerializationUtils;
@@ -73,7 +73,7 @@ public class AvroVersionedGenericSerializer implements Serializer<Object> {
 
     public byte[] toBytes(Object object) {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        Encoder encoder = new BinaryEncoder(output);
+        Encoder encoder = EncoderFactory.get().binaryEncoder(output, null);
         GenericDatumWriter<Object> datumWriter = null;
 
         output.write(newestVersion.byteValue());
@@ -112,7 +112,7 @@ public class AvroVersionedGenericSerializer implements Serializer<Object> {
     private byte[] toBytes(Object object, Schema writer, Integer writerVersion) {
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        Encoder encoder = new BinaryEncoder(output);
+        Encoder encoder = EncoderFactory.get().binaryEncoder(output, null);
         GenericDatumWriter<Object> datumWriter = null;
 
         output.write(writerVersion.byteValue());

--- a/src/java/voldemort/tools/admin/command/AdminCommandDebug.java
+++ b/src/java/voldemort/tools/admin/command/AdminCommandDebug.java
@@ -38,6 +38,7 @@ import joptsimple.OptionSet;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.JsonDecoder;
 import org.apache.commons.codec.DecoderException;
 import org.codehaus.jackson.JsonFactory;
@@ -322,7 +323,7 @@ public class AdminCommandDebug extends AbstractAdminCommand {
                         String keySerializerName = keySerializerDef.getName();
                         if(isAvroSchema(keySerializerName)) {
                             Schema keySchema = Schema.parse(keySerializerDef.getCurrentSchemaInfo());
-                            JsonDecoder decoder = new JsonDecoder(keySchema, keyString);
+                            JsonDecoder decoder = DecoderFactory.get().jsonDecoder(keySchema, keyString);
                             GenericDatumReader<Object> datumReader = new GenericDatumReader<Object>(keySchema);
                             keyObject = datumReader.read(null, decoder);
                         } else if(keySerializerName.equals(DefaultSerializerFactory.JSON_SERIALIZER_TYPE_NAME)) {

--- a/test/unit/voldemort/serialization/avro/AvroGenericSerializerTest.java
+++ b/test/unit/voldemort/serialization/avro/AvroGenericSerializerTest.java
@@ -16,11 +16,12 @@
 package voldemort.serialization.avro;
 
 import static org.junit.Assert.assertArrayEquals;
-import junit.framework.TestCase;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.util.Utf8;
+
+import junit.framework.TestCase;
 
 import voldemort.utils.ByteUtils;
 
@@ -49,13 +50,13 @@ public class AvroGenericSerializerTest extends TestCase {
     }
 
     public void testRoundtripAvroWithGenericRecord() throws Exception {
-        String jsonSchema = "{\"name\": \"Compact Disk\", \"type\": \"record\", "
+        String jsonSchema = "{\"name\": \"CompactDisk\", \"type\": \"record\", "
                             + "\"fields\": ["
                             + "{\"name\": \"name\", \"type\": \"string\", \"order\": \"ascending\"}"
                             + "]}";
 
         AvroGenericSerializer serializer = new AvroGenericSerializer(jsonSchema);
-        Record record = new Record(Schema.parse(jsonSchema));
+        Record record = new Record(new Schema.Parser().parse(jsonSchema));
         // we need to use a Utf8 instance to map to a String.
         record.put("name", new Utf8("Hello"));
         byte[] bytes = serializer.toBytes(record);

--- a/test/unit/voldemort/serialization/avro/AvroSpecificSerializerTest.java
+++ b/test/unit/voldemort/serialization/avro/AvroSpecificSerializerTest.java
@@ -15,12 +15,15 @@
  */
 package voldemort.serialization.avro;
 
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+
 import junit.framework.TestCase;
 
 import org.apache.avro.ipc.HandshakeRequest;
 import org.apache.avro.ipc.MD5;
 import org.apache.avro.specific.SpecificRecord;
-import org.apache.avro.util.Utf8;
 
 import voldemort.utils.ByteUtils;
 
@@ -43,11 +46,11 @@ public class AvroSpecificSerializerTest extends TestCase {
 
         String className = "java=org.apache.avro.ipc.HandshakeRequest";
 
-        HandshakeRequest req = new HandshakeRequest();
-        // set a few values to avoid NPEs
-        req.clientHash = new MD5();
-        req.clientProtocol = new Utf8("");
-        req.serverHash = new MD5();
+        MD5 clientHash = new MD5();
+        String clientProtocol = "";
+        MD5 serverHash = new MD5();
+        Map<String, ByteBuffer> meta = Collections.emptyMap();
+        HandshakeRequest req = new HandshakeRequest(clientHash, clientProtocol, serverHash, meta);
 
         AvroSpecificSerializer<HandshakeRequest> serializer = new AvroSpecificSerializer<HandshakeRequest>(className);
         byte[] bytes = serializer.toBytes(req);

--- a/test/unit/voldemort/serialization/avro/versioned/AvroBackwardsCompatibilityTest.java
+++ b/test/unit/voldemort/serialization/avro/versioned/AvroBackwardsCompatibilityTest.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.util.Utf8;
 import org.junit.Test;
 
@@ -53,10 +52,9 @@ public class AvroBackwardsCompatibilityTest {
         String versionZero = "{\"type\": \"record\", \"name\": \"myrec\",\"fields\": [{ \"name\": \"original\", \"type\": \"string\" }]}";
 
         String versionOne = "{\"type\": \"record\", \"name\": \"myrec\",\"fields\": [{ \"name\": \"original\", \"type\": \"string\" } ,"
-                            + "{ \"name\": \"new-field\", \"type\": \"string\", \"default\":\"\" }]}";
+                            + "{ \"name\": \"new_field\", \"type\": \"string\", \"default\":\"\" }]}";
 
-        Schema s0 = Schema.parse(versionZero);
-        Schema s1 = Schema.parse(versionOne);
+        Schema s0 = new Schema.Parser().parse(versionZero);
 
         Map<Integer, String> versions = new HashMap<Integer, String>();
 
@@ -65,8 +63,7 @@ public class AvroBackwardsCompatibilityTest {
 
         byte[] versionZeroBytes = writeVersion0(s0);
 
-        GenericData.Record record = (Record) readVersion0(versions, versionZeroBytes);
-
+        readVersion0(versions, versionZeroBytes);
     }
 
     /*
@@ -79,17 +76,16 @@ public class AvroBackwardsCompatibilityTest {
         String versionZero = "{\"type\": \"record\", \"name\": \"myrec\",\"fields\": [{ \"name\": \"original\", \"type\": \"string\" }]}";
 
         String versionOne = "{\"type\": \"record\", \"name\": \"myrec\",\"fields\": [{ \"name\": \"original\", \"type\": \"string\" } ,"
-                            + "{ \"name\": \"new-field\", \"type\": \"string\", \"default\":\"\" }]}";
+                            + "{ \"name\": \"new_field\", \"type\": \"string\", \"default\":\"\" }]}";
 
-        Schema s0 = Schema.parse(versionZero);
-        Schema s1 = Schema.parse(versionOne);
+        Schema s0 = new Schema.Parser().parse(versionZero);
 
         Map<Integer, String> versions = new HashMap<Integer, String>();
 
         versions.put(0, versionZero);
         versions.put(1, versionOne);
 
-        byte[] versionZeroBytes = writeVersion0with1Present(versions, s0);
+        writeVersion0with1Present(versions, s0);
 
     }
 }


### PR DESCRIPTION
Avro release 1.4.0 is about 5 years old now and therefore heavily outdated. Therefore I propose this update to

* Get possible avro improvement and bugfixes
* To make later updates easier (in other words: to be able to keep up with future releases)
* To get less libraries conflicts in todays common hadoop environments

The last point is a minor one because library conflicts can be avoided by deploying the bnp jar which shadows the avro dependency. My point is that even if one neglects this and deploys the voldemort-contrib jar instead, this version should yield less conflicts in todays common environments and therefore has a higher probability to work out of the box. And even if there are conflicts one can always use the shadowed jar, so there is no reason not to update.

Of course we could think about updating to an even newer version, but I'm a conservative here since this is the patch we are already using in production since about 1.5 years, so regressions are not to be expected. If this is merged an update to an even newer version is still an option and should be easier than updating directly from 1.4.0.