### PR TITLE
Add verification of protocolVersion in voldemort.client.protocol.vold.VoldemortNativeClientRequestFormat

### DIFF
--- a/src/java/voldemort/client/protocol/vold/VoldemortNativeClientRequestFormat.java
+++ b/src/java/voldemort/client/protocol/vold/VoldemortNativeClientRequestFormat.java
@@ -54,6 +54,8 @@ public class VoldemortNativeClientRequestFormat implements RequestFormat {
     private final Logger logger = Logger.getLogger(getClass());
 
     public VoldemortNativeClientRequestFormat(int protocolVersion) {
+		if(protocolVersion < 0 || protocolVersion > 3)
+			throw new IllegalArgumentException("Unknown protocol version: " + protocolVersion);
         this.mapper = new ErrorCodeMapper();
         this.protocolVersion = protocolVersion;
     }


### PR DESCRIPTION
The value of protocolVersion may be invalid such as <0 or >3 in voldemort.client.protocol.vold.VoldemortNativeClientRequestFormat
Add verification of the parameter "protocolVersion".
