### PR TITLE
The RO server is now returning old async op IDs idempotently.

### DIFF
--- a/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
+++ b/src/java/voldemort/store/readonly/ReadOnlyStorageEngine.java
@@ -74,6 +74,7 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
     private volatile boolean isOpen;
     private long lastSwapped;
     private int lastFetchRequestId;
+    private Long lastVersionGettingFetched = null;
 
     /**
      * Create an instance of the store
@@ -670,5 +671,12 @@ public class ReadOnlyStorageEngine extends AbstractStorageEngine<ByteArray, byte
 
     public int getFetchingRequest() { return lastFetchRequestId; }
 
-    public void setFetchingRequest(int requestId) { lastFetchRequestId = requestId; }
+    public Long getLastVersionGettingFetched() {
+        return lastVersionGettingFetched;
+    }
+
+    public void setFetchingRequest(int requestId, long lastVersionGettingFetched) {
+        this.lastFetchRequestId = requestId;
+        this.lastVersionGettingFetched = lastVersionGettingFetched;
+    }
 }


### PR DESCRIPTION
Previously, the BnP job could retry a fetch if it had connectivity
issues midway through, and the server would reject the new fetch
if the previous one was already going on. Now, it will instead
return the previous async op ID if the new fetch request is for the
same version as previously requested.