### PR TITLE
CDN feature release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'java'
 apply plugin: 'war'
 
 buildscript {
-  repositories { jcenter() }
-  dependencies {
-    classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.1'
-  }
+    repositories { jcenter() }
+    dependencies {
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+    }
 }
 
 apply plugin: 'com.github.johnrengelman.shadow'
@@ -50,6 +50,12 @@ def javadocEnabled = getProjectProperty('javadoc.enabled').toBoolean()
 def deleteDirectoryContents(directory) {
     project.file(directory).deleteDir()
     project.file(directory).mkdirs()
+}
+
+def gobblinExcludes = {
+    exclude group: 'org.apache.hive'
+    exclude group: 'com.google.protobuf'
+    exclude group: 'org.apache.avro'
 }
 
 allprojects {
@@ -200,10 +206,18 @@ def depTehuti = 'io.tehuti:tehuti:0.7.0'
 
 
 shadowJar {
+    zip64 true  // Required if fatjar has more than 64K files
     classifier "bnp"
     from sourceSets.main.output, sourceSets.test.output, sourceSets.main.resources
     from {subprojects*.sourceSets.main.output}
     from {subprojects*.sourceSets.test.output}
+    from project('gobblin').projectDir
+    dependsOn 'gobblin:shadowJar'
+
+    // Hadoop dependencies are expected to be provided by Azkaban.
+    // If Azkaban is not included in your deployment, you may need to remove the following excludes
+    exclude("**/org/apache/hadoop/**")
+    exclude("**/org.apache.hadoop**")
 
     // Required when working in an Hadoop 2.x environment
     dependencies {
@@ -613,6 +627,11 @@ dependencies {
 
     // Bouncy Castle Libaray
     compile 'org.bouncycastle:bcprov-jdk15on:1.48'
+
+    // Gobblin
+    compile 'com.linkedin.gobblin:gobblin-runtime:0.10.0', gobblinExcludes
+    compile 'com.linkedin.gobblin:gobblin-data-management:0.10.0', gobblinExcludes
+    compile 'com.linkedin.gobblin:gobblin-throttling-service-client:0.10.0', gobblinExcludes
 }
 
 subprojects {

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/hooks/BuildAndPushStatus.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/hooks/BuildAndPushStatus.java
@@ -8,11 +8,14 @@ public enum BuildAndPushStatus {
     STARTING,               // emitted once per job
     BUILDING,               // emitted once per job
     PUSHING,                // emitted once per cluster
+    DISTCP_STARTING,        // emitted once per cluster
+    DISTCP_FINISHED,        // emitted once per cluster
     SWAPPED,                // emitted once per cluster
     FINISHED(true),         // emitted once per job
     HEARTBEAT,              // emitted periodically during any of the stages...
 
     // The "not-so-happy path" status:
+    DISTCP_FAILED,          // emitted once per cluster
     SWAPPED_WITH_FAILURES,  // emitted for each cluster that failed to push completely but still managed to swap
     CANCELLED(true),        // emitted once per job
     FAILED(true);           // emitted once per job

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/GobblinDistcpJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/GobblinDistcpJob.java
@@ -1,0 +1,281 @@
+package voldemort.store.readonly.mr.azkaban;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import java.net.URI;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.mapred.JobConf;
+
+import gobblin.runtime.api.JobExecutionResult;
+import gobblin.runtime.embedded.EmbeddedGobblin;
+import gobblin.runtime.embedded.EmbeddedGobblinDistcp;
+
+import voldemort.utils.Props;
+import voldemort.utils.logging.PrefixedLogger;
+
+import azkaban.jobExecutor.AbstractJob;
+
+
+public class GobblinDistcpJob extends AbstractJob {
+    private final static String ATTR_PREFIX = "distcpConf.";
+    private final static String OTHER_NAMENODES = "other_namenodes";
+    private String source;
+    private final String destination;
+    private final Props props;
+    private FileSystem cdnTargetFS;
+
+    GobblinDistcpJob(String id, String sourceHdfsCluster, String destinationVoldemortCluster, Props props) {
+        super(id, PrefixedLogger.getLogger(GobblinDistcpJob.class.getName(), destinationVoldemortCluster));
+        this.source = sourceHdfsCluster;
+        this.destination = destinationVoldemortCluster;
+        this.props = props;
+    }
+
+    public void run() throws Exception {
+        info("###############  Distcp  ###############");
+        long startTime = System.currentTimeMillis();
+        try {
+            String cdnURL = pickCDN();
+            if (!cdnURL.isEmpty()) {
+                info("CDN: " + cdnURL);
+                String storeName = props.getString(VoldemortBuildAndPushJob.PUSH_STORE_NAME).trim();
+                String pathPrefix = props.getString(VoldemortBuildAndPushJob.PUSH_CDN_PREFIX).trim();
+                if (!pathPrefix.startsWith("/")) {
+                    throw new RuntimeException(VoldemortBuildAndPushJob.PUSH_CDN_PREFIX + " must start with '/': " + pathPrefix);
+                }
+                pathPrefix = removeTrailingSlash(pathPrefix);
+
+                // Replace original cluster with CDN, e.g. hdfs://original:9000/a/b/c => webhdfs://cdn:50070/prefix/user/a/b/c
+                String cdnDir =  cdnURL + pathPrefix + "/" + storeName + extractPathFromUrl(source);
+                cdnTargetFS = getTargetFS(cdnDir);
+                Path from = new Path(source);
+                Path to = new Path(cdnDir);
+
+                if (!prereqSatisfied(cdnURL)) {
+                    warn("Please add/append \"" + cdnURL + "\" to the \"" + OTHER_NAMENODES + "\" attribute in your job specification.");
+                    throw new RuntimeException("\"" + OTHER_NAMENODES + "\" does not contain the CDN cluster address " + cdnURL);
+                }
+
+                deleteDir(cdnTargetFS, cdnDir);
+                runDistcp(from, to);
+                deleteDirOnExit(cdnTargetFS, cdnDir);
+                addPermissionsToParentDirs(cdnTargetFS, cdnDir, pathPrefix);
+                source = cdnDir;
+                info("Will use data on CDN HDFS cluster: " + source);
+            }
+        } catch (Exception e) {
+            warn("An exception occurred during distcp: ", e);
+            warn("Will use data on original HDFS cluster: " + source);
+            long duration = System.currentTimeMillis() - startTime;
+            info("#############  End of Distcp (FAILED) ############ (duration: " + duration/1000 + "s)");
+            throw new RuntimeException("An exception occurred during distcp", e);
+        }
+        long duration = System.currentTimeMillis() - startTime;
+        info("#############  End of Distcp  ########### (duration: " + duration/1000 + "s)");
+    }
+
+    private void runDistcp(Path from, Path to) throws Exception {
+        info("sourcePath: " + from + ", destinationPath: " + to);
+        EmbeddedGobblin embeddedGobblin = new EmbeddedGobblinDistcp(from, to).mrMode();
+
+        // Used for global throttling"
+        embeddedGobblin.distributeJar("lib/*");
+
+        for (Map.Entry<String, String> entry : this.props.entrySet()) {
+            if (entry.getKey() != null && (entry.getKey()).startsWith(ATTR_PREFIX)) {
+                String key = (entry.getKey()).substring(ATTR_PREFIX.length());
+                embeddedGobblin.setConfiguration(key, entry.getValue());
+            }
+        }
+        JobExecutionResult result =  embeddedGobblin.run();
+
+        if (!result.isSuccessful()) {
+            throw new RuntimeException("Distcp job failed!", result.getErrorCause());
+        }
+    }
+
+    private FileSystem getTargetFS(String target) throws Exception {
+        URI targetURI = new URI(removePathFromUrl(target));
+        return FileSystem.get(targetURI, new JobConf());
+    }
+
+    private void deleteDir(FileSystem fs, String target) throws Exception {
+        Path path = new Path(extractPathFromUrl(target));
+
+        if (fs.exists(path)) {
+            fs.delete(path, true);
+            if (fs.exists(path)) {
+                warn("Could not delete temp directory " + path + " in CDN!");
+            } else {
+                info("Deleted " + path);
+            }
+        }
+    }
+
+    private void deleteDirOnExit(FileSystem fs, String target) throws Exception {
+        Path path = new Path(extractPathFromUrl(target));
+
+        fs.deleteOnExit(path);  // Delete the directory even if an exception occurs
+        info(path + " is scheduled to be deleted on exit.");
+    }
+
+    private void checkPermission(FileSystem fs, Path path, boolean checkWritePermission) throws Exception {
+        FsPermission perm = fs.getFileStatus(path).getPermission();
+        FsAction u = perm.getUserAction();
+        FsAction g = perm.getGroupAction();
+        FsAction o = perm.getOtherAction();
+        boolean changed = false;
+
+        // Check read permission
+        if (props.getBoolean(VoldemortBuildAndPushJob.PUSH_CDN_READ_BY_GROUP, true)) {
+            if (!g.implies(FsAction.READ_EXECUTE)) {
+                g = g.or(FsAction.READ_EXECUTE);
+                changed = true;
+            }
+        }
+
+        if (props.getBoolean(VoldemortBuildAndPushJob.PUSH_CDN_READ_BY_OTHER, true)) {
+            if (!o.implies(FsAction.READ_EXECUTE)) {
+                o = o.or(FsAction.READ_EXECUTE);
+                changed = true;
+            }
+        }
+
+        // Check write permission
+        if (checkWritePermission) {
+            if (props.getBoolean(VoldemortBuildAndPushJob.PUSH_CDN_WRITTEN_BY_GROUP, true)) {
+                if (!g.implies(FsAction.WRITE)) {
+                    g = g.or(FsAction.WRITE);
+                    changed = true;
+                }
+            }
+
+            if (props.getBoolean(VoldemortBuildAndPushJob.PUSH_CDN_WRITTEN_BY_OTHER, true)) {
+                if (!o.implies(FsAction.WRITE)) {
+                    o = o.or(FsAction.WRITE);
+                    changed = true;
+                }
+            }
+        }
+
+        if (changed) {
+            FsPermission desiredPerm = new FsPermission(u, g, o);
+            fs.setPermission(path, desiredPerm);
+            if (!fs.getFileStatus(path).getPermission().equals(desiredPerm)) {
+                throw new RuntimeException("Failed to set permission for " + path + " from: " + perm + " to: " + desiredPerm);
+            }
+            info("for path " + path + ", permissions changed from: " + perm + " to: " + desiredPerm);
+        }
+    }
+
+    private void addPermissionsToParentDirs(FileSystem fs, String target, String pathPrefix) throws Exception {
+        String pathFromRoot = removeLeadingSlash(extractPathFromUrl(target));
+        String parent = "";
+
+        for (String seg: pathFromRoot.split("/")) {
+            parent = parent + "/" + seg;
+            Path parentPath = new Path(parent);
+
+            if (parent.length() <= pathPrefix.length()) {
+                checkPermission(fs, parentPath, false);
+            } else {
+                checkPermission(fs, parentPath, true);
+            }
+        }
+    }
+
+    private Map<String, String> buildCdnMap() throws Exception {
+        List<String> pairs = props.getList(VoldemortBuildAndPushJob.PUSH_CDN_CLUSTER);
+        Map<String, String> cdnMap = new HashMap<>(pairs.size());
+
+        for (String pair : pairs) {
+            if (!pair.contains("|")) {
+                throw new RuntimeException("Cannot find separator '|' in K-V pair \"" + pair + "\"");
+            }
+            String[] urls = pair.split("\\|");
+            if (urls.length != 2) {
+                throw new RuntimeException("More than one separator found in K-V pair \"" + pair + "\"");
+            }
+            cdnMap.put(removeTrailingSlash(urls[0].trim()), removeTrailingSlash(urls[1].trim()));
+        }
+        return cdnMap;
+    }
+
+    private String pickCDN() throws Exception {
+        String cdnCluster = buildCdnMap().get(removeTrailingSlash(destination));
+
+        if (cdnCluster == null) {
+            warn("Cannot find corresponding CDN! Will bypass CDN for push cluster " + destination);
+            return "";
+        }
+
+        if (cdnCluster.equals("null")) {
+            info("Will bypass CDN for push cluster " + destination);
+            return "";
+        }
+
+        if (!cdnCluster.matches(".*hdfs://.+:[0-9]{1,5}")) {
+            warn("Invalid URL format! Will bypass CDN for push cluster " + destination);
+            return "";
+        }
+        return cdnCluster;
+    }
+
+    private boolean prereqSatisfied(String cdnURL) throws Exception {
+        for (String namenode: props.getList(OTHER_NAMENODES)) {
+            if (removeTrailingSlash(namenode).equals(cdnURL)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String removeLeadingSlash(String s) {
+        return s.replaceAll("^/", "");
+    }
+
+    private String removeTrailingSlash(String s) {
+        return s.replaceAll("/$", "");
+    }
+
+    /**
+     * Extract directory path from URL, e.g. hdfs://hostname:9000/a/b/c => /a/b/c
+     */
+    private String extractPathFromUrl(String url) {
+        String path = url.replaceAll(".+://.+?(?=/)", "");
+        if (!path.startsWith("/")) {
+            throw new RuntimeException("Path must start with '/': " + path);
+        }
+        return path;
+    }
+
+    /**
+     * Remove directory path from URL,  e.g. hdfs://hostname:9000/a/b/c => hdfs://hostname:9000
+     */
+    private String removePathFromUrl(String url) {
+        String path = extractPathFromUrl(url);
+        int end = url.indexOf(path);
+        return url.substring(0, end);
+
+        // Alternative: return url.replaceAll("(?<=:[0-9]{1,5})/.*", "")), assume url contains port number
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    void closeCdnFS() {
+        try {
+            if (cdnTargetFS != null) {
+                cdnTargetFS.close();
+            }
+        } catch (Exception e) {
+            warn("Failed to close CDN filesystem!");
+        }
+    }
+}

--- a/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
+++ b/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/azkaban/VoldemortBuildAndPushJob.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
 import org.apache.avro.mapred.AvroInputFormat;
 import org.apache.commons.lang.Validate;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
@@ -124,6 +125,14 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
     public final static String PUSH_ROLLBACK = "push.rollback";
     public final static String PUSH_FORCE_SCHEMA_KEY = "push.force.schema.key";
     public final static String PUSH_FORCE_SCHEMA_VALUE = "push.force.schema.value";
+    public final static String PUSH_CDN_CLUSTER = "push.cdn.cluster";   // e.g. "tcp://v-cluster1:6666|hdfs://cdn1:9000,tcp://v-cluster2:6666|webhdfs://cdn2:50070,tcp://v-cluster3:6666|null"
+    public final static String PUSH_CDN_PREFIX = "push.cdn.prefix";     // e.g. "/jobs/VoldemortBnP"
+    public final static String PUSH_CDN_ENABLED = "push.cdn.enabled";   // e.g. "true"
+    public final static String PUSH_CDN_READ_BY_GROUP = "push.cdn.readByGroup";   // e.g. "true"
+    public final static String PUSH_CDN_READ_BY_OTHER = "push.cdn.readByOther";   // e.g. "true"
+    public final static String PUSH_CDN_WRITTEN_BY_GROUP = "push.cdn.writtenByGroup";   // e.g. "true"
+    public final static String PUSH_CDN_WRITTEN_BY_OTHER = "push.cdn.writtenByOther";   // e.g. "true"
+    public final static String PUSH_CDN_STORE_WHITELIST = "push.cdn.storeWhitelist";    // "storename1,storename2" no whitespace
     // others.optional
     public final static String KEY_SELECTION = "key.selection";
     public final static String VALUE_SELECTION = "value.selection";
@@ -816,6 +825,29 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
 
         log.info("Push starting for cluster: " + url);
 
+        // CDN distcp
+        boolean cdnEnabled = props.getBoolean(PUSH_CDN_ENABLED, false);
+        String modifiedDataDir = new Path(dataDir).makeQualified(FileSystem.get(new JobConf())).toString();
+        List storeWhitelist = props.getList(PUSH_CDN_STORE_WHITELIST, null);
+        GobblinDistcpJob distcpJob = null;
+
+        if (cdnEnabled && storeWhitelist != null && storeWhitelist.contains(storeName)) {
+            try {
+                if (modifiedDataDir.matches(".*hdfs://.*:[0-9]{1,5}/.*")) {
+                    invokeHooks(BuildAndPushStatus.DISTCP_STARTING, url);
+                    distcpJob = new GobblinDistcpJob(getId(), modifiedDataDir, url, props);
+                    distcpJob.run();
+                    modifiedDataDir = distcpJob.getSource();
+                    invokeHooks(BuildAndPushStatus.DISTCP_FINISHED, url);
+                } else {
+                    warn("Invalid URL format! Skip Distcp.");
+                    throw new RuntimeException("Invalid URL format! Skip Distcp.");
+                }
+            } catch (Exception e) {
+                invokeHooks(BuildAndPushStatus.DISTCP_FAILED, url + " : " + e.getMessage());
+            }
+        }
+
         new VoldemortSwapJob(
                 this.getId() + "-push-store",
                 cluster,
@@ -830,7 +862,13 @@ public class VoldemortBuildAndPushJob extends AbstractJob {
                 maxNodeFailures,
                 failedFetchStrategyList,
                 url,
+                modifiedDataDir,
                 buildPrimaryReplicasOnly).run();
+
+        if (distcpJob != null) {
+            // This would allow temp dirs marked by deleteDirOnExit() to be deleted.
+            distcpJob.closeCdnFS();
+        }
     }
 
     /**

--- a/gobblin/build.gradle
+++ b/gobblin/build.gradle
@@ -1,0 +1,51 @@
+apply plugin: 'com.github.johnrengelman.shadow'
+
+repositories {
+    jcenter()
+}
+
+configurations {
+    gobblin {
+        exclude group: 'com.google.guava'
+        // Hadoop dependencies are expected to be provided by Azkaban.
+        // If Azkaban is not included in your deployment, you may need to remove the following line
+        exclude group: 'org.apache.hadoop'
+
+        // Deadweight:
+        exclude group: 'org.apache.curator'
+        exclude group: 'org.apache.hive'
+        exclude group: 'org.apache.httpcomponents'
+        exclude group: 'org.quartz-scheduler'
+        exclude group: 'com.google.inject', module: 'guice'
+        exclude group: 'com.linkedin.gobblin', module: 'gobblin-hive-registration'
+        exclude group: 'com.linkedin.gobblin', module: 'google-ingestion'
+        exclude group: 'com.twitter', module: 'parquet-hadoop-bundle'
+    }
+    resolvedIncorrectly
+}
+
+dependencies {
+    gobblin 'com.linkedin.gobblin:gobblin-runtime:0.10.0'
+    gobblin 'com.linkedin.gobblin:gobblin-data-management:0.10.0'
+    gobblin 'com.linkedin.gobblin:gobblin-throttling-service-client:0.10.0'
+    gobblin 'com.linkedin.gobblin:gobblin-throttling-service-api-rest-client:0.10.0'
+    gobblin 'com.linkedin.gobblin:gobblin-throttling-service-api-data-template:0.10.0'
+    gobblin 'com.linkedin.gobblin:gobblin-metrics:0.10.0'
+    resolvedIncorrectly 'com.google.guava:guava:15.0'
+}
+
+shadowJar {
+    zip64 true
+    configurations = [project.configurations.gobblin, project.configurations.resolvedIncorrectly]
+
+    def troublemakers = ['org.apache.avro', 'com.google.protobuf', 'com.google.common']
+    troublemakers.each {
+        relocate it, 'gobblin-dep/' + it
+    }
+    doLast {
+        def file = new File("${buildDir}/libs/${project.name}-all.jar")
+        println '================================'
+        println "${project.name} jar size: ${((float)(file.length()/1024/1024)).round(2)} MB"
+        println '================================'
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,3 @@
-
 rootProject.name = 'voldemort'
 
 // the following dance creates the subprojects (the contrib modules) and
@@ -14,3 +13,6 @@ project(':contrib-krati').projectDir = file('contrib/krati')
 
 include 'contrib-restclient'
 project(':contrib-restclient').projectDir = file('contrib/restclient')
+
+include 'gobblin'
+project(':gobblin').projectDir = file('gobblin')


### PR DESCRIPTION
This is a squashed version of the [previous pull request](https://github.com/voldemort/voldemort/pull/481) for release purpose.
For development details and code review comments, please refer to the [previous version](https://github.com/voldemort/voldemort/pull/481).

----------------------------------------------------------------------
Added optional CDN feature to the BnP pipeline.

Currently the Voldemort Build and Push (BnP) plugin tells Voldemort
cluster to fetch twice from the source HDFS cluster.
This optional CDN feature will instead copy files to dedicated CDN
clusters, and therefore reduce bandwidth requirement for the source.

The following are new attributes that are related to this release:
1. push.cdn.enabled
    The global switch.
    Example: true
    Default: false

2. push.cdn.cluster
    A list of "destination|cdn" pairs separated by comma, where "destination"
    is a Voldemort cluster, and "cdn" is the corresponding HDFS cluster used
    as CDN. if "cdn" is "null", V-cluster will fetch directly from the source
    HDFS cluster instead, in which case the behavior is identical to the
    previous versions of Voldemort.
    Example: tcp://v-cluster1:6666|hdfs://cdn1:9000,tcp://v-cluster2:6666|webhdfs://cdn2:50070,tcp://v-cluster3:6666|null
    Default: null

3. push.cdn.prefix
    A directory on the CDN cluster as the root for all distcp copied files.
    Example: /jobs/VoldemortBnP
    Default: null

4. push.cdn.readByGroup
    Set true if CDN files are read by a different user in the same group.
    Example: true
    Default: true

5. push.cdn.readByOther
    Set true if CDN files are read by a different user in a different group.
    Example: true
    Default: true

6. push.cdn.writtenByGroup
    Set true if CDN files are written by a different user in the same group.
    Example: true
    Default: true

7. push.cdn.writtenByOther
    Set true if CDN files are written by a different user in a different group.
    Example: true
    Default: true

8. push.cdn.storeWhitelist
    A comma-separated list of Voldemort store names to which the CDN feature will
    apply. (for testing purposes)
    Default: null (means apply to every store)

This release is compatible with existing job configurations. The default
behavior is identical to the previous version.
