### PR TITLE
New RECOVERY mode to partially automate node repair following BnP HA.

### DIFF
--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/swapper/HdfsFailedFetchLock.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/swapper/HdfsFailedFetchLock.java
@@ -367,64 +367,6 @@ public class HdfsFailedFetchLock extends FailedFetchLock {
 
     }
 
-    @Override
-    public void removeObsoleteStateForStore(int nodeId, String storeName, Map<Long, Boolean> versionToEnabledMap) throws Exception {
-        int attempts = 1;
-        boolean success = false;
-        while (!success && attempts <= maxAttempts) {
-            try {
-                String nodeIdDir = NODE_ID_DIR_PREFIX + nodeId;
-                Path failedStorePath = new Path(clusterDir + "/" + nodeIdDir + "/" + storeName);
-
-                FileStatus[] disabledVersions;
-                try {
-                    disabledVersions = this.fileSystem.listStatus(failedStorePath);
-                    for (FileStatus disabledVersionDir: disabledVersions) {
-                        Long disabledVersion = Long.parseLong(disabledVersionDir.getPath().getName());
-                        Boolean isDisabledLocally = versionToEnabledMap.get(disabledVersion);
-                        if (isDisabledLocally == null || !isDisabledLocally) {
-                            logger.info("The shared state has an obsolete disabled stored version which we will delete: " +
-                                    disabledVersionDir.getPath().toString());
-                            this.fileSystem.delete(disabledVersionDir.getPath(), true);
-                        }
-                    }
-
-                    // Let's see if there's still anything left for this store?
-                    disabledVersions = this.fileSystem.listStatus(failedStorePath);
-                    if (disabledVersions.length == 0) {
-                        logger.info("There are no more disabled versions for this store, so we will delete: " +
-                                failedStorePath.toString());
-                        this.fileSystem.delete(failedStorePath, true);
-                    }
-                } catch (FileNotFoundException e) {
-                    logger.info("The shared state has no obsolete versions in: " + failedStorePath.toString());
-                }
-
-                // Let's see if there's still anything left for this node?
-                Path disabledStoresPath = new Path(clusterDir + "/" + nodeIdDir);
-                try {
-                    FileStatus[] disabledStores = this.fileSystem.listStatus(disabledStoresPath);
-                    if (disabledStores.length == 0) {
-                        logger.info("There are no more disabled stores for this node, so we will delete: " +
-                                disabledStoresPath.toString());
-                        this.fileSystem.delete(disabledStoresPath, true);
-                    }
-                } catch (FileNotFoundException e) {
-                    logger.info("The shared state has no obsolete stores in: " + disabledStoresPath.toString());
-                }
-
-                success = true;
-            }  catch (IOException e) {
-                handleIOException(e, CLEAR_OBSOLETE_STATE, attempts);
-                attempts++;
-            }
-        }
-
-        if (!success) {
-            throw new VoldemortException(exceptionMessage(CLEAR_OBSOLETE_STATE));
-        }
-    }
-
     /**
      * Closes this stream and releases any system resources associated
      * with it. If the stream is already closed then invoking this

--- a/src/java/voldemort/server/StoreRepository.java
+++ b/src/java/voldemort/server/StoreRepository.java
@@ -201,11 +201,11 @@ public class StoreRepository {
         return new ArrayList<StorageEngine<ByteArray, byte[], byte[]>>(this.storageEngines.values());
     }
 
-    public List<StorageEngine<ByteArray, byte[], byte[]>> getStorageEnginesByClass(Class<? extends StorageEngine<?, ?, ?>> c) {
-        List<StorageEngine<ByteArray, byte[], byte[]>> l = new ArrayList<StorageEngine<ByteArray, byte[], byte[]>>();
+    public <STORAGE_ENGINE extends StorageEngine<ByteArray, byte[], byte[]>> List<STORAGE_ENGINE> getStorageEnginesByClass(Class<STORAGE_ENGINE> c) {
+        List<STORAGE_ENGINE> l = new ArrayList<STORAGE_ENGINE>();
         for(StorageEngine<ByteArray, byte[], byte[]> engine: this.storageEngines.values())
             if(engine.getClass().equals(c))
-                l.add(engine);
+                l.add((STORAGE_ENGINE) engine);
         return l;
     }
 

--- a/src/java/voldemort/server/http/gui/ReadOnlyStoreManagementServlet.java
+++ b/src/java/voldemort/server/http/gui/ReadOnlyStoreManagementServlet.java
@@ -132,12 +132,7 @@ public class ReadOnlyStoreManagementServlet extends HttpServlet {
     private List<ReadOnlyStorageEngine> getReadOnlyStores(VoldemortServer server) {
         StorageService storage = (StorageService) Utils.notNull(server)
                                                        .getService(ServiceType.STORAGE);
-        List<ReadOnlyStorageEngine> l = Lists.newArrayList();
-        for(StorageEngine<ByteArray, byte[], byte[]> engine: storage.getStoreRepository()
-                                                                    .getStorageEnginesByClass(ReadOnlyStorageEngine.class)) {
-            l.add((ReadOnlyStorageEngine) engine);
-        }
-        return l;
+        return storage.getStoreRepository().getStorageEnginesByClass(ReadOnlyStorageEngine.class);
     }
 
     @Override

--- a/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
+++ b/src/java/voldemort/server/protocol/admin/AdminServiceRequestHandler.java
@@ -1005,10 +1005,10 @@ public class AdminServiceRequestHandler implements RequestHandler {
 
         String currentDirPath = store.getCurrentDirPath();
 
-        logger.info("Swapping RO store '" + storeName + "' to version directory '" + directory
+        logger.info("Will swap RO store '" + storeName + "' to version directory '" + directory
                     + "'");
         store.swapFiles(directory);
-        logger.info("Swapping swapped RO store '" + storeName + "' to version directory '"
+        logger.info("Finished swapping RO store '" + storeName + "' to version directory '"
                     + directory + "'");
 
         return currentDirPath;
@@ -1019,17 +1019,15 @@ public class AdminServiceRequestHandler implements RequestHandler {
         final String storeName = request.getStoreName();
         VAdminProto.SwapStoreResponse.Builder response = VAdminProto.SwapStoreResponse.newBuilder();
 
-        if(!metadataStore.getServerStateUnlocked()
-                         .equals(MetadataStore.VoldemortState.NORMAL_SERVER)
-           && !metadataStore.getServerStateUnlocked()
-                            .equals(MetadataStore.VoldemortState.OFFLINE_SERVER)) {
+        MetadataStore.VoldemortState state = metadataStore.getServerStateUnlocked();
+        if(!state.enableReadOnlyFetches) {
             response.setError(ProtoUtils.encodeError(errorCodeMapper,
                                                      new VoldemortException("Voldemort server "
                                                                             + metadataStore.getNodeId()
-                                                                            + " is neither in normal state nor in offline state while swapping store "
-                                                                            + storeName
-                                                                            + " with directory "
-                                                                            + dir)));
+                                                                            + " is in state '" + state + "'"
+                                                                            + " which does not allow Read-Only fetches."
+                                                                            + " Aborting the swap of store '"
+                                                                            + storeName + "' to directory: " + dir)));
             return response.build();
         }
 

--- a/src/java/voldemort/store/readonly/swapper/FailedFetchLock.java
+++ b/src/java/voldemort/store/readonly/swapper/FailedFetchLock.java
@@ -28,9 +28,6 @@ public abstract class FailedFetchLock implements Closeable {
     public abstract void addDisabledNode(int nodeId,
                                          String storeName,
                                          long storeVersion) throws Exception;
-    public abstract void removeObsoleteStateForStore(int nodeId,
-                                                     String storeName,
-                                                     Map<Long, Boolean> versionToEnabledMap) throws Exception;
     public abstract void removeObsoleteStateForNode(int nodeId) throws Exception;
 
     @Override

--- a/test/unit/voldemort/store/readonly/StoreVersionManagerTest.java
+++ b/test/unit/voldemort/store/readonly/StoreVersionManagerTest.java
@@ -23,7 +23,7 @@ public class StoreVersionManagerTest extends TestCase {
         Assert.assertTrue("Failed to create version directory!", version0.mkdir());
         Assert.assertTrue("Failed to create version directory!", version1.mkdir());
         storeVersionManager = new StoreVersionManager(rootDir, null);
-        storeVersionManager.syncInternalStateFromFileSystem(false);
+        storeVersionManager.syncInternalStateFromFileSystem();
     }
 
     @Test
@@ -43,7 +43,7 @@ public class StoreVersionManagerTest extends TestCase {
 
         // Verify that another instance of StoreVersionManager, freshly synced from disk, also has proper state.
         StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir, null);
-        storeVersionManager2.syncInternalStateFromFileSystem(false);
+        storeVersionManager2.syncInternalStateFromFileSystem();
         Assert.assertTrue("Expected persistent state to have some store version disabled.",
                           storeVersionManager2.hasAnyDisabledVersion());
         Assert.assertTrue("Expected persistent state to have store version 1 enabled.",
@@ -75,7 +75,7 @@ public class StoreVersionManagerTest extends TestCase {
 
         // Verify that another instance of StoreVersionManager, freshly synced from disk, does NOT have proper state.
         StoreVersionManager storeVersionManager2 = new StoreVersionManager(rootDir, null);
-        storeVersionManager2.syncInternalStateFromFileSystem(false);
+        storeVersionManager2.syncInternalStateFromFileSystem();
         Assert.assertFalse("Expected persistent state to have no version disabled.",
                           storeVersionManager2.hasAnyDisabledVersion());
     }


### PR DESCRIPTION
In the new RECOVERY mode, the server will deny online requests from
clients (just like in OFFLINE mode) but will allow new BnP jobs to
push into the node. After starting the server in this mode, the
operator can kick off a data restoration job to recover the rest of
the missing stores. Meanwhile, the server will periodically check
if any of its symlinks have changed, and if so will load the newly
restored stores as the active version. Finally, when no more stores
are disabled, the server automatically transitions to the ONLINE
mode and resume serving client requests.

The benefits of this new mode are:

1) Less manual work for the operator.
2) No need for a planned BnP outage during the node recovery process.

FYI: This is untested. It barely compiles. Hot off the IDE. Handle with care.