### PR TITLE
Fixed the issue with too long command line in Windows 10 + updated the readme file to reflect proper build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It is used at LinkedIn by numerous critical services powering a large portion of
 cd ~/workspace
 git clone https://github.com/voldemort/voldemort.git
 cd voldemort
-./gradlew clean jar
+./gradlew clean build -x test
 ```
 
 ### Start Server ###

--- a/bin/run-class.bat
+++ b/bin/run-class.bat
@@ -29,9 +29,9 @@ SET CLASSPATH=.
 
 set VOLDEMORT_CONFIG_DIR=%1%/config
 
-for %%j in ("%BASE_DIR%\dist\*.jar") do (call :append_classpath "%%j")
+call :append_classpath "dist\*"
 for %%j in ("%BASE_DIR%\contrib\*\lib\*.jar") do (call :append_classpath "%%j")
-for %%j in ("%BASE_DIR%\lib\*.jar") do (call :append_classpath "%%j")
+call :append_classpath "lib\*"
 set CLASSPATH=%CLASSPATH%;"%BASE_DIR%\dist\resources"
 goto :run
 

--- a/bin/voldemort-convert-bdb.bat
+++ b/bin/voldemort-convert-bdb.bat
@@ -20,9 +20,9 @@ REM ** This Windows BAT file is not tested with each Voldemort release. **
 SET BASE_DIR=%~dp0..
 SET CLASSPATH=.
 
-for %%j in ("%BASE_DIR%\dist\*.jar") do (call :append_classpath "%%j")
+call :append_classpath "dist\*"
 for %%j in ("%BASE_DIR%\contrib\*\lib\*.jar") do (call :append_classpath "%%j")
-for %%j in ("%BASE_DIR%\lib\*.jar") do (call :append_classpath "%%j")
+call :append_classpath "lib\*"
 set CLASSPATH=%CLASSPATH%;"%BASE_DIR%\dist\resources"
 goto :run
 

--- a/bin/voldemort-coordinator.bat
+++ b/bin/voldemort-coordinator.bat
@@ -36,9 +36,9 @@ goto :eof
 SET BASE_DIR=%~dp0..
 SET CLASSPATH=.
 
-for %%j in ("%BASE_DIR%\dist\*.jar") do (call :append_classpath "%%j")
+call :append_classpath "dist\*"
 for %%j in ("%BASE_DIR%\contrib\*\lib\*.jar") do (call :append_classpath "%%j")
-for %%j in ("%BASE_DIR%\lib\*.jar") do (call :append_classpath "%%j")
+call :append_classpath "lib\*"
 set CLASSPATH=%CLASSPATH%;"%BASE_DIR%\dist\resources"
 goto :run
 

--- a/bin/voldemort-server.bat
+++ b/bin/voldemort-server.bat
@@ -31,9 +31,9 @@ SET CLASSPATH=.
 
 set VOLDEMORT_CONFIG_DIR=%1%/config
 
-for %%j in ("%BASE_DIR%\dist\*.jar") do (call :append_classpath "%%j")
+call :append_classpath "dist\*"
 for %%j in ("%BASE_DIR%\contrib\*\lib\*.jar") do (call :append_classpath "%%j")
-for %%j in ("%BASE_DIR%\lib\*.jar") do (call :append_classpath "%%j")
+call :append_classpath "lib\*"
 set CLASSPATH=%CLASSPATH%;"%BASE_DIR%\dist\resources"
 goto :run
 


### PR DESCRIPTION
The problem under Windows 10 was that:
1. Using the build instructions in the readme file (i.e. gradlew clean jar) didn't result in the lib folder created and the dependent jars copied into it therefore at startup the first library to be loaded (Log4J) could not be loaded and caused the application to stop.
2. After proper build (i.e. gradlew clean build -x test), the build succeeded, the lib folder and dependent jars were there, but during the execution of the bat file the concatenation of the actual command to run resulted in a too long command line at some point and the execution halted. It was unnecessary however to do the concatenation of the absolute paths in the lib folder, Java accepts wildcard in classpath definitions, so I just replaced that logic with appending a single "lib/*" to the classpath.

This fixes #485.